### PR TITLE
majestic: makefile - enable t21 ultimate build

### DIFF
--- a/general/package/majestic/majestic.mk
+++ b/general/package/majestic/majestic.mk
@@ -14,7 +14,7 @@ MAJESTIC_FAMILY = $(OPENIPC_SOC_FAMILY)
 MAJESTIC_RELEASE = $(OPENIPC_FLAVOR)
 
 # we don't have Majestic ultimate for these platforms
-MAJESTIC_LIST = hi3516av100 hi3519v101 t21
+MAJESTIC_LIST = hi3516av100 hi3519v101
 
 ifneq ($(filter $(MAJESTIC_LIST),$(MAJESTIC_FAMILY)),)
 	MAJESTIC_RELEASE = lite


### PR DESCRIPTION
majestic ultimate builds for t21 are now available, adjust makefile to enable them.