### PR TITLE
[no ci] imp-control: update file permissions

### DIFF
--- a/general/package/ingenic-libimp-control/ingenic-libimp-control.mk
+++ b/general/package/ingenic-libimp-control/ingenic-libimp-control.mk
@@ -15,7 +15,7 @@ endef
 
 define INGENIC_LIBIMP_CONTROL_INSTALL_TARGET_CMDS
     $(INSTALL) -D -m 0755 $(@D)/libimp_control.so $(TARGET_DIR)/usr/lib
-    $(INSTALL) -m 644 -t $(TARGET_DIR)/usr/sbin $(INGENIC_LIBIMP_CONTROL_PKGDIR)/src/imp-control.sh
+    $(INSTALL) -m 755 -t $(TARGET_DIR)/usr/sbin $(INGENIC_LIBIMP_CONTROL_PKGDIR)/src/imp-control.sh
 
 endef
 


### PR DESCRIPTION
Fix: set imp-control.sh permissions to 755 by default.