### PR TITLE
add support for WiFi on LifeSmart LS179

### DIFF
--- a/general/overlay/etc/wireless/usb
+++ b/general/overlay/etc/wireless/usb
@@ -41,6 +41,13 @@ if [ "$1" = "mt7601u-hi3516ev300-camhi" ]; then
 	exit 0
 fi
 
+# HI3518EV200 LifeSmart
+if [ "$1" = "rtl8188fu-hi3518ev200-lifesmart" ]; then
+	set_gpio 54 1
+	modprobe 8188fu
+	exit 0
+fi
+
 # SSC337DE Foscam
 if [ "$1" = "rtl8188fu-ssc337de-foscam" ]; then
 	set_gpio 15 0


### PR DESCRIPTION
this device has a HI3518EV200 SoC
the RTL8188 is connected over USB
the GPIO 54 is used to power the module