### PR TITLE
ingenic-motors: correct module install dir

### DIFF
--- a/general/package/ingenic-motors-t31/ingenic-motors-t31.mk
+++ b/general/package/ingenic-motors-t31/ingenic-motors-t31.mk
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# AltoBeam INGENIC_MOTORS_T31 wifi driver
+# Ingenic Motors Driver
 #
 ################################################################################
 
@@ -11,6 +11,8 @@ define INGENIC_MOTORS_T31_EXTRACT_CMDS
 endef
 
 INGENIC_MOTORS_T31_MODULE_MAKE_OPTS = \
+	INSTALL_MOD_PATH=$(TARGET_DIR) \
+	INSTALL_MOD_DIR=ingenic \
 	KVER=$(LINUX_VERSION_PROBED) \
 	KSRC=$(LINUX_DIR)
 


### PR DESCRIPTION
Fix: 
- sample-motor.ko should be installed in the ingenic modules directory, lets adjust the make file to correct this.
- correct module name in makefile header