### PR TITLE
Update gc4023.yaml

### DIFF
--- a/general/package/ingenic-osdrv-t31/files/sensor/gc4023.yaml
+++ b/general/package/ingenic-osdrv-t31/files/sensor/gc4023.yaml
@@ -1,6 +1,6 @@
 sensor:
   name: gc4023
-  address: 0x21
+  address: 0x29
   width: 2560
   height: 1440
   bus: i2c


### PR DESCRIPTION
Because the sensor source code is 0x29,
Here 0x21 will not generate an image, just change it to 0x29. I have verified it on the hardware.
https://github.com/OpenIPC/openingenic/blob/master/kernel/sensors/t31/gc4023/gc4023.c