### PR TITLE
[no ci] overlay-files: add watchdog option to init.d

### DIFF
--- a/general/overlay/etc/init.d/S99watchdog
+++ b/general/overlay/etc/init.d/S99watchdog
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+DAEMON="watchdog"
+
+WATCHDOG_ENABLED=false
+WATCHDOG_TIMEOUT=60
+WATCHDOG_ARGS="-T $WATCHDOG_TIMEOUT /dev/watchdog"
+
+start()
+{
+	[ "$(cli -g .watchdog.enabled)" = "false" ] && [ "$WATCHDOG_ENABLED" = "true" ] || { echo "Watchdog: Majestic Watchdog is enabled or standalone watchdog disabled"; exit 0; }
+
+	printf "Starting ${NAME}: "
+	start-stop-daemon -S -q -x "/sbin/${DAEMON}" -- ${WATCHDOG_ARGS}
+	[ $? = 0 ] && echo "OK" || echo "FAIL"
+}
+
+stop()
+{
+	printf "Stopping ${NAME}: "
+	if start-stop-daemon -K -q -s KILL -n "${DAEMON}"; then
+		echo "OK"
+	else
+		echo "FAIL"
+	fi
+}
+
+case "$1" in
+	start|stop)
+		"$1"
+		;;
+
+	restart|reload)
+		stop
+		start
+		;;
+
+	*)
+		echo "Usage: $0 {start|stop|restart|reload}" >&2
+		exit 1
+		;;
+esac

--- a/general/overlay/etc/init.d/S99watchdog
+++ b/general/overlay/etc/init.d/S99watchdog
@@ -2,22 +2,34 @@
 
 DAEMON="watchdog"
 
+WATCHDOG_VENDOR=$(ipcinfo -v)
 WATCHDOG_ENABLED=false
 WATCHDOG_TIMEOUT=60
 WATCHDOG_ARGS="-T $WATCHDOG_TIMEOUT /dev/watchdog"
+SUPPORTED_VENDORS="ingenic"
+
+vendor_supported() {
+	for vendor in $SUPPORTED_VENDORS; do
+		[ "$WATCHDOG_VENDOR" = "$vendor" ] && return 0
+	done
+	return 1
+}
 
 start()
 {
-	[ "$(cli -g .watchdog.enabled)" = "false" ] && [ "$WATCHDOG_ENABLED" = "true" ] || { echo "Watchdog: Majestic Watchdog is enabled or standalone watchdog disabled"; exit 0; }
-
-	printf "Starting ${NAME}: "
-	start-stop-daemon -S -q -x "/sbin/${DAEMON}" -- ${WATCHDOG_ARGS}
-	[ $? = 0 ] && echo "OK" || echo "FAIL"
+	if vendor_supported && [ "$(cli -g .watchdog.enabled)" = "false" ] && [ "$WATCHDOG_ENABLED" = "true" ]; then
+		printf "Starting ${DAEMON}: "
+		start-stop-daemon -S -q -x "/sbin/${DAEMON}" -- ${WATCHDOG_ARGS}
+		[ $? = 0 ] && echo "OK" || echo "FAIL"
+	else
+		echo "Watchdog: Unsupported vendor or Majestic Watchdog is enabled/standalone watchdog disabled"
+		exit 0
+	fi
 }
 
 stop()
 {
-	printf "Stopping ${NAME}: "
+	printf "Stopping ${DAEMON}: "
 	if start-stop-daemon -K -q -s KILL -n "${DAEMON}"; then
 		echo "OK"
 	else


### PR DESCRIPTION
Implement optional system watchdog in init.d scripts:

Introduced an optional hardware-based system watchdog, functioning independently of the majestic program. This feature provides an alternative layer of reliability, allowing users to utilize the system's hardware watchdog independently from majestic's internal operations. 

This enhancement ensures that the system watchdog remains operational even in scenarios where majestic may not be functioning correctly, for instance, hanging on reboot.

Users can activate this feature by modifying the init.d script. To prevent conflicts, this system watchdog is designed not to run if majestic's own internal watchdog is active, even if the system watchdog is enabled.  It is disabled, by default.
