### PR TITLE
fix watchdog when majestic crashes

### DIFF
--- a/general/package/hisilicon-osdrv-hi3516cv100/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516cv100/files/script/load_hisilicon
@@ -345,7 +345,7 @@ insert_ko() {
 	insert_audio
 	echo "==== Your input Sensor type is $SENSOR ===="
 
-	insmod wdt.ko #nodeamon=1
+	insmod wdt.ko nodeamon=1
 
 	# system configuration
 	sysctl


### PR DESCRIPTION
per wdt.ko:
```
parm=nodeamon:By default, a kernel deamon feed watchdog when idle, set 'nodeamon=1' to disable this. (default=0)
parmtype=nodeamon:int
```
as documented in https://github.com/OpenIPC/majestic/issues/171, when majestic crashes, without `nodeamon=1` param to wdt kmod, camera does not automatically reboot.

Expected behavior is for majestic to feed the watchdog, and if majestic crashes, watchdog timer would expire and reset cpu, forcing host reboot.