### PR TITLE
Limit the number of channels supported by the VENC module.

### DIFF
--- a/general/package/goke-osdrv-gk7205v200/files/script/load_goke
+++ b/general/package/goke-osdrv-gk7205v200/files/script/load_goke
@@ -179,7 +179,7 @@ insert_ko() {
 	insmod gk7205v200_chnl.ko
 	insmod gk7205v200_vedu.ko
 	insmod gk7205v200_rc.ko
-	insmod gk7205v200_venc.ko
+	insmod gk7205v200_venc.ko VencMaxChnNum=3
 	insmod gk7205v200_h264e.ko
 	insmod gk7205v200_h265e.ko
 	insmod gk7205v200_jpege.ko

--- a/general/package/hisilicon-osdrv-hi3516ev200/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516ev200/files/script/load_hisilicon
@@ -182,7 +182,7 @@ insert_ko() {
 	modprobe open_chnl
 	modprobe open_vedu
 	modprobe open_rc
-	modprobe open_venc
+	modprobe open_venc VencMaxChnNum=3
 	modprobe open_h264e
 	modprobe open_h265e
 	modprobe open_jpege


### PR DESCRIPTION
 Some of the OS memory can be saved