### PR TITLE
Added light script

### DIFF
--- a/general/overlay/usr/sbin/gpio
+++ b/general/overlay/usr/sbin/gpio
@@ -1,18 +1,26 @@
 #!/bin/sh
 
 help() {
-    echo "gpio <set|clear|toggle> <pin>"
-    echo "gpio <unexport|release> <pin>"
-    echo "gpio read <pin>"
+    echo -e "\n=== GPIO usage ===\n"
+
+    echo -e ">\t gpio <set|clear|toggle|unexport|read> <pin>\n"
+    echo -e "set\t\t = Output HI\nclear\t\t = Output LOW\ntoggle\t\t = Swap HI <> LOW\nunexport\t = Release GPIO pin back to the kernel space\nread\t\t = Read GPIO pin output state\n"
+    
+    echo -e "---\n"
+
+    echo -e ">\t gpio search <from pin> <to pin>\n"
+    echo -e "Toggle a range of GPIO pins from HI to LOW"
+    echo -e "gpio search logs to syslog\n"
+
+    echo -e "==================\n"
 }
 
 exp() {
     if [ ! -d /sys/class/gpio/gpio$1 ]; then
+        [ ! -f /sys/class/gpio/export ] && echo "Error: No export file!" && exit
         echo $1 > /sys/class/gpio/export
+        [ ! -f /sys/class/gpio/gpio$1/direction ] && echo "Error: No direction file!" && exit
         echo out > /sys/class/gpio/gpio$1/direction
-    elif [ $(cat /sys/class/gpio/gpio$1/direction) = "in" ]; then
-        echo Pin $1 is currently configured as input. Be careful!
-        exit 0
     fi
 }
 
@@ -21,43 +29,72 @@ write(){
 }
 
 read() {
+    [ ! -f /sys/class/gpio/gpio$1/value ] && echo "Error: GPIO-$1 is not set" && exit
     echo $(cat /sys/class/gpio/gpio$1/value)
 }
 
 unexport() {
     if [ -d /sys/class/gpio/gpio$1 ]; then
         echo $1 > /sys/class/gpio/unexport
+    else
+        echo "GPIO-${1} is not exported."
     fi
+}
+
+search() {
+    echo -e "Start blink (output) on GPIO range $1 to $2\n"
+    for pin in $(seq $1 $2); do
+        echo "================================="
+        exp ${pin} && echo "  Exported GPIO-${pin} from kernel space" && echo "    Set GPIO-${pin} to OUTPUT mode"
+        write 0 ${pin} && echo "      Set GPIO-${pin} to LO level" ; sleep 1
+        write 1 ${pin} && echo "      Set GPIO-${pin} to HI level" ; sleep 1
+        echo in > /sys/class/gpio/gpio${pin}/direction && echo "    Set GPIO-${pin} to INPUT mode"
+        unexport ${pin} && echo "  Unexported GPIO-${pin}"
+        logger HELLO - ${pin}
+    done
 }
 
 if [ -n $1 ] && [ -n $2 ] && [ $2 -eq $2 ]; then
         case $1 in
             set)
                 exp $2
+                echo "Setting GPIO-$2 to HI"
                 write 1 $2
                 ;;
 
             clear)
                 exp $2
+                echo "Setting GPIO-$2 to LOW"
                 write 0 $2
                 ;;
 
             toggle)
                 exp $2
-                if [ read -eq 0 ]; then
+                if [ $(read $2) -eq 0 ]; then
+                    echo "Setting GPIO-$2 to HI"
                     write 1 $2
                 else
+                    echo "Setting GPIO-$2 to LOW"
                     write 0 $2
                 fi
                 ;;
 
-            unexport|release)
+            unexport)
                 unexport $2
                 ;;
 
             read)
                 echo $(read $2)
                 ;;
+
+            search)
+                if [ ! -z $3 ] && [ $3 -eq $3 ]; then
+                    search $2 $3
+                else
+                    echo -e "\n Caution: Toggling single pin. Use <gpio search <from pin> <to pin> to search a range.\n"
+                    search $2 $2
+                fi
+            ;;
 
             *)  
                 help

--- a/general/overlay/usr/sbin/gpio
+++ b/general/overlay/usr/sbin/gpio
@@ -1,0 +1,68 @@
+#!/bin/sh
+
+help() {
+    echo "gpio <set|clear|toggle> <pin>"
+    echo "gpio <unexport|release> <pin>"
+    echo "gpio read <pin>"
+}
+
+exp() {
+    if [ ! -d /sys/class/gpio/gpio$1 ]; then
+        echo $1 > /sys/class/gpio/export
+        echo out > /sys/class/gpio/gpio$1/direction
+    elif [ $(cat /sys/class/gpio/gpio$1/direction) = "in" ]; then
+        echo Pin $1 is currently configured as input. Be careful!
+        exit 0
+    fi
+}
+
+write(){
+    echo $1 > /sys/class/gpio/gpio$2/value
+}
+
+read() {
+    echo $(cat /sys/class/gpio/gpio$1/value)
+}
+
+unexport() {
+    if [ -d /sys/class/gpio/gpio$1 ]; then
+        echo $1 > /sys/class/gpio/unexport
+    fi
+}
+
+if [ -n $1 ] && [ -n $2 ] && [ $2 -eq $2 ]; then
+        case $1 in
+            set)
+                exp $2
+                write 1 $2
+                ;;
+
+            clear)
+                exp $2
+                write 0 $2
+                ;;
+
+            toggle)
+                exp $2
+                if [ read -eq 0 ]; then
+                    write 1 $2
+                else
+                    write 0 $2
+                fi
+                ;;
+
+            unexport|release)
+                unexport $2
+                ;;
+
+            read)
+                echo $(read $2)
+                ;;
+
+            *)  
+                help
+                ;;
+        esac
+else
+    help
+fi

--- a/general/overlay/usr/sbin/light
+++ b/general/overlay/usr/sbin/light
@@ -12,8 +12,7 @@ help() {
 
 setRed() {
     if [ -n "$GPIO_RED" ]; then
-        [ $1 -eq 1 ] && gpio set "$GPIO_RED"
-        [ $1 -eq 0 ] && gpio clear "$GPIO_RED"
+        [ $1 -eq 1 ] && gpio set "$GPIO_RED" || gpio clear "$GPIO_RED"
     else
         echo "Red GPIO undefined"
     fi
@@ -21,8 +20,7 @@ setRed() {
 
 setGreen() {
     if [ -n "$GPIO_GREEN" ]; then
-        [ $1 -eq 1 ] && gpio set "$GPIO_GREEN"
-        [ $1 -eq 0 ] && gpio clear "$GPIO_GREEN"
+        [ $1 -eq 1 ] && gpio set "$GPIO_GREEN" || gpio clear "$GPIO_GREEN"
     else
         echo "Green GPIO undefined"
     fi
@@ -30,8 +28,7 @@ setGreen() {
 
 setBlue() {
     if [ -n "$GPIO_BLUE" ]; then
-        [ $1 -eq 1 ] && gpio set "$GPIO_BLUE"
-        [ $1 -eq 0 ] && gpio clear "$GPIO_BLUE"
+        [ $1 -eq 1 ] && gpio set "$GPIO_BLUE" || gpio clear "$GPIO_BLUE"
     else
         echo "Blue GPIO undefined"
     fi

--- a/general/overlay/usr/sbin/light
+++ b/general/overlay/usr/sbin/light
@@ -7,7 +7,7 @@ GPIO_BLUE=
 help() {
     echo -e "\n================= LIGHT usage =================\n"
     echo -e "Set the colour of the status light\n"
-    echo -e "light <red|green|blue|yellow|magenta|cyan|white>\n"
+    echo -e "light <off|red|green|blue|yellow|magenta|cyan|white>\n"
 }
 
 setRed() {
@@ -36,6 +36,12 @@ setBlue() {
 
 if [ -n $1 ]; then
         case $1 in
+            off)
+                setRed 0
+                setGreen 0
+                setBlue 0
+                ;;
+
             red)
                 setRed 1
                 setGreen 0

--- a/general/overlay/usr/sbin/light
+++ b/general/overlay/usr/sbin/light
@@ -1,0 +1,90 @@
+#!/bin/sh
+
+GPIO_RED=78
+GPIO_GREEN=75
+GPIO_BLUE=
+
+help() {
+    echo -e "\n================= LIGHT usage =================\n"
+    echo -e "Set the colour of the status light\n"
+    echo -e "light <red|green|blue|yellow|magenta|cyan|white>\n"
+}
+
+setRed() {
+    if [ -n "$GPIO_RED" ]; then
+        [ $1 -eq 1 ] && gpio set "$GPIO_RED"
+        [ $1 -eq 0 ] && gpio clear "$GPIO_RED"
+    else
+        echo "Red GPIO undefined"
+    fi
+}
+
+setGreen() {
+    if [ -n "$GPIO_GREEN" ]; then
+        [ $1 -eq 1 ] && gpio set "$GPIO_GREEN"
+        [ $1 -eq 0 ] && gpio clear "$GPIO_GREEN"
+    else
+        echo "Green GPIO undefined"
+    fi
+}
+
+setBlue() {
+    if [ -n "$GPIO_BLUE" ]; then
+        [ $1 -eq 1 ] && gpio set "$GPIO_BLUE"
+        [ $1 -eq 0 ] && gpio clear "$GPIO_BLUE"
+    else
+        echo "Blue GPIO undefined"
+    fi
+}
+
+if [ -n $1 ]; then
+        case $1 in
+            red)
+                setRed 1
+                setGreen 0
+                setBlue 0
+                ;;
+
+            green)
+                setRed 0
+                setGreen 1
+                setBlue 0
+                ;;
+
+            blue)
+                setRed 0
+                setGreen 0
+                setBlue 1
+                ;;
+
+            yellow)
+                setRed 1
+                setGreen 1
+                setBlue 0
+                ;;
+
+            magenta|purple)
+                setRed 1
+                setGreen 0
+                setBlue 1
+                ;;
+
+            cyan)
+                setRed 0
+                setGreen 1
+                setBlue 1
+                ;;
+
+            white)
+                setRed 1
+                setGreen 1
+                setBlue 1
+                ;;
+
+            *)  
+                help
+                ;;
+        esac
+else
+    help
+fi


### PR DESCRIPTION
My camera (and I'm sure others) have indicator/ status lights on the front of them.

Currently OpenIPC doesn't utilise these. This command allows scripts to do so.

GPIO for Red, Green and Blue LED's per camera is configurable at the top of the script