### PR TITLE
[no ci] update network init script and configs

### DIFF
--- a/general/overlay/etc/init.d/S40network
+++ b/general/overlay/etc/init.d/S40network
@@ -6,22 +6,20 @@ set_wireless() {
 	path=/etc/wireless
 	if $path/usb "$dev" || $path/modem "$dev" || $path/sdio "$dev"; then
 		[ -n "$mac" ] && ip link set dev wlan0 address "$mac"
-		ifup wlan0
-		ifconfig eth0 192.168.192.10
 	fi
 }
 
 case "$1" in
 	start)
 		echo "Starting network..."
-		ifup -a
 		[ -n "$dev" ] && set_wireless || ifup eth0
+		ifup -a
 		;;
 
 	stop)
 		echo "Stopping network..."
-		ifdown -a
 		[ -n "$dev" ] && ifdown wlan0 || ifdown eth0
+		ifdown -a
 		;;
 
 	restart|reload)

--- a/general/overlay/etc/network/interfaces.d/eth0
+++ b/general/overlay/etc/network/interfaces.d/eth0
@@ -1,2 +1,3 @@
+auto eth0
 iface eth0 inet dhcp
     hwaddress ether $(fw_printenv -n ethaddr || echo 00:00:23:34:45:66)

--- a/general/overlay/etc/network/interfaces.d/wlan0
+++ b/general/overlay/etc/network/interfaces.d/wlan0
@@ -1,3 +1,4 @@
+auto wlan0
 iface wlan0 inet dhcp
     pre-up wpa_passphrase "$(fw_printenv -n wlanssid)" "$(fw_printenv -n wlanpass)" > /tmp/wpa_supplicant.conf
     pre-up sed -i 's/#psk.*/scan_ssid=1/g' /tmp/wpa_supplicant.conf


### PR DESCRIPTION
updated some settings for logic and functionality. draft for discussion.

removed:
```
ifup wlan0
ifconfig eth0 192.168.192.10
```
these should be managed in the ifup scripts.

changed:
```
[ -n "$dev" ] && set_wireless || ifup eth0 <------- set up wireless modules gpio, etc first, before bringing up network
ifup -a
```

