### PR TITLE
[draft] add fsck setting for automount.sh

### DIFF
--- a/general/overlay/lib/mdev/automount.sh
+++ b/general/overlay/lib/mdev/automount.sh
@@ -21,6 +21,13 @@ my_mount()
         exit 1
     fi
 
+    type=$(df -T | grep "/dev/$1" | awk '{print $2}')
+    if [ -n $type ]; then
+        mount -o remount,ro "/dev/$1"
+        fsck -a -t $type "/dev/$1"
+        mount -o remount,rw "/dev/$1"
+    fi
+
     # copy files from autoconfig folder
     [ -d "${destdir}/$1/autoconfig" ] && cp -afv ${destdir}/$1/autoconfig/* / | logger -s -p daemon.info -t autoconfig
 


### PR DESCRIPTION
Intended as draft since this is a general change and might have the possibility to break things.

As far as i can tell there is currently no check in place that verify the integrity of (externally) mounted filesystems.
One option would be to identify the filesystem, remount it as readonly, do the check and remount it as readwrite again.