### PR TITLE
Add reset daemon for cameras with gpio buttons

### DIFF
--- a/general/overlay/etc/init.d/S10resetd
+++ b/general/overlay/etc/init.d/S10resetd
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+case "$1" in
+  start)
+    echo -e '\nLoading resetd...'
+    /usr/sbin/resetd &
+    ;;
+esac

--- a/general/overlay/usr/sbin/resetd
+++ b/general/overlay/usr/sbin/resetd
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# Set Reset switch GPIO
+GPIO=
+
+[ -z $GPIO ] && echo "GPIO not set. Exiting" && echo "[resetd] GPIO undefined in /usr/sbin/resetd" > /dev/kmsg && exit
+
+# Counter for button press until reset
+count=0
+
+# prepare the pin
+if [ ! -d /sys/class/gpio/gpio${GPIO} ]; then
+    echo "${GPIO}" > /sys/class/gpio/export
+    echo "in" > /sys/class/gpio/gpio"${GPIO}"/direction
+fi
+
+# continuously monitor current value of reset switch
+while [ true ]
+do  
+    if [ "$(cat /sys/class/gpio/gpio"${GPIO}"/value)" -eq 1 ]; then
+        count=0
+    else
+        count=$((count+1))
+
+        # 20 counts =~ 5 seconds @ 0.25 sleep intervals
+        if [ $count -eq 20 ]; then
+            echo RESETTING FIRMWARE
+            firstboot
+        fi
+    fi
+    sleep 0.25 # This interval uses 1% CPU. Less sleep = more CPU
+done

--- a/general/overlay/usr/sbin/resetd
+++ b/general/overlay/usr/sbin/resetd
@@ -24,9 +24,10 @@ do
 
         # 20 counts =~ 5 seconds @ 0.25 sleep intervals
         if [ $count -eq 20 ]; then
-            echo RESETTING FIRMWARE
+            echo 'RESETTING FIRMWARE'
             firstboot
         fi
     fi
-    sleep 0.25 # This interval uses 1% CPU. Less sleep = more CPU
+    # This interval uses 1% CPU. Less sleep = more CPU
+    sleep 0.25
 done


### PR DESCRIPTION
Some cameras have a general purpose reset button attached to a GPIO pin. This script is called in `/etc/init.d`, and if the reset button GPIO is configured, checks to see if it is pressed 4 times per second.

If the button is counted to have been held for 5 seconds, the `firstboot` command is called, resetting the camera.