### PR TITLE
[no ci] cancel previous workflow if pr is updated

### DIFF
--- a/.github/workflows/matrix_build.yml
+++ b/.github/workflows/matrix_build.yml
@@ -17,6 +17,10 @@ on:
        - '**.md'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 env:
   MAX_KERNEL_SIZE: 0x200000
   MAX_ROOTFS_SIZE: 0x500000


### PR DESCRIPTION
I tend to update pull requests several times during the review, the current workflow mechanism queues and executes each change, which can lead to long queue times.
One solution is to provide only one runner for each pull request or cancel the workflow as soon as the pr is updated.

- Reference: [How to cancel previous runs in the PR when you push new commits](https://stackoverflow.com/a/67939898)