### PR TITLE
[no ci] add fallback value for concurrency group

### DIFF
--- a/.github/workflows/matrix_build.yml
+++ b/.github/workflows/matrix_build.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
Fixes a problem with the workflow if the head_ref variable is empty.