### PR TITLE
Enhanced system timezone configuration via U-Boot.

### DIFF
--- a/general/overlay/etc/init.d/rcS
+++ b/general/overlay/etc/init.d/rcS
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 # Setting the TimeZone for all processes
+/usr/sbin/timezone.sh
 export TZ=$(cat /etc/TZ)
 
 # Set the firmware creation time as the base system time

--- a/general/overlay/usr/sbin/timezone.sh
+++ b/general/overlay/usr/sbin/timezone.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+#Set the system timezone based on the u-boot environment variable
+
+#Convert the timezone from lowercase, replace underscores with spaces for proper searching
+convert_timezone() {
+    local converted=""
+    IFS="/"
+    for part in $1; do
+        part="$(echo "$part" | sed 's/_/ /g' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) tolower(substr($i,2));}1' OFS=" " )"
+        if [ -z "$converted" ]; then
+            converted="$part"
+        else
+            converted="$converted/$part"
+        fi
+    done
+    unset IFS
+    echo "$converted"
+}
+
+#Seek the timezone from the u-boot environment variable
+timezone=$(fw_printenv -n timezone 2>/dev/null)
+if [ -z "$timezone" ]; then
+    echo "Timezone env variable not found, using system default."
+    exit 1
+fi
+
+#Set the system timezone file
+converted_timezone=$(convert_timezone "$timezone")
+echo "User defined timezone: $converted_timezone"
+echo $converted_timezone > /etc/timezone
+
+# Search for the transformed timezone in the file
+matching_line=$(zcat /var/www/a/tz.js.gz | grep -i -F "$converted_timezone")
+if [ -z "$matching_line" ]; then
+    echo "Timezone not found in system file."
+    exit 1
+fi
+
+# Extract the value associated with the timezone, set the system TZ file
+value=$(echo "$matching_line" | awk -F',' '{print $2}' | awk -F':' '{print $2}' | tr -d "'}")
+echo $value > /etc/TZ
+export TZ=$value
+
+if tty -s; then
+    echo "timezone.sh: You are running from a shell, please restart or log out to update timezone environment variables."
+fi

--- a/general/overlay/usr/sbin/timezone.sh
+++ b/general/overlay/usr/sbin/timezone.sh
@@ -1,23 +1,5 @@
 #!/bin/sh
 
-# Set the system timezone based on the u-boot environment variable
-
-# Convert the timezone from lowercase, replace underscores with spaces for proper searching
-convert_timezone() {
-    local converted=""
-    IFS="/"
-    for part in $1; do
-        part="$(echo "$part" | sed 's/_/ /g' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) tolower(substr($i,2));}1' OFS=" " )"
-        if [ -z "$converted" ]; then
-            converted="$part"
-        else
-            converted="$converted/$part"
-        fi
-    done
-    unset IFS
-    echo "$converted"
-}
-
 # Get the timezone from the u-boot environment variable
 timezone=$(fw_printenv -n timezone 2>/dev/null)
 if [ -z "$timezone" ]; then
@@ -25,20 +7,19 @@ if [ -z "$timezone" ]; then
     exit 1
 fi
 
-converted_timezone=$(convert_timezone "$timezone")
-echo "User defined timezone: $converted_timezone"
+echo "User defined timezone: $timezone"
 
 # Check if the values in /etc/timezone and /etc/TZ match the ones from fw_printenv
 current_timezone=$(cat /etc/timezone 2>/dev/null)
 current_tz_value=$(cat /etc/TZ 2>/dev/null)
 
-if [ "$converted_timezone" = "$current_timezone" ] && [ "$timezone" = "$current_tz_value" ]; then
+if [ "$timezone" = "$current_timezone" ] && [ "$timezone" = "$current_tz_value" ]; then
     echo "Timezone settings are already up to date."
     exit 0
 fi
 
-# Search for the transformed timezone in the file
-matching_line=$(zcat /var/www/a/tz.js.gz | grep -i -F "$converted_timezone")
+# Search for the timezone in the file
+matching_line=$(zcat /var/www/a/tz.js.gz | grep -i -F "$timezone")
 if [ -z "$matching_line" ]; then
     echo "Timezone not found in system file."
     exit 1
@@ -51,7 +32,7 @@ value=$(echo "$matching_line" | awk -F',' '{print $2}' | awk -F':' '{print $2}' 
 echo $value > /etc/TZ
 
 # Then write the timezone file
-echo $converted_timezone > /etc/timezone
+echo $timezone > /etc/timezone
 
 export TZ=$value
 


### PR DESCRIPTION
Introduced capability to derive system timezone from U-Boot's 'timezone' environment variable, ensuring persistence even if the overlay is reset.
Added a new utility, timezone.sh, located in /usr/sbin.
Updated /etc/rcS to invoke timezone.sh, guaranteeing the updated timezone settings are accessible to all programs and scripts during boot.

This change was implemented to provide users with a more resilient and flexible approach to timezone management, especially in scenarios where system overlays might be frequently modified or reset, or for deployment configuration to multiple devices.