### PR TITLE
add wifi support for t5810hct-m02 board

### DIFF
--- a/general/overlay/etc/wireless/usb
+++ b/general/overlay/etc/wireless/usb
@@ -106,6 +106,14 @@ if [ "$1" = "rtl8188fu-hi3518ev300-unknown1" ]; then
 	exit 0
 fi
 
+# HI3518EV300 t5810hct-m02
+if [ "$1" = "rtl8188fu-hi3518ev300-t5810hct-m02" ]; then
+        set_gpio 40 1
+        modprobe mac80211
+        modprobe 8188fu
+        exit 0
+fi
+
 # SSC325DE IMOU C22EP-S2
 if [ "$1" = "rtl8188fu-ssc325de-imou-c22ep-s2" ]; then
 	set_gpio 62 1


### PR DESCRIPTION
adding the correct gpio pin to power up the wifi chip for t5810hct-m02 board.

Camera brand name in India: Smitch (Discontinued)
Actual Manufaturer: Goscom

SOC: Hi3518ERNCV300
wifi chip: BL-M8188fu1
Camera sensor: jxf23