### PR TITLE
Tweak ash history file settings in debug mode

### DIFF
--- a/general/overlay/etc/profile
+++ b/general/overlay/etc/profile
@@ -6,6 +6,10 @@ export SENSOR=$(fw_printenv -n sensor)
 export ARCH=$(uname -m)
 export HISTFILE=/tmp/.ash_history
 
+export DEBUG=$(($(fw_printenv -n debug)))
+[ $DEBUG -ge 1 ] && [ -f "${HISTFILE//tmp/root}" ] && cp ${HISTFILE//tmp/root} /tmp/
+[ $DEBUG -ge 2 ] && export HISTFILE=${HISTFILE//tmp/root}
+
 echo_c() { echo -ne "\e[1;$1m$2\e[0m"; }
 
 if [ "$PS1" ]; then


### PR DESCRIPTION
- use a pre-saved history file for the session (debug 1)
- use a permanent history file (debug 2)
  danger: that'll exhaust flash memory prematurely!