### PR TITLE
Added MSPOSD font files for every flight controller software. Size of…

### DIFF
--- a/general/package/msposd/msposd.mk
+++ b/general/package/msposd/msposd.mk
@@ -31,8 +31,12 @@ define MSPOSD_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 755 -t $(TARGET_DIR)/usr/bin $(@D)/safeboot.sh
 
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/usr/share/fonts
-	$(INSTALL) -m 644 -t $(TARGET_DIR)/usr/share/fonts $(@D)/fonts/common/font.png
-	$(INSTALL) -m 644 -t $(TARGET_DIR)/usr/share/fonts $(@D)/fonts/common/font_hd.png
+	$(INSTALL) -m 644 -t $(TARGET_DIR)/usr/share/fonts $(@D)/fonts/font_inav.png
+	$(INSTALL) -m 644 -t $(TARGET_DIR)/usr/share/fonts $(@D)/fonts/font_inav_hd.png
+	$(INSTALL) -m 644 -t $(TARGET_DIR)/usr/share/fonts $(@D)/fonts/font_btfl.png
+	$(INSTALL) -m 644 -t $(TARGET_DIR)/usr/share/fonts $(@D)/fonts/font_btfl_hd.png
+	$(INSTALL) -m 644 -t $(TARGET_DIR)/usr/share/fonts $(@D)/fonts/font_ardu.png
+	$(INSTALL) -m 644 -t $(TARGET_DIR)/usr/share/fonts $(@D)/fonts/font_ardu_hd.png
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/etc $(@D)/vtxmenu.ini
 endef
 


### PR DESCRIPTION
MSPOSD now adds the option to automatically detect the Flight Controller SW used.
The font files were converted from 32bit color to 4bit color png, so their sized is reduced 8 times.
Now all 6 files will have less total size than the 2 files till now