### PR TITLE
[no ci] overlay: add rc.local capability

### DIFF
--- a/general/overlay/etc/init.d/S99rc.local
+++ b/general/overlay/etc/init.d/S99rc.local
@@ -1,0 +1,32 @@
+#!/bin/sh
+#
+# Start rc.local
+#
+
+
+start() {
+	printf "Starting rc.local"
+	/etc/rc.local
+}
+
+restart() {
+	printf "Restarting rc.local"
+	/etc/rc.local
+}
+
+case "$1" in
+	start)
+		"$1"
+		;;
+
+	restart|reload)
+		start
+		;;
+
+	*)
+		echo "Usage: $0 {start|restart|reload}"
+		exit 1
+		;;
+esac
+
+exit $?

--- a/general/overlay/etc/rc.local
+++ b/general/overlay/etc/rc.local
@@ -1,0 +1,14 @@
+#!/bin/sh -e
+#
+# rc.local
+#
+# This script is executed at the end of each multiuser runlevel.
+# Make sure that the script will "exit 0" on success or any other
+# value on error.
+#
+# In order to enable or disable this script just change the execution
+# bits.
+#
+# By default this script does nothing.
+
+exit 0


### PR DESCRIPTION
Improved Startup with rc.local Scripts.  Added S99rc.local to /etc/init.d/ and created /etc/rc.local. This lets users easily run their own commands at the end of startup. It's a straightforward way to customize and optimize the system's start-up process.