### PR TITLE
add t21 family to lite-only MAJESTIC_LIST release variable

### DIFF
--- a/general/package/majestic/majestic.mk
+++ b/general/package/majestic/majestic.mk
@@ -14,7 +14,7 @@ MAJESTIC_FAMILY = $(OPENIPC_SOC_FAMILY)
 MAJESTIC_RELEASE = $(OPENIPC_FLAVOR)
 
 # we don't have Majestic ultimate for these platforms
-MAJESTIC_LIST = hi3516av100 hi3519v101
+MAJESTIC_LIST = hi3516av100 hi3519v101 t21
 
 ifneq ($(filter $(MAJESTIC_LIST),$(MAJESTIC_FAMILY)),)
 	MAJESTIC_RELEASE = lite


### PR DESCRIPTION
since t20/t21 doesn't have a majetsic ultimate release yet, add the t21 family to the MAJESTIC_LIST variable list so majestic can be installed.