### PR TITLE
[no-ci] ingenic-osdrv: don't claim gpio 0

### DIFF
--- a/general/package/ingenic-osdrv-t30/files/script/load_ingenic
+++ b/general/package/ingenic-osdrv-t30/files/script/load_ingenic
@@ -90,6 +90,6 @@ if [ ! -z "$(lsmod | grep "gpio")" ]; then
 	for GPIO in $(echo ${GPIOS})
 	do
 	  G=$(cli -g ${GPIO})
-	  [ ! -z "${G}" ] && echo ${G} > /proc/gpio_claim/gpio
+	  [ ! -z "${G}" ] && [ "${G}" -gt "0" ] && echo ${G} > /proc/gpio_claim/gpio
 	done
 fi

--- a/general/package/ingenic-osdrv-t31/files/script/load_ingenic
+++ b/general/package/ingenic-osdrv-t31/files/script/load_ingenic
@@ -215,6 +215,6 @@ if [ ! -z "$(lsmod | grep "gpio")" ]; then
 	for GPIO in $(echo ${GPIOS})
 	do
 		G=$(cli -g ${GPIO})
-		[ ! -z "${G}" ] && echo ${G} > /proc/gpio_claim/gpio
+		[ ! -z "${G}" ] && [ "${G}" -gt "0" ] && echo ${G} > /proc/gpio_claim/gpio
 	done
 fi

--- a/general/package/ingenic-osdrv-t40/files/script/load_ingenic
+++ b/general/package/ingenic-osdrv-t40/files/script/load_ingenic
@@ -112,6 +112,6 @@ if [ ! -z "$(lsmod | grep "gpio")" ]; then
 	for GPIO in $(echo ${GPIOS})
 	do
 		G=$(cli -g ${GPIO})
-		[ ! -z "${G}" ] && echo ${G} > /proc/gpio_claim/gpio
+		[ ! -z "${G}" ] && [ "${G}" -gt "0" ] && echo ${G} > /proc/gpio_claim/gpio
 	done
 fi


### PR DESCRIPTION
Don't claim any GPIO `0` (or a negative value), retrieved from the `majestic.yaml` configuration for any GPIO setting.

`GPIOS=".nightMode.irCutPin1 .nightMode.irCutPin2 .nightMode.irSensorPin .nightMode.backlightPin .audio.speakerPin"`