### PR TITLE
Add sysupgrade changes to support gluebi

### DIFF
--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -76,14 +76,15 @@ do_update_rootfs() {
 do_wipe_overlay() {
 	echo_c 33 "\nOverlayFS"
 	echo "Erase overlay partition"
-	flash_eraseall -j "$(get_device "rootfs_data")"
+	[ $(ipcinfo -F) = "nand" ] || jffs2="-j"
+	flash_eraseall $jffs2 "$(get_device "rootfs_data")"
 }
 
 download_firmware() {
 	echo_c 33 "\nFirmware"
 	osr=$(get_system_build)
 	ftype=$(ipcinfo -F 2>/dev/null)
-	[ ${#ftype} -gt 4 ] && ftype=$(get_flash_type)
+	[ ${#ftype} -ge 4 ] && ftype=$(get_flash_type)
 	build="${soc}-${ftype}-${osr}"
 	[ -z "$url" ] && url="https://github.com/OpenIPC/firmware/releases/download/latest/openipc.${build}.tgz"
 	echo "Download from $url"


### PR DESCRIPTION
The second type check will always be skipped since it checks for a text with more than four characters, gluebi uses the nor package to update the firmware, so it relies on the old style check.
Cleanmarkers are not supported by gluebi, it will use the ipcinfo type detection to skip this command.