### PR TITLE
overlay: wlan0: set mac address from uboot env variable

### DIFF
--- a/general/overlay/etc/network/interfaces.d/wlan0
+++ b/general/overlay/etc/network/interfaces.d/wlan0
@@ -1,4 +1,5 @@
 iface wlan0 inet dhcp
+    pre-up wlan_addr=$(fw_printenv -n wlanaddr); if [ -n "$wlan_addr" ]; then ip link set dev wlan0 address $wlan_addr; fi
     post-up wpa_passphrase "$(fw_printenv -n wlanssid || echo OpenIPC)" "$(fw_printenv -n wlanpass || echo OpenIPC12345)" > /tmp/wpa_supplicant.conf
     post-up sed -i '2i \\tscan_ssid=1' /tmp/wpa_supplicant.conf
     post-up wpa_supplicant -B -i wlan0 -D nl80211,wext -c /tmp/wpa_supplicant.conf

--- a/general/overlay/etc/wireless/interfaces/wlan0
+++ b/general/overlay/etc/wireless/interfaces/wlan0
@@ -1,5 +1,6 @@
 auto wlan0
 iface wlan0 inet dhcp
+    pre-up wlan_addr=$(fw_printenv -n wlanaddr); if [ -n "$wlan_addr" ]; then ip link set dev wlan0 address $wlan_addr; fi
     post-up wpa_passphrase "$(fw_printenv -n wlanssid || echo OpenIPC)" "$(fw_printenv -n wlanpass || echo OpenIPC12345)" > /tmp/wpa_supplicant.conf
     post-up sed -i '2i \\tscan_ssid=1' /tmp/wpa_supplicant.conf
     post-up wpa_supplicant -B -i wlan0 -D nl80211,wext -c /tmp/wpa_supplicant.conf


### PR DESCRIPTION
Introduced a feature that lets the user customize the MAC address of the wireless device (wlan0). Here's how it works:

Added a setting in U-Boot called wlan_addr to `/etc/network/interfaces.d/wlan0` and `/etc/wireless/interfaces/wlan0`.  

If the user provides a MAC address in wlan_addr, the wlan0 device will use that address when it starts up. 

This is useful because sometimes the MAC address printed on a device doesn't match what the device's wireless hardware actually uses, example Wyze and Atom device vendors. 

The user can choose their own MAC address if desired. If wlan_addr is empty or not set it at all, the device will just start up normally with the default MAC address.