### PR TITLE
fix msposd make output

### DIFF
--- a/general/package/msposd/msposd.mk
+++ b/general/package/msposd/msposd.mk
@@ -22,7 +22,7 @@ else
 endif
 
 define MSPOSD_BUILD_CMDS
-	$(MAKE) CC=$(TARGET_CC) DRV=$(MSPOSD_OSDRV)/files/lib $(MSPOSD_FAMILY) -C $(@D)
+	$(MAKE) CC=$(TARGET_CC) DRV=$(MSPOSD_OSDRV)/files/lib $(MSPOSD_FAMILY) OUTPUT=$(@D) -C $(@D)
 endef
 
 define MSPOSD_INSTALL_TARGET_CMDS


### PR DESCRIPTION
For me br does not correctly build the binary at the expected location.
This changes the output of the binary to be `output/per-package/msposd/target/usr/bin/msposd` as expected by the install commands.