### PR TITLE
Parse output from qrscan for wifi

### DIFF
--- a/general/package/quirc-openipc/files/qrparse
+++ b/general/package/quirc-openipc/files/qrparse
@@ -1,0 +1,113 @@
+#!/bin/sh
+
+################################################################################
+#
+# THIS SCRIPT WILL PARSE AN ZXING FORMAT QR CODE PAYLOAD FOR WIFI CREDENTIALS
+#
+# INPUT MUST BE PASSED IN SINGLE QUOTES
+#
+# BARCODE CONTENTS CAN BE FOUND HERE
+# https://github.com/zxing/zxing/wiki/Barcode-Contents#wi-fi-network-config-android-ios-11
+#
+# THIS SCRIPT USES SIMILAR LOGIC TO:
+# https://github.com/zxing/zxing/blob/master/core/src/main/java/com/google/zxing/client/result/WifiResultParser.java
+#
+# @author jayfan0
+#
+# OPENIPC USAGE: qrparse $(qrscan -p /mnt/mmcblk0p1/qrcode2.jpg | head -n 1)
+# OPENIPC FULL USAGE: curl -s -o /tmp/img.jpg http://127.0.0.1/image.jpg ; qrparse $(qrscan -p /tmp/img.jpg | head -n 1)
+################################################################################
+
+if [ "$1" = "help" ]; then
+    echo -e "\n================= QRPARSER usage =================\n"
+    echo -e "Parse the QR code scanned by qrscan and extract wifi credentials\n"
+    echo -e "INPUT MUST BE PASSED IN SINGLE QUOTES\n"
+    echo -e "USAGE EXAMPLES:\n"
+    echo -e 'Standalone:\t\t qrparse $(qrscan -p /mnt/mmcblk0p1/qrcode2.jpg | head -n 1)\n'
+    echo -e 'With camera sensor:\t curl -s -o /tmp/img.jpg http://127.0.0.1/image.jpg ; qrparse $(qrscan -p /tmp/img.jpg | head -n 1)\n'
+    exit
+fi
+
+# scan='WIFI:S:thi$iSmdsywifi;H:false;T:WPA2;P:$e£cr3tt;PH2:MSCHAPv2;;'
+scan=$1
+
+if [[ ${scan:0:5} == "WIFI:" ]]; then
+
+    trunc=$(echo $scan | sed 's/WIFI://')
+
+    delims=${trunc//[^;]}
+
+    count=${#delims}
+
+    fields=$(( $count-1 ))
+
+    for i in $(seq 1 $fields);
+    do
+        line=$(echo $trunc | cut -d ';' -f $i)
+
+        for j in $(seq 1 2);
+        do
+            single=$(echo $line | cut -d ':' -f $j)
+
+            case $single in
+                S)
+                    SSID=$(echo $line | cut -d ':' -f $(( j + 1 )))
+                    [ -z $SSID ] && echo "SSID Empty. Aborting" && exit
+                    echo "SSID = $SSID"
+                ;;
+
+                P)
+                    password=$(echo $line | cut -d ':' -f $(( j + 1 )))
+                    echo "Password = $password"
+                ;;
+
+                T)
+                    auth=$(echo $line | cut -d ':' -f $(( j + 1 )))
+                    [ -z $auth ] && auth = "nopass"
+                    echo "Authentication type = $auth"
+                ;;
+
+                H)
+                    hidden=$(echo $line | cut -d ':' -f $(( j + 1 )))
+#                     echo "Hidden SSID = $hidden"
+                ;;
+
+                E)
+                    eap=$(echo $line | cut -d ':' -f $(( j + 1 )))
+                    echo "EAP method = $eap"
+                ;;
+
+                A)
+                    anon=$(echo $line | cut -d ':' -f $(( j + 1 )))
+                    echo "Anonymous identity = $anon"
+                ;;
+
+                I)
+                    identity=$(echo $line | cut -d ':' -f $(( j + 1 )))
+                    echo "Identity = $identity"
+                ;;
+
+                PH2)
+                    ph2=$(echo $line | cut -d ':' -f $(( j + 1 )))
+                    echo "PH2 = $ph2"
+                ;;
+            esac
+        done
+    done
+
+    # Unfortunately, in the past, H: was not just used for boolean 'hidden', but 'phase 2 method'.
+    # To try to retain backwards compatibility, we set one or the other based on whether the string
+    #is 'true' or 'false':
+    if [ ! -z $hidden ]; then
+        # If PH2 was specified separately, or if the value is clearly boolean, interpret it as 'hidden'
+        if [ ! -z "$ph2" ] || [[ $(echo "$hidden" | tr '[:upper:]' '[:lower:]') = $(echo "true") ]] || [[ $(echo "$hidden" | tr '[:upper:]' '[:lower:]') = $(echo "false") ]]; then
+            hidden=$hidden
+            echo "Hidden = $hidden"
+        else
+            ph2=$hidden
+            echo "PH2 = $ph2"
+        fi
+    fi
+else
+    echo "Invalid QR Code"
+fi

--- a/general/package/quirc-openipc/quirc-openipc.mk
+++ b/general/package/quirc-openipc/quirc-openipc.mk
@@ -20,6 +20,8 @@ endef
 
 define QUIRC_OPENIPC_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 0755 -D $(@D)/qrscan $(TARGET_DIR)/usr/sbin
+	$(INSTALL) -m 755 -d $(TARGET_DIR)/usr/sbin
+	$(INSTALL) -m 755 -t $(TARGET_DIR)/usr/sbin $(QUIRC_OPENIPC_PKGDIR)files/qrparse
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
@cronyx has a package for [quirc](https://github.com/OpenIPC/firmware/tree/master/general/package/quirc-openipc). Currently the package only scans qr codes to retrieve wifi credential data from them, however there is no logic behind it as yet.

This script takes the output of (/usr/sbin/)qrscan, parses the information and after some sanity checks outputs the separate information, ready to be written to the appropriate network files.

It has been tested and works on a clean/ clear QR code image of the [Zxing](https://github.com/zxing/zxing/wiki/Barcode-Contents#wi-fi-network-config-android-ios-11) format:

```
WIFI:T:WPA;S:mynetwork;P:mypass;;
```

Usage:

```
qrparse $(qrscan -p qrcode.jpg | head -n 1)
```
Full usage:

```
curl -s -o /tmp/img.jpg http://127.0.0.1/image.jpg ; qrparse $(qrscan -p /tmp/img.jpg | head -n 1)
```

Current issues with the entire pack:

- `qrscan` currently outputs an empty second line, therefore `| head -n 1` is required at the moment
- `qrparse` works on a clean, clear qr image, however on my camera the image sensor cannot capture a clear enough image for `qrscan` to successfully extract data from
- `qrparse` currently `echo`'s the fields to terminal output, stdout. An appropriate file needs to be decided. Possibly aligned with @viktorxda's [wireless-configuration ](https://github.com/OpenIPC/firmware/blob/454b15a1a2e62cd680a4c8a37b9a93b38b2482ff/general/package/wireless-configuration/files/script/wireless#L2) package (at `/etc/wireless.conf`), which is making good progress on the AP mode functionality.

Discussions on best course of action required