### PR TITLE
Add usb WiFi module QVC-IPC-136W

### DIFF
--- a/general/overlay/etc/wireless/usb
+++ b/general/overlay/etc/wireless/usb
@@ -76,7 +76,7 @@ if [ "$1" = "rtl8188fu-hi3518ev200-lifesmart" ]; then
 fi
 
 # HI3518EV200 Rostelecom QVC-IPC-136W
-if [ "$1" = "rtl8188eu-hi3518ev200-QVC-IPC-136W" ]; then
+if [ "$1" = "rtl8188eu-hi3518ev200-qvc-ipc-136w" ]; then
 	set_gpio 7 1
 	modprobe 8188eu
 	exit 0

--- a/general/overlay/etc/wireless/usb
+++ b/general/overlay/etc/wireless/usb
@@ -75,6 +75,13 @@ if [ "$1" = "rtl8188fu-hi3518ev200-lifesmart" ]; then
 	exit 0
 fi
 
+# HI3518EV200 Rostelecom QVC-IPC-136W
+if [ "$1" = "rtl8188eu-hi3518ev200-QVC-IPC-136W" ]; then
+	set_gpio 7 1
+	modprobe 8188eu
+	exit 0
+fi
+
 # HI3518EV300 Unknown1
 if [ "$1" = "rtl8188fu-hi3518ev300-unknown1" ]; then
 	set_gpio 57 0


### PR DESCRIPTION
Activate usb wifi module on QVC-IPC-136W

![IMG_20231007_210407](https://github.com/OpenIPC/firmware/assets/19822036/32781f84-ebbe-460b-9e90-7de010b0da5d)
![IMG_20231007_210450](https://github.com/OpenIPC/firmware/assets/19822036/27c346be-041e-4226-8160-dc84f3f3f29d)

```php
#>lsusb
Bus 001 Device 003: ID 0bda:0179 <--- RTL8188ETV
Bus 001 Device 001: ID 1d6b:0002
Bus 002 Device 001: ID 1d6b:0001
```