### PR TITLE
[no ci] add switch_debug function to profile

### DIFF
--- a/general/overlay/etc/profile
+++ b/general/overlay/etc/profile
@@ -49,6 +49,17 @@ show_wlan() {
 	grep -r '$1..=' /etc/wireless | cut -d '"' -f 4 | sort | grep -e $(fw_printenv -n soc) -e generic
 }
 
+switch_debug() {
+	[ "$1" = "on" ] && action='+' report='enabled' || action='-' report='disabled'
+	mount | grep -q 'debugfs' || mount -t debugfs none /sys/kernel/debug
+	echo "${action}p" > /sys/kernel/debug/dynamic_debug/control
+	for entry in mmc_core avpu squashfs mtdblock; do
+		echo "module $entry -p" > /sys/kernel/debug/dynamic_debug/control
+	done
+	echo "file fs/sysfs/file.c -p" > /sys/kernel/debug/dynamic_debug/control
+	echo "Dynamic debug for all files has been $report."
+}
+
 # Source configuration files from /etc/profile.d
 for i in /etc/profile.d/*.sh; do
 	[ -r "$i" ] && . $i


### PR DESCRIPTION
**Integrate the `switch_debug` command function into the Default User Profile**

Building upon the advancements in [PR #1053](https://github.com/OpenIPC/firmware/pull/1053), we have facilitated the `CONFIG_DYNAMIC_DEBUG` feature within the Linux kernel. This is tailored to suppress most engineering debug logs by default, as to not display them to everyday users.

Users now have the flexibility to toggle these debug messages through simple commands:
- To enable: `switch_debug on`
- To disable: `switch_debug off` or just `switch_debug`

While the majority of debugging filters are active, we've deliberately excluded  the following modules: `mmc_core`, `avpu`, `squashfs`, `mtdblock`, and `fs/sysfs/file.c`. These modules are known to generate an overwhelming number (thousands) of debug lines. However, users who wish to tap into these specific debug messages can manually enable them via `/sys/kernel/debug/dynamic_debug/control`.
