### PR TITLE
Add mt7601sta as it's the only .ko available in T10 ingenic camera builds

### DIFF
--- a/general/overlay/etc/network/interfaces
+++ b/general/overlay/etc/network/interfaces
@@ -20,6 +20,7 @@ iface wlan0 inet dhcp
     pre-up echo out > /sys/class/gpio/gpio7/direction
     pre-up echo 0 > /sys/class/gpio/gpio7/value
     pre-up modprobe mt7601u
+    pre-up modprobe mt7601sta
     pre-up wpa_passphrase "SSID" "password" >/tmp/wpa_supplicant.conf
     pre-up sed -i '2i \\tscan_ssid=1' /tmp/wpa_supplicant.conf
     pre-up (sleep 3; wpa_supplicant -B -D nl80211 -i wlan0 -c/tmp/wpa_supplicant.conf)


### PR DESCRIPTION
This statement will only add a few microseconds to interface bringup but helps T10 cameras have an up and running configuration right after flashing the new firmware.

Thanks @themactep for his stellar support over Telegram, kudos ;)