### PR TITLE
[no ci] ingenic-osdrv - adjust loglevel for ingenic ISP module

### DIFF
--- a/general/package/ingenic-osdrv-t21/files/script/load_ingenic
+++ b/general/package/ingenic-osdrv-t21/files/script/load_ingenic
@@ -98,7 +98,7 @@ echo --------------------
 
 lsmod | grep "tx_isp" >/dev/null
 if [ $? -ne 0 ]; then
-	insmod ${KMOD_PATH/%\//}/tx-isp-${SOC}.ko ${ISP_PARAM}
+	insmod ${KMOD_PATH/%\//}/tx-isp-${SOC}.ko ${ISP_PARAM} print_level=2
 	check_return "insmod isp drv"
 fi
 

--- a/general/package/ingenic-osdrv-t30/files/script/load_ingenic
+++ b/general/package/ingenic-osdrv-t30/files/script/load_ingenic
@@ -63,7 +63,7 @@ echo --------------------
 
 lsmod | grep "tx_isp" >/dev/null
 if [ $? -ne 0 ]; then
-	insmod ${KMOD_PATH/%\//}/tx-isp-${SOC}.ko ${ISP_PARAM}
+	insmod ${KMOD_PATH/%\//}/tx-isp-${SOC}.ko ${ISP_PARAM} print_level=2
 	check_return "insmod isp drv"
 fi
 

--- a/general/package/ingenic-osdrv-t31/files/script/load_ingenic
+++ b/general/package/ingenic-osdrv-t31/files/script/load_ingenic
@@ -188,7 +188,7 @@ fi
 
 lsmod | grep "tx_isp" >/dev/null
 if [ $? -ne 0 ]; then
-	modprobe tx-isp-${SOC} ${ISP_PARAM}
+	modprobe tx-isp-${SOC} ${ISP_PARAM} print_level=2
 	check_return "insmod isp drv"
 fi
 

--- a/general/package/ingenic-osdrv-t40/files/script/load_ingenic
+++ b/general/package/ingenic-osdrv-t40/files/script/load_ingenic
@@ -85,7 +85,7 @@ fi
 
 lsmod | grep "tx_isp" >/dev/null
 if [ $? -ne 0 ]; then
-	modprobe tx-isp-${SOC} ${ISP_PARAM}
+	modprobe tx-isp-${SOC} ${ISP_PARAM} print_level=2
 	check_return "insmod isp drv"
 fi
 


### PR DESCRIPTION
Since https://github.com/OpenIPC/firmware/pull/1053 where we enabled CONFIG_DYNAMIC_DEBUG in linux kernel, the ingenic tx-isp module by default logs all debug info to dmesg.  

This is not adjustable in the source code for the isp module as the default logging level is set inside the `libtxx-firmware.a` precompiled binary, although we are able to adjust the log level via a module parameter at load time: `print_level=int`

```
...
[   20.631348] buflist:0x05a36800
[   20.631354] buf get:0x04e42800 isp_index = 70779960
[   20.870525] mscaler: index = 0, buffer idx = 7
[   20.870538] buflist:0x0662a800
[   20.870543] buflist:0x06927800
[   20.870548] buflist:0x06c24800
[   20.870554] buflist:0x06f21800
[   20.870559] buflist:0x0721e800
[   20.870564] buflist:0x0751b800
...
```

To adjust for this, lets set the loglevel to 2, which should be equal to "WARNING"   The user can still adjust this in `/usr/bin/load_ingenic` by changing the print_level if so desired to increase logging verbosity.

Applies to T21/30/31/T40 only