### PR TITLE
added Archer T4U to wifibroadcast startup script

### DIFF
--- a/general/package/wifibroadcast/files/S98wfb
+++ b/general/package/wifibroadcast/files/S98wfb
@@ -19,7 +19,7 @@ detect_wifi_card() {
   for card in ${devices}
 	do
 	  case "${card}" in
-	  "0bda:8812" | "0bda:881a" | "0b05:17d2")
+	  "0bda:8812" | "0bda:881a" | "0b05:17d2" | "2357:0101")
 		driver="realtek"
 		modprobe 88XXau rtw_tx_pwr_idx_override=${driver_txpower_override}
 	  ;;


### PR DESCRIPTION
USB id 2357:0101 belongs to TP-Link Archer T4U
https://linux-hardware.org/?id=usb:2357-0101

consider to use the possible device IDs of th driver.