### PR TITLE
Fix wireless-configuration to properly overwrite files

### DIFF
--- a/general/package/wireless-configuration/files/netsetup
+++ b/general/package/wireless-configuration/files/netsetup
@@ -19,10 +19,10 @@ fi
 if [ $1 = "startup" ]; then
 	/etc/network/netadapter $1
 	ifconfig eth0 192.168.2.10
-	ifup wlan0
 fi
 
 if [ $1 = "shutdown" ]; then
+	killall -q udhcpd
 	killall -q wpa_supplicant
 	/etc/network/netadapter $1
 fi

--- a/general/package/wireless-configuration/wireless-configuration.mk
+++ b/general/package/wireless-configuration/wireless-configuration.mk
@@ -9,19 +9,6 @@ WIRELESS_CONFIGURATION_SITE =
 WIRELESS_CONFIGURATION_LICENSE = MIT
 WIRELESS_CONFIGURATION_LICENSE_FILES = LICENSE
 
-WIRELESS_CONFIGURATION_PATH = ../general/package/wireless-configuration/files
-
-define WIRELESS_CONFIGURATION_INSTALL_TARGET_CMDS
-	$(INSTALL) -m 755 -d $(TARGET_DIR)/etc
-	cp -f $(WIRELESS_CONFIGURATION_PATH)/udhcpd.conf $(TARGET_DIR)/etc
-
-	$(INSTALL) -m 755 -d $(TARGET_DIR)/etc/network
-	cp -f $(WIRELESS_CONFIGURATION_PATH)/interfaces $(TARGET_DIR)/etc/network
-	cp -f $(WIRELESS_CONFIGURATION_PATH)/netadapter $(TARGET_DIR)/etc/network
-	cp -f $(WIRELESS_CONFIGURATION_PATH)/netsetup $(TARGET_DIR)/etc/network
-
-	$(INSTALL) -m 755 -d $(TARGET_DIR)/usr/sbin
-	cp -f $(WIRELESS_CONFIGURATION_PATH)/wireless $(TARGET_DIR)/usr/sbin
-endef
+BR2_ROOTFS_POST_BUILD_SCRIPT += $(WIRELESS_CONFIGURATION_PKGDIR)/wireless-configuration.sh
 
 $(eval $(generic-package))

--- a/general/package/wireless-configuration/wireless-configuration.sh
+++ b/general/package/wireless-configuration/wireless-configuration.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+FILES=../general/package/wireless-configuration/files
+cp -f $FILES/udhcpd.conf $TARGET_DIR/etc
+cp -f $FILES/interfaces $TARGET_DIR/etc/network
+cp -f $FILES/netadapter $TARGET_DIR/etc/network
+cp -f $FILES/netsetup $TARGET_DIR/etc/network
+cp -f $FILES/wireless $TARGET_DIR/usr/sbin


### PR DESCRIPTION
The wireless-configuration package is executed before the rootfs is finalized, thus it gets overwritten by the contains of the general overlay. The fix is to utilize the install script with BR2_ROOTFS_POST_BUILD_SCRIPT to copy the needed files after the general overlay is in place.
It also includes a small fixup for the netsetup script.

Adding an additional POST_BUILD_SCRIPT does not interfere with previous set scripts:
```
>>>   Copying overlay /home/ubuntu/firmware/buildroot-2021.02.12/../general/overlay
>>>   Executing post-build script /home/ubuntu/firmware/buildroot-2021.02.12/../scripts/executing_commands_for_glibc.sh
Note: BR2_TOOLCHAIN_BUILDROOT_LIBC="glibc"
>>>   Executing post-build script /home/ubuntu/firmware/br-ext-chip-sigmastar/package/wireless-configuration//wireless-configuration.sh
touch /home/ubuntu/firmware/output/target/usr
>>>   Generating root filesystems common tables
```