### PR TITLE
Please update \etc\wireless\usb to include specific profile for IPC-3…

### DIFF
--- a/general/overlay/etc/wireless/usb
+++ b/general/overlay/etc/wireless/usb
@@ -55,6 +55,13 @@ if [ "$1" = "rtl8733bu-gk7205v200-camhi" ]; then
 	exit 0
 fi
 
+# GK7205V200 Kafei
+if [ "$1" = "8188fu-gk7205v200-kafei" ]; then
+	set_gpio 57 0
+	modprobe 8188fu
+	exit 0
+fi
+
 # GK7205V300 CamHi
 if [ "$1" = "rtl8733bu-gk7205v300-camhi" ]; then
 	set_gpio 7 0
@@ -62,10 +69,11 @@ if [ "$1" = "rtl8733bu-gk7205v300-camhi" ]; then
 	exit 0
 fi
 
-# GK7205V200 Kafei
-if [ "$1" = "8188fu-gk7205v200-kafei" ]; then
-	set_gpio 57 0
-	modprobe 8188fu
+# GK7205V300 XM IVG-G6S
+if [ "$1" = "atbm603x-gk7205v300-xm-g6s" ]; then
+  devmem 0x100C0080 32 0x530
+  set_gpio 7 0
+	modprobe atbm603x_wifi_usb
 	exit 0
 fi
 
@@ -254,14 +262,6 @@ fi
 # T31 ZTE K540
 if [ "$1" = "atbm603x-t31-zte-k540" ]; then
 	set_gpio 51 0
-	modprobe atbm603x_wifi_usb
-	exit 0
-fi
-
-# IVG G6S (GK7205V300+Sony IMX335) with IPC-38x38-WIFI-IF V1.02 - ATBM603x 
-if [ "$1" = "IPC-38x38-WIFI-atbm603x-usb" ]; then
-  devmem 0x100C0080 32 0x530
-  set_gpio 7 0
 	modprobe atbm603x_wifi_usb
 	exit 0
 fi

--- a/general/overlay/etc/wireless/usb
+++ b/general/overlay/etc/wireless/usb
@@ -258,4 +258,12 @@ if [ "$1" = "atbm603x-t31-zte-k540" ]; then
 	exit 0
 fi
 
+# IVG G6S (GK7205V300+Sony IMX335) with IPC-38x38-WIFI-IF V1.02 - ATBM603x 
+if [ "$1" = "IPC-38x38-WIFI-atbm603x-usb" ]; then
+  devmem 0x100C0080 32 0x530
+  set_gpio 7 0
+	modprobe atbm603x_wifi_usb
+	exit 0
+fi
+
 exit 1


### PR DESCRIPTION

![00](https://github.com/user-attachments/assets/5559ad2d-30e3-4a23-a7bf-04507e65e95e)
![01](https://github.com/user-attachments/assets/b9d99124-f19e-47df-8302-f8508e02b082)
…8x38-WIFI-IF V1.02 - ATBM603x

This configuration works for IVG G6S (GK7205V300+Sony IMX335) with the wifi/SD board IPC-38x38-WIFI-IF V1.02 - ATBM603x

This should solve also:
https://github.com/OpenIPC/firmware/issues/1486

Aliexpress link:
https://www.aliexpress.com/item/33015015652.html?spm=a2g0o.productlist.main.1.2c6939bdqpwIVR&algo_pvid=61c64c77-0081-484c-9586-79a87b883e1f&algo_exp_id=61c64c77-0081-484c-9586-79a87b883e1f-0&pdp_npi=4%40dis%21EUR%2143.54%2135.70%21%21%2146.31%2137.97%21%4021039cae17217272838005982ed87d%2112000037476197901%21sea%21IT%21734104683%21&curPageLogUid=I0ERTOKYsxr6&utparam-url=scene%3Asearch%7Cquery_from%3A