### PR TITLE
Update divinus.mk

### DIFF
--- a/general/package/divinus/divinus.mk
+++ b/general/package/divinus/divinus.mk
@@ -10,9 +10,9 @@ DIVINUS_LICENSE = MIT
 DIVINUS_LICENSE_FILES = LICENSE
 
 ifeq ($(BR2_TOOLCHAIN_USES_GLIBC),y)
-	DIVINUS_OPTIONS = "-s -Os -lm"
+	DIVINUS_OPTIONS = "-rdynamic -s -Os -lm"
 else
-	DIVINUS_OPTIONS = "-s -Os"
+	DIVINUS_OPTIONS = "-rdynamic -s -Os"
 endif
 
 define DIVINUS_BUILD_CMDS


### PR DESCRIPTION
The -rdynamic flag was missing and it is required to export the symbols enclosed in the executable and make them visible to the dynamically loaded manufacturer userspace libraries