### PR TITLE
Shutdown Ruby, if present, during sysupgrade procedure

### DIFF
--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -98,6 +98,9 @@ download_firmware() {
 
 free_resources() {
 	echo_c 37 "\nStop services, sync files, free up memory"
+	if [ -f /etc/init.d/S73ruby ]; then
+    		/etc/init.d/S73ruby stop
+	fi
 	killall -q -3 majestic
 	sleep 1
 	/etc/init.d/S99rc.local stop


### PR DESCRIPTION
Stop all Ruby processes, if present, when launching a sysupgrade procedure.