### PR TITLE
Safely exiting in case of error

### DIFF
--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -21,6 +21,7 @@ echo_c() {
 die() {
 	echo_c 31 "$1 Aborting."
 	reboot_system
+	exit 1
 }
 
 check_soc() {


### PR DESCRIPTION
In case of incomplete download of the firmware file, erasing the flash may start before the reboot

![telegram-cloud-photo-size-2-5280575734412337330-y](https://github.com/OpenIPC/firmware/assets/60222962/9a59d4a3-2795-4c02-8aa1-b0704f6b1b6d)
