### PR TITLE
[no ci] wireless: sdio update

### DIFF
--- a/general/overlay/etc/wireless/sdio
+++ b/general/overlay/etc/wireless/sdio
@@ -15,37 +15,26 @@ set_mmc() {
 	fi
 }
 
-# T31 ATBM603X mmc0
-if [ "$1" = "atbm603x-t31-mmc0" ]; then
-	# PB10 wifi mmc1, pull-down -> high-impedance
-	devmem 0x10011128 32 0x400
-	# Set wifi mmc1 clk drive capability to 8mA
-	devmem 0x10011134 32 0x20000
-	set_mmc 0
-
-	cp /usr/share/atbm60xx_conf/atbm_txpwer_dcxo_cfg.txt /tmp
-	cp /usr/share/atbm60xx_conf/set_rate_power.txt /tmp
-	modprobe atbm603x_wifi_sdio atbm_printk_mask=0
-	exit 0
+# RTL8189FS Generic
+if [ "$1" = "rtl8189fs-generic" ]; then
+	set_mmc 1
+        modprobe 8189fs
+        exit 0
 fi
 
-# T31 ATBM603X mmc1
-if [ "$1" = "atbm603x-t31-mmc1" ]; then
-	# Copied from stock firmware
-	devmem 0x10011110 32 0x6e094800
+# ATBM603x Generic
+if [ "$1" = "atbm603x-generic" ]; then
 	set_mmc 1
-
 	cp /usr/share/atbm60xx_conf/atbm_txpwer_dcxo_cfg.txt /tmp
 	cp /usr/share/atbm60xx_conf/set_rate_power.txt /tmp
-	modprobe atbm603x_wifi_sdio atbm_printk_mask=0
-	exit 0
+        modprobe atbm603x_wifi_sdio
+        exit 0
 fi
 
 # T31 Wyze V3 / AtomCam 2 ATBM603x
 if [ "$1" = "atbm603x-t31-wyze-v3" ]; then
 	set_gpio 57 0;set_gpio 57 1
 	set_mmc 1
-
 	cp /usr/share/atbm60xx_conf/atbm_txpwer_dcxo_cfg.txt /tmp
 	cp /usr/share/atbm60xx_conf/set_rate_power.txt /tmp
 	modprobe atbm603x_wifi_sdio atbm_printk_mask=0
@@ -54,10 +43,8 @@ fi
 
 # T31 Wyze PanV2 ATBM603x
 if [ "$1" = "atbm603x-t31-wyze-pan-v2" ]; then
-
 	set_gpio 58 0;set_gpio 58 1
 	set_mmc 1
-
 	cp /usr/share/atbm60xx_conf/atbm_txpwer_dcxo_cfg.txt /tmp
 	cp /usr/share/atbm60xx_conf/set_rate_power.txt /tmp
 	modprobe atbm603x_wifi_sdio atbm_printk_mask=0


### PR DESCRIPTION
- Remove obsolete atbm603x entries since we removed the driver in #1170
- Add generic entries for rtl8189fs and atbm603x