### PR TITLE
Allow switching MSPOSD from air to ground and vice-versa via config

### DIFF
--- a/general/package/datalink/files/telemetry
+++ b/general/package/datalink/files/telemetry
@@ -43,7 +43,10 @@ case "$1" in
 		else
 			if [ "$router" -eq 2  ]; then
 				msposd --channels "$channels" --master "$serial" --baudrate "$baud"  \
-					--out 127.0.0.1:$(($port_tx + 1)) -osd -r "$fps" --ahi "$ahi" > /dev/null &
+					-osd -r "$fps" --ahi "$ahi" > /dev/null &
+			elif [ "$router" -eq 3 ]; then
+				msposd --channels "$channels" --master "$serial" --baudrate "$baud"  \
+					--out 10.5.0.1:$(($port_tx + 1)) -osd -r "$fps" > /dev/null &
 			else
 				mavfwd --channels "$channels" --master "$serial" --baudrate "$baud" -p 100 -t -a "$aggregate" \
 					--out 127.0.0.1:$port_tx --in 127.0.0.1:$port_rx > /dev/null &

--- a/general/package/datalink/files/telemetry
+++ b/general/package/datalink/files/telemetry
@@ -44,6 +44,9 @@ case "$1" in
 			if [ "$router" -eq 2  ]; then
 				msposd --channels "$channels" --master "$serial" --baudrate "$baud"  \
 					--out 127.0.0.1:$(($port_tx + 1)) -osd -r "$fps" --ahi "$ahi" > /dev/null &
+			elif [ "$router" -eq 3 ]; then
+				msposd --channels "$channels" --master "$serial" --baudrate "$baud"  \
+					--out 10.5.0.1:$(($port_tx + 1)) -r "$fps" --ahi "$ahi" > /dev/null &
 			else
 				mavfwd --channels "$channels" --master "$serial" --baudrate "$baud" -p 100 -t -a "$aggregate" \
 					--out 127.0.0.1:$port_tx --in 127.0.0.1:$port_rx > /dev/null &

--- a/general/package/datalink/files/telemetry
+++ b/general/package/datalink/files/telemetry
@@ -46,7 +46,7 @@ case "$1" in
 					-osd -r "$fps" --ahi "$ahi" > /dev/null &
 			elif [ "$router" -eq 3 ]; then
 				msposd --channels "$channels" --master "$serial" --baudrate "$baud"  \
-					--out 10.5.0.1:$(($port_tx + 1)) -osd -r "$fps" > /dev/null &
+					--out 10.5.0.1:$(($port_tx + 1)) -r "$fps" > /dev/null &
 			else
 				mavfwd --channels "$channels" --master "$serial" --baudrate "$baud" -p 100 -t -a "$aggregate" \
 					--out 127.0.0.1:$port_tx --in 127.0.0.1:$port_rx > /dev/null &

--- a/general/package/datalink/files/telemetry
+++ b/general/package/datalink/files/telemetry
@@ -44,9 +44,6 @@ case "$1" in
 			if [ "$router" -eq 2  ]; then
 				msposd --channels "$channels" --master "$serial" --baudrate "$baud"  \
 					--out 127.0.0.1:$(($port_tx + 1)) -osd -r "$fps" --ahi "$ahi" > /dev/null &
-			elif [ "$router" -eq 3 ]; then
-				msposd --channels "$channels" --master "$serial" --baudrate "$baud"  \
-					--out 10.5.0.1:$(($port_tx + 1)) -r "$fps" --ahi "$ahi" > /dev/null &
 			else
 				mavfwd --channels "$channels" --master "$serial" --baudrate "$baud" -p 100 -t -a "$aggregate" \
 					--out 127.0.0.1:$port_tx --in 127.0.0.1:$port_rx > /dev/null &

--- a/general/package/datalink/files/telemetry_drone.conf
+++ b/general/package/datalink/files/telemetry_drone.conf
@@ -4,7 +4,7 @@ unit=drone
 serial=/dev/ttyAMA0
 baud=115200
 
-### router: use simple mavfwd (0), classic mavlink-routerd (1) or msposd instead of mavfwd (2)
+### router: use simple mavfwd (0), classic mavlink-routerd (1) or msposd instead of mavfwd (2) or msposd on ground station (3)
 router=0
 
 wlan=wlan0

--- a/general/package/datalink/files/telemetry_drone.conf
+++ b/general/package/datalink/files/telemetry_drone.conf
@@ -4,7 +4,7 @@ unit=drone
 serial=/dev/ttyAMA0
 baud=115200
 
-### router: use simple mavfwd (0), classic mavlink-routerd (1) or msposd instead of mavfwd (2) or msposd on ground station (3)
+### router: use simple mavfwd (0), classic mavlink-routerd (1) or msposd instead of mavfwd (2)
 router=0
 
 wlan=wlan0

--- a/general/package/datalink/files/telemetry_drone.conf
+++ b/general/package/datalink/files/telemetry_drone.conf
@@ -4,7 +4,7 @@ unit=drone
 serial=/dev/ttyAMA0
 baud=115200
 
-### router: use simple mavfwd (0), classic mavlink-routerd (1) or msposd instead of mavfwd (2)
+### router: use simple mavfwd (0), classic mavlink-routerd (1) or msposd instead of mavfwd (2) or msposd on groundstation (3)
 router=0
 
 wlan=wlan0

--- a/general/package/wifibroadcast-ng/files/wfb.yaml
+++ b/general/package/wifibroadcast-ng/files/wfb.yaml
@@ -13,3 +13,4 @@ telemetry:
   router: msposd
   serial: /dev/ttyS2
   osd_fps: 20
+  ahi: 0

--- a/general/package/wifibroadcast-ng/files/wifibroadcast
+++ b/general/package/wifibroadcast-ng/files/wifibroadcast
@@ -91,11 +91,11 @@ start_telemetry() {
 
 	if [ "$router" = "msposd" ]; then
 		echo "- Starting $router"
-		msposd --baudrate 115200 --channels 8 -osd --ahi 0 -r "$osd_fps" \
+		msposd --baudrate 115200 --channels 8 -osd --ahi "$ahi" -r "$osd_fps" \
 			--master "$serial" --out 10.5.0.1:14551 > /dev/null &
-	elif ["$router" = "msposd_gs"]; then
+	elif [ "$router" = "msposd_gs" ]; then
 		echo "- Starting $router"
-		msposd --baudrate 115200 --channels 8 --ahi 0 -r "$osd_fps" \
+		msposd --baudrate 115200 --channels 8 --ahi "$ahi" -r "$osd_fps" \
 			--master "$serial" --out 10.5.0.1:14551 > /dev/null &
 	elif [ "$router" = "mavfwd" ]; then
 		echo "- Starting $router"

--- a/general/package/wifibroadcast-ng/files/wifibroadcast
+++ b/general/package/wifibroadcast-ng/files/wifibroadcast
@@ -92,10 +92,10 @@ start_telemetry() {
 	if [ "$router" = "msposd" ]; then
 		echo "- Starting $router"
 		msposd --baudrate 115200 --channels 8 -osd --ahi "$ahi" -r "$osd_fps" \
-			--master "$serial" --out 10.5.0.1:14551 > /dev/null &
+			--master "$serial" > /dev/null &
 	elif [ "$router" = "msposd_gs" ]; then
 		echo "- Starting $router"
-		msposd --baudrate 115200 --channels 8 --ahi "$ahi" -r "$osd_fps" \
+		msposd --baudrate 115200 --channels 8 -r "$osd_fps" \
 			--master "$serial" --out 10.5.0.1:14551 > /dev/null &
 	elif [ "$router" = "mavfwd" ]; then
 		echo "- Starting $router"

--- a/general/package/wifibroadcast-ng/files/wifibroadcast
+++ b/general/package/wifibroadcast-ng/files/wifibroadcast
@@ -93,6 +93,10 @@ start_telemetry() {
 		echo "- Starting $router"
 		msposd --baudrate 115200 --channels 8 -osd --ahi 0 -r "$osd_fps" \
 			--master "$serial" --out 10.5.0.1:14551 > /dev/null &
+	elif ["$router" = "msposd_gs"]; then
+		echo "- Starting $router"
+		msposd --baudrate 115200 --channels 8 --ahi 0 -r "$osd_fps" \
+			--master "$serial" --out 10.5.0.1:14551 > /dev/null &
 	elif [ "$router" = "mavfwd" ]; then
 		echo "- Starting $router"
 		mavfwd --baudrate 115200 --channels 8 -p 100 -a 15 -t \


### PR DESCRIPTION
Added the ability to switch MSPOSD from rendering on the air or on the ground based on value configured in /etc/wfb.yaml

Also added the ability to configure MSPOSD AHI type via /etc/wfb.yaml config file