### PR TITLE
Pin to commit for release Release 1.5.0

### DIFF
--- a/general/package/aws-producer/aws-producer.mk
+++ b/general/package/aws-producer/aws-producer.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 AWS_PRODUCER_SITE = $(call github,awslabs,amazon-kinesis-video-streams-producer-c,$(AWS_PRODUCER_VERSION))
-AWS_PRODUCER_VERSION = HEAD
+AWS_PRODUCER_VERSION = 65121322c3a48377c84c7e835b05e75b3737797a
 
 AWS_PRODUCER_INSTALL_STAGING = YES
 AWS_PRODUCER_LICENSE = Apache-2.0


### PR DESCRIPTION
As previously this was following HEAD and a more recent commit broke the build with the following error

/openipc-firmware/output/per-package/aws-webrtc/host/opt/ext-toolchain/bin/../lib/gcc/mipsel-openipc-linux-musl/12.3.0/../../../../mipsel-openipc-linux-musl/bin/ld: /data_drive/omlet/openipc-firmware/output/per-package/aws-webrtc/host/mipsel-buildroot-linux-musl/sysroot/usr/lib/libkvsCommonLws.so: undefined reference to `GMTIME_THREAD_SAFE'