### PR TITLE
[Sigmastar] adjust infinity6e module loading

### DIFF
--- a/general/package/sigmastar-osdrv-infinity6e/files/script/bin/load_sigmastar
+++ b/general/package/sigmastar-osdrv-infinity6e/files/script/bin/load_sigmastar
@@ -1,17 +1,13 @@
 #!/bin/sh
 #
-# OpenIPC.org | 2023.04.01
+# OpenIPC.org | 2023.05.01
 #
-# Usage: load_sigmastar [ -r | -i ]
-#         -r : remove all modules
-#         -i : insert all modules
-#    default : insert all modules
 
 PATH_MODULE=/lib/modules/4.9.84/sigmastar
 PATH_FIRMWARE=/etc/sensors/venc_fw/chagall.bin
 
 # Sensor
-sensor=$(fw_printenv -n sensor)
+SENSOR=$(fw_printenv -n sensor)
 
 # Watchdog
 watchdog -t 10 /dev/watchdog
@@ -31,7 +27,7 @@ insert_ko() {
 	insmod ${PATH_MODULE}/mi_vif.ko
 	insmod ${PATH_MODULE}/mi_vpe.ko
 	insmod ${PATH_MODULE}/mi_venc.ko fw_path=${PATH_FIRMWARE}
-	insmod ${PATH_MODULE}/sensor_${sensor}_mipi.ko chmap=1
+	insmod ${PATH_MODULE}/sensor_${SENSOR}_mipi.ko chmap=1
 
 	major=$(awk '$2=="mi_poll" {print $1}' /proc/devices)
 	mknod /dev/mi_poll c $major 0
@@ -40,42 +36,15 @@ insert_ko() {
 	mdev -s
 }
 
-remove_ko() {
-	rmmod -w drv_ms_cus_${sensor}_MIPI
-	rmmod -w mi_venc
-	rmmod -w mi_shadow
-	rmmod -w mi_sensor
-	rmmod -w mi_mipitx
-	rmmod -w mi_ao
-	rmmod -w mi_ai
-	rmmod -w mi_vpe
-	rmmod -w mi_vif
-	rmmod -w mi_divp
-	rmmod -w mi_ldc
-	rmmod -w mi_rgn
-	rmmod -w mi_sys
-	rmmod -w mi_common
-	rmmod -w mhal
-}
-
-if [ -z ${sensor} ]; then
+if [ -z ${SENSOR} ]; then
 	echo -e "\n\e[1;31mThe sensor parameter is MISSING\e[0m\n" | logger -s -t OpenIPC
 	echo -e "\n\e[1;33mUsage: fw_setenv sensor imx415\e[0m\n" | logger -s -t OpenIPC
-	echo -e "\n\e[1;33m       load_sigmastar\e[0m\n" | logger -s -t OpenIPC
 	exit 1
 else
-	echo -e "\n\e[1;32mThe sensor is assigned - ${sensor}\e[0m\n" | logger -s -t OpenIPC
+	echo -e "\n\e[1;32mThe sensor is assigned - ${SENSOR}\e[0m\n" | logger -s -t OpenIPC
 fi
 
-if [ "$1" = "-i" ]; then
-	insert_ko
-fi
-
-if [ "$1" = "-r" ]; then
-	remove_ko
-fi
-
-if [ $# -eq 0 ]; then
+if [ ! -e /dev/mi_poll ]; then
 	insert_ko
 fi
 

--- a/general/package/sigmastar-osdrv-infinity6e/files/script/init.d/S80sigmastar
+++ b/general/package/sigmastar-osdrv-infinity6e/files/script/init.d/S80sigmastar
@@ -13,8 +13,7 @@ load_majestic() {
 		[ "$(yaml-cli -i /etc/majestic.yaml -g .watchdog.timeout)" -lt "30" ] && yaml-cli -i /etc/majestic.yaml -s .watchdog.timeout 30
 		ulimit -c unlimited && echo "|/usr/sbin/sendcoredump.sh" >/proc/sys/kernel/core_pattern
 	fi
-	start-stop-daemon -b -m -S -q -p "$PIDFILE" -x "/usr/bin/$DAEMON" \
-		-- $DAEMON_ARGS
+	start-stop-daemon -b -m -S -q -p "$PIDFILE" -x "/usr/bin/$DAEMON" -- $DAEMON_ARGS
 	status=$?
 	if [ "$status" -eq 0 ]; then
 		echo "OK"
@@ -34,7 +33,7 @@ start() {
 	fi
 	logger -s -p daemon.info -t sigmastar "Loading of kernel modules and initialization of the video system has started"
 	export TZ=$(cat /etc/TZ)
-	load_sigmastar -i
+	load_sigmastar
 	load_majestic
 }
 


### PR DESCRIPTION
The main proprietary modules cannot be properly unloaded, it seems there are some missing cleanup checks/functions.
Removing them, even for debugging purposes causes all sorts of problems.
Since it is not expected to unload the modules during operation, it should be reasonable to remove this function.