### PR TITLE
Ingenic t20: use openingenic sdk

### DIFF
--- a/general/package/ingenic-osdrv-t20/files/script/load_ingenic
+++ b/general/package/ingenic-osdrv-t20/files/script/load_ingenic
@@ -22,6 +22,8 @@ check_return() {
 	fi
 }
 
+SENSOR_EXT_PARAM=""
+
 lsmod | grep "sinfo" >/dev/null
 if [ $? -ne 0 ]; then
 	modprobe sinfo.ko
@@ -84,21 +86,20 @@ echo "SENSOR: ${SENSOR}"
 echo "SENSOR_PARAM: ${SENSOR_PARAM}"
 echo --------------------
 
-lsmod | grep "tx_isp" > /dev/null
-if [ $? -ne 0 ] ;then
-	insmod ${KMOD_PATH/%\//}/tx-isp-${SOC}.ko ${ISP_PARAM}
+lsmod | grep "tx_isp" >/dev/null
+if [ $? -ne 0 ]; then
+	modprobe tx-isp-${SOC} ${ISP_PARAM}
 	check_return "insmod isp drv"
 fi
 
-lsmod | grep ${SENSOR} > /dev/null
-if [ $? -ne 0 ] ;then
-	insmod ${KMOD_PATH/%\//}/sensor_${SENSOR}.ko ${SENSOR_PARAM}
+lsmod | grep ${SENSOR} >/dev/null
+if [ $? -ne 0 ]; then
+	modprobe sensor_${SENSOR}_${SOC} ${SENSOR_PARAM} ${SENSOR_EXT_PARAM}
 	check_return "insmod sensor drv"
 fi
 
 lsmod | grep "audio" >/dev/null
 if [ $? -ne 0 ]; then
-	insmod ${KMOD_PATH/%\//}/audio2.ko spk_gpio=-1
+	modprobe audio spk_gpio=-1
 	check_return "insmod audio"
 fi
-

--- a/general/package/ingenic-osdrv-t20/ingenic-osdrv-t20.mk
+++ b/general/package/ingenic-osdrv-t20/ingenic-osdrv-t20.mk
@@ -22,22 +22,9 @@ define INGENIC_OSDRV_T20_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/etc/sensor $(INGENIC_OSDRV_T20_PKGDIR)/files/sensor/params/sc2232.bin
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/etc/sensor $(INGENIC_OSDRV_T20_PKGDIR)/files/sensor/params/sc2235.bin
 
-	$(INSTALL) -m 755 -d $(TARGET_DIR)/lib/modules/3.10.14/ingenic
-	# $(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/3.10.14/ingenic $(INGENIC_OSDRV_T20_PKGDIR)/files/kmod/*.ko
-
-	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/3.10.14/ingenic $(INGENIC_OSDRV_T20_PKGDIR)/files/kmod/audio.ko
-	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/3.10.14/ingenic $(INGENIC_OSDRV_T20_PKGDIR)/files/kmod/audio2.ko
-	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/3.10.14/ingenic $(INGENIC_OSDRV_T20_PKGDIR)/files/kmod/tx-isp-t10.ko
-	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/3.10.14/ingenic $(INGENIC_OSDRV_T20_PKGDIR)/files/kmod/tx-isp-t20.ko
-	ln -sf tx-isp-t20.ko $(TARGET_DIR)/lib/modules/3.10.14/ingenic/tx-isp-t20l.ko
-
-	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/3.10.14/ingenic $(INGENIC_OSDRV_T20_PKGDIR)/files/kmod/sensor_jxf22.ko
-	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/3.10.14/ingenic $(INGENIC_OSDRV_T20_PKGDIR)/files/kmod/sensor_jxf23.ko
-	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/3.10.14/ingenic $(INGENIC_OSDRV_T20_PKGDIR)/files/kmod/sensor_jxh42.ko
-	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/3.10.14/ingenic $(INGENIC_OSDRV_T20_PKGDIR)/files/kmod/sensor_jxh62.ko
-	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/3.10.14/ingenic $(INGENIC_OSDRV_T20_PKGDIR)/files/kmod/sensor_sc2135.ko
-	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/3.10.14/ingenic $(INGENIC_OSDRV_T20_PKGDIR)/files/kmod/sensor_sc2232.ko
-	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/3.10.14/ingenic $(INGENIC_OSDRV_T20_PKGDIR)/files/kmod/sensor_sc2235.ko
+        # Modules for T20 are built from the openingenic repository sources, so we don't need to copy them.
+	#$(INSTALL) -m 755 -d $(TARGET_DIR)/lib/modules/3.10.14/ingenic
+	#ln -sf tx-isp-t20.ko $(TARGET_DIR)/lib/modules/3.10.14/ingenic/tx-isp-t20l.ko
 
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/usr/bin
 	$(INSTALL) -m 755 -t $(TARGET_DIR)/usr/bin $(INGENIC_OSDRV_T20_PKGDIR)/files/script/load*


### PR DESCRIPTION
openingenic sdk has been updated with T20 sources, switch to that instead of pre-compiled binaries.