### PR TITLE
Update load_hisilicon - USB initialization,  disable usb wifi module

### DIFF
--- a/general/package/hisilicon-osdrv-hi3516cv100/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516cv100/files/script/load_hisilicon
@@ -152,7 +152,7 @@ sys_config() {
 	# lowpower.sh
 	devmem 0x20050080 32 0x000121a8
 	#USB PHY
-	devmem 0x20050084 32 0x005d2188
+	#devmem 0x20050084 32 0x005d2188
 	#NANDC
 	devmem 0x200300D0 32 0x5
 	devmem 0x200f00c8 32 0x1


### PR DESCRIPTION
Just disabled usb pin setup to make it compatible with a usb wifi module. Some usb sensor may need it.