### PR TITLE
fix build curl byte range error

### DIFF
--- a/building.sh
+++ b/building.sh
@@ -127,7 +127,7 @@ fresh() {
   fi
 
   echo_c 34 "Downloading Buildroot sources to cache directory ..."
-  log_and_run "curl --continue-at - --output ${SRC_CACHE_DIR}/buildroot-${BR_VER}.tar.gz https://buildroot.org/downloads/buildroot-${BR_VER}.tar.gz"
+  log_and_run "curl --output ${SRC_CACHE_DIR}/buildroot-${BR_VER}.tar.gz https://buildroot.org/downloads/buildroot-${BR_VER}.tar.gz"
   echo_c 34 "Done.\n"
 
   echo_c 34 "Extracting a fresh copy of Buildroot from Buildroot sources ..."


### PR DESCRIPTION
fixes #920
```
Downloading Buildroot sources to cache directory ...
curl --continue-at - --output /tmp/buildroot_dl/buildroot-2023.02.1.tar.gz https://buildroot.org/downloads/buildroot-2023.02.1.tar.gz
** Resuming transfer from byte position 7181664
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (33) HTTP server doesn't seem to support byte ranges. Cannot resume.
```
seems like buildroot.org servers not supporting byte range requests
