### PR TITLE
feat(extutils): add yq

### DIFF
--- a/general/overlay/usr/sbin/extutils
+++ b/general/overlay/usr/sbin/extutils
@@ -9,6 +9,14 @@ else
 	ARC=''
 fi
 
+case "${ARCH}" in
+	armv7l)
+		YQARCH=arm
+		;;
+	*)
+		YQARCH=$ARCH;;
+esac
+
 case "${CMD}" in
 	cli)
 		yaml-cli -i /etc/majestic.yaml "$@"
@@ -26,6 +34,17 @@ case "${CMD}" in
 			echo "The ipctool installed as remote GitHub plugin"
 		fi
 		$IPCTOOL $@
+		;;
+
+	yq)
+		YQTOOL=/tmp/yq
+		if [ ! -x $YQTOOL ]; then
+			YQLATEST=$(curl -sIq https://github.com/mikefarah/yq/releases/latest | awk -F '/' '/^(L|l)ocation/ {print  substr($NF, 1, length($NF)-1)}')
+			curl -s -L -o $YQTOOL "https://github.com/mikefarah/yq/releases/download/${YQLATEST}/yq_linux_$YQARCH"
+			chmod +x $YQTOOL
+			echo "The yq installed as remote GitHub plugin"
+		fi
+		$YQTOOL $@
 		;;
 
 	check_mac)

--- a/general/overlay/usr/sbin/yq
+++ b/general/overlay/usr/sbin/yq
@@ -1,0 +1,1 @@
+extutils


### PR DESCRIPTION
`yaml-cli` can not deal with arrays, check issue https://github.com/OpenIPC/yaml-cli/issues/3; We could use `yq` until `yaml-cli` supports it. It would enable `microbe-web` to configure the `outgoing` section of the `majestic.yaml`.