### PR TITLE
Fix first time usage of load_hisilicon

### DIFF
--- a/general/package/hisilicon-osdrv-hi3516cv100/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516cv100/files/script/load_hisilicon
@@ -408,8 +408,8 @@ else
         logger -s -p daemon.info -t hisilicon "Get data from environment and set SENSOR as ${SENSOR}"
     else
         insert_detect
-        SENSOR_DETECT=$(ipcinfo --short-sensor)
-        export SENSOR=${SENSOR_DETECT:=unknown}
+        SNS_TYPE=$(ipcinfo --short-sensor)
+        export SENSOR=${SNS_TYPE:=unknown}
         remove_detect
         logger -s -p daemon.info -t hisilicon "Get data from ipcinfo and set SENSOR as ${SENSOR}"
         fw_setenv sensor $SENSOR && logger -s -p daemon.info -t hisilicon "Write detected ${SENSOR} to U-Boot ENV"


### PR DESCRIPTION
When fw_env does not contain `sensor`$SNS_TYPE will always be ar0130 thus `insert_sns` never executes intended code for actually detected sensor.