### PR TITLE
fix system time from sd card files

### DIFF
--- a/general/overlay/etc/rc.local
+++ b/general/overlay/etc/rc.local
@@ -11,4 +11,18 @@
 #
 # By default this script does nothing.
 
+target_dir="/mnt/mmcblk0p1"
+[ ! -d "$target_dir" ] && echo "not find" && exit 1
+
+latest_time=$(find "$target_dir" -exec stat -c '%Y' {} \; 2>/dev/null | sort -nr | head -1)
+[ -z "$latest_time" ] && echo "no sub dir" && exit 0
+echo latest_time $latest_time
+
+current_time=$(date +%s)
+echo current_time $current_time
+
+if [ "$latest_time" -gt "$current_time" ]; then
+    date -s "@$latest_time" >/dev/null && echo "ok" || echo "fail"
+fi
+
 exit 0


### PR DESCRIPTION
Add little shell code to restore system time from sd card file after boot up.It's woking in my rc.local, but I'm not sure there's a better place to put it.

---

The root reason for modifying the time is that the sky-side card recording DVR stores files according to the system time. When offline, the system always use defaults time, resulting in chaotic connection of video files. Possible solutions include:

1, Modify the time
1.1, Manually modify the time
1.2, Automatically correct the time
1.2.1, Use GPS data to synchronize the time
1.2.2, The receiving end (Android) pushes the time
1.2.3, Use the existing DVR to infer the time, at least avoid duplication
2, Modify the algorithm
2.1, Detect the existence of the file and append a number
2.2, Do not use time as the file name
This pr is method 1.2.3, method 1.1 send in msposd pr #58

---

修改时间的根本原因是天空端卡录DVR按系统时间存储文件，离线时系统总是默认时间，导致视频文件混乱连接在一起。可能的解決方式包括：
1,修改时间
1.1,手动修改时间
1.2,自动修正时间
1.2.1，使用GPS数据同步时间
1.2.2，接收端（安卓）推送时间
1.2.3，借助已有DVR推测时间，至少避免重复
2,修改算法
2.1，检测文件存在，追加数字
2.2，不适用时间作为文件名
本pr为方法1.2.3,方法1.1已经在msposd pr #58 提交