### PR TITLE
Change S98Datalink and wifibroadcast stop messages

### DIFF
--- a/general/package/datalink/files/S98datalink
+++ b/general/package/datalink/files/S98datalink
@@ -47,7 +47,7 @@ case "$1" in
 		;;
 
 	stop)
-		echo "Stopping all services..."
+		echo "Stopping FPV datalink services..."
 		killall -q wfb_tx
 		killall -q wfb_rx
 		killall -q telemetry_rx

--- a/general/package/wifibroadcast/files/wifibroadcast
+++ b/general/package/wifibroadcast/files/wifibroadcast
@@ -144,7 +144,7 @@ case "$1" in
 		;;
 
 	stop)
-		echo "Stopping all services..."
+		echo "Stopping Wifibroadcast services..."
 		killall -q wfb_tx
 		killall -q wfb_rx
 		killall -q telemetry_rx


### PR DESCRIPTION
Changed stop messages for S98Datalink and wifibroadcast scripts to no longer say "Stopping all services" as they are not actually stopping _all_ services.