### PR TITLE
Added camera temperature to the OSD

### DIFF
--- a/general/package/datalink/files/telemetry
+++ b/general/package/datalink/files/telemetry
@@ -39,7 +39,7 @@ case "$1" in
 		if [ "$router" -eq 1 ] || [ "$fw" = "lte" ]; then
 			mavlink-routerd -c /etc/mavlink.conf > /dev/null 2>&1 &
 		else
-			mavfwd --channels "$channels" --master "$serial" --baudrate "$baud" -a "$aggregate" \
+			mavfwd --channels "$channels" --master "$serial" --baudrate "$baud" -p 100 -t -a "$aggregate" \
 				--out 127.0.0.1:$port_tx --in 127.0.0.1:$port_rx > /dev/null &
 		fi
 		if [ "$fw" = "fpv" ] || [ "$fw" = "venc" ]; then


### PR DESCRIPTION
With the new mavfwd of Tipo Man we can now have OSD temperature of the camera. The -t option will inject the temperature of the camera to the MAVLINK IMU messages and then we will be able to display it on the OSD. The -p 100 will enable a 3-way switch to be used for changing modes remotely.  For 6-way switch increase the delay value and setup the transmitter accordingly.