### PR TITLE
Add JXH62 sensors to Ingenic T10/T20

### DIFF
--- a/general/package/ingenic-osdrv-t20/ingenic-osdrv-t20.mk
+++ b/general/package/ingenic-osdrv-t20/ingenic-osdrv-t20.mk
@@ -18,6 +18,7 @@ define INGENIC_OSDRV_T20_INSTALL_TARGET_CMDS
 
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/etc/sensor $(BR2_EXTERNAL_INGENIC_PATH)/package/ingenic-osdrv-t20/files/sensor/params/jxf22.bin
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/etc/sensor $(BR2_EXTERNAL_INGENIC_PATH)/package/ingenic-osdrv-t20/files/sensor/params/jxh42.bin
+	$(INSTALL) -m 644 -t $(TARGET_DIR)/etc/sensor $(BR2_EXTERNAL_INGENIC_PATH)/package/ingenic-osdrv-t20/files/sensor/params/jxh62.bin
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/etc/sensor $(BR2_EXTERNAL_INGENIC_PATH)/package/ingenic-osdrv-t20/files/sensor/params/sc2135.bin
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/etc/sensor $(BR2_EXTERNAL_INGENIC_PATH)/package/ingenic-osdrv-t20/files/sensor/params/sc2232.bin
 
@@ -32,6 +33,7 @@ define INGENIC_OSDRV_T20_INSTALL_TARGET_CMDS
 
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/3.10.14/ingenic $(BR2_EXTERNAL_INGENIC_PATH)/package/ingenic-osdrv-t20/files/kmod/sensor_jxf22.ko
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/3.10.14/ingenic $(BR2_EXTERNAL_INGENIC_PATH)/package/ingenic-osdrv-t20/files/kmod/sensor_jxh42.ko
+	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/3.10.14/ingenic $(BR2_EXTERNAL_INGENIC_PATH)/package/ingenic-osdrv-t20/files/kmod/sensor_jxh62.ko
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/3.10.14/ingenic $(BR2_EXTERNAL_INGENIC_PATH)/package/ingenic-osdrv-t20/files/kmod/sensor_sc2135.ko
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/3.10.14/ingenic $(BR2_EXTERNAL_INGENIC_PATH)/package/ingenic-osdrv-t20/files/kmod/sensor_sc2232.ko
 


### PR DESCRIPTION
Follows up on commit https://github.com/OpenIPC/firmware/commit/cf6f7030248949308ba4a803a763f2d3e5724571 where @FlyRouter rearranges sensors.

Otherwise after sysupgrade, my camera went belly up like this:

```
ingenic: Loading of kernel modules and initialization of the video system has started 
ingenic: Get data from environment and set SENSOR as jxh62 
-------------------- 
ISP_PARAM: isp_clk=90000000 
SENSOR: jxh62 
SENSOR_PARAM:  
-------------------- 
insmod: can't insert '/lib/modules/3.10.14/ingenic/sensor_jxh62.ko': No such file or directory 
err: insmod sensor drv 
```

Tangential thought: wouldn't it make sense in order to save space and reduce update complexity to have a T10-specific `ingenic-osdrv-t20` such as `ingenic-osdrv-t10`?

This change is misleading because my camera doesn't have an Ingenic T20.