### PR TITLE
[no-ci] overlay-files: update rc.local init script

### DIFF
--- a/general/overlay/etc/init.d/S94rc.local
+++ b/general/overlay/etc/init.d/S94rc.local
@@ -3,7 +3,6 @@
 # Start rc.local
 #
 
-
 start() {
 	echo "Starting rc.local"
 	/etc/rc.local
@@ -14,16 +13,25 @@ restart() {
 	/etc/rc.local
 }
 
+stop() {
+	echo "Stopping rc.local"
+	# Check if rc.local.stop exists and if so, execute it
+	if [ -x /etc/rc.local.stop ]; then
+		/etc/rc.local.stop
+	else
+		echo "/etc/rc.local.stop not found or not executable."
+	fi
+}
+
 case "$1" in
 	start)
-		"$1"
-		;;
-
-	restart|reload)
 		start
 		;;
+	restart|reload)
+		restart
+		;;
 	stop)
-		# Intentionally left blank, no need to stop rc.local
+		stop
 		;;
 	*)
 		echo "Usage: $0 {start|stop|restart|reload}"


### PR DESCRIPTION
Fixes:

- Change the name of S99rc.local to S94rc.local. By doing this, any tasks within this file will run before tasks in S95majestic. This fixes issues like recording to network storage failing because network share is not mounted before S95majestic starts.

Enhancement:

- Introduce an optional file named rc.local.stop. If you have tasks you need to run when the system is rebooting (like disconnecting from a network storage), you can add them to this file.