### PR TITLE
Pre-select dependencies with Majestic package

### DIFF
--- a/general/package/majestic/Config.in
+++ b/general/package/majestic/Config.in
@@ -1,6 +1,12 @@
 config BR2_PACKAGE_MAJESTIC
 	bool "Majestic streamer"
 	default n
+	select BR2_PACKAGE_LIBEVENT_OPENIPC
+	select BR2_PACKAGE_LIBOGG_OPENIPC
+	select BR2_PACKAGE_JSON_C_OPENIPC
+	select BR2_PACKAGE_MBEDTLS_OPENIPC
+	select BR2_PACKAGE_OPUS_OPENIPC
+	select BR2_PACKAGE_ZLIB
 	help
 	  Tiny but powerful IPC streaming software
 	  (non-commercial version for personal use only)


### PR DESCRIPTION
Compilation fails if a package from Majestic's dependencies not selected in makeconfig.
```
Makefile:575: *** libogg-openipc is in the dependency chain of majestic that has added it to its _DEPENDENCIES variable without selecting it or depending on it from Config.in.  Stop.
Makefile:575: *** opus-openipc is in the dependency chain of majestic that has added it to its _DEPENDENCIES variable without selecting it or depending on it from Config.in.  Stop.
```