### PR TITLE
Add temperature monitor, add channels.sh, add jumbo frames

### DIFF
--- a/general/package/wifibroadcast-ng/files/S991temp_monitor
+++ b/general/package/wifibroadcast-ng/files/S991temp_monitor
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+case "$1" in
+	start)
+		echo "Starting temperature check..."
+		temp_monitor &>/dev/null &
+		;;
+
+	stop)
+		echo "Stopping temperature check..."
+		killall -q temp_monitor
+		;;
+
+	*)
+		echo "Usage: $0 {start|stop}"
+		exit 1
+		;;
+esac

--- a/general/package/wifibroadcast-ng/files/channels.sh
+++ b/general/package/wifibroadcast-ng/files/channels.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+case "$1" in
+    5)
+        echo "Channel5 change."
+        channel5.sh "$2"
+        ;;
+    6)
+        echo "Channel6 change."
+        channel6.sh "$2"
+        ;;
+    7)
+        echo "Channel7 change."
+        channel7.sh "$2"
+        ;;
+    8)
+        echo "Channel8 change."
+        channel8.sh "$2"
+        ;;
+    9)
+        echo "Channel9 change."
+        channel9.sh "$2"
+        ;;
+    10)
+        echo "Channel10 change."
+        channel10.sh "$2"
+        ;;
+    11)
+        echo "Channel11 change."
+        channel11.sh "$2"
+        ;;
+    12)
+        echo "Channel12 change."
+        channel12.sh "$2"
+        ;;
+    *)
+        echo "No valid channel specified."
+        ;;
+esac
+
+exit 0

--- a/general/package/wifibroadcast-ng/files/temp_monitor
+++ b/general/package/wifibroadcast-ng/files/temp_monitor
@@ -1,0 +1,74 @@
+#!/bin/sh
+# Define temperature thresholds:
+NORMAL_THRESHOLD=85    # Normal if below 85°C
+REBOOT_THRESHOLD=100   # Reboot if 100°C or higher
+
+# --- Get Adapter info ---
+for card in $(lsusb | awk '{print $6}' | sort | uniq); do
+    case "$card" in
+        "0bda:8812" | "0bda:881a" | "0b05:17d2" | "2357:0101" | "2604:0012")
+            driver=88XXau
+            ;;
+        "0bda:a81a")
+            driver=8812eu
+            ;;
+        "0bda:f72b" | "0bda:b733")
+            driver=8733bu
+            ;;
+    esac
+done
+wifi_adapter=""$driver""
+echo "Wifi adapter found: $driver"
+
+while true; do
+    # --- Get VTX Temperature ---
+    # Example output from ipcinfo --temp: "39.00"
+    vtx_temp=$(ipcinfo --temp)
+    vtx_int=$(echo "$vtx_temp" | cut -d. -f1)
+    
+    adapter_temp=0
+    if [ "$wifi_adapter" = "8733bu" ]; then
+        # Expected format: "rf_path: 0, thermal_value: 37, offset: 45, temperature: 20"
+        adapter_temp=$(grep -o 'temperature: [0-9]*' /proc/net/rtl8733bu/wlan0/thermal_state | awk '{print $2}')
+    elif [ "$wifi_adapter" = "88XXau" ]; then
+        echo "Adapter 88XXau temperature extraction not implemented yet."
+        adapter_temp=0
+    elif [ "$wifi_adapter" = "8812eu" ]; then
+        if [ -f /proc/net/rtl88x2eu/wlan0/thermal_state ]; then
+            # Extract both temperature values and choose the highest
+            adapter_temp=$(grep -o 'temperature: [0-9]*' /proc/net/rtl88x2eu/wlan0/thermal_state | awk '{print $2}' | sort -n | tail -1)
+        else
+            echo "Thermal state file for 8812eu not found."
+            adapter_temp=0
+        fi
+    else
+        echo "Unknown adapter type: $wifi_adapter"
+    fi
+
+    # Fallback if adapter_temp is empty
+    if [ -z "$adapter_temp" ]; then
+        adapter_temp=0
+    fi
+
+    echo "VTX temperature: ${vtx_temp}°C, Adapter temperature: ${adapter_temp}°C"
+
+    # --- Determine the Highest Temperature ---
+    if [ "$adapter_temp" -gt "$vtx_int" ]; then
+        max_temp=$adapter_temp
+    else
+        max_temp=$vtx_int
+    fi
+
+    # --- Determine the current state based on max_temp ---
+    if [ "$max_temp" -lt "$NORMAL_THRESHOLD" ]; then
+        echo "All is well... Nothing to do" > /dev/null
+    elif [ "$max_temp" -lt "$REBOOT_THRESHOLD" ]; then
+        echo "Warning: High temperature was detected.\nVTX Temp:&T WifiTemp:&W &L30 &G8 &F18" > /tmp/MSPOSD.msg
+    else
+        echo "VTX will reboot due to thermal state...\nVTX Temp:&T WifiTemp:&W &L30 &G8 &F18.\nRebooting in 15 seconds..." > /tmp/MSPOSD.msg
+        sleep 15
+        reboot
+    fi
+
+    sleep 5
+done

--- a/general/package/wifibroadcast-ng/files/wfb.yaml
+++ b/general/package/wifibroadcast-ng/files/wfb.yaml
@@ -10,7 +10,7 @@ broadcast:
   stbc: 0
   ldpc: 0
   link_id: 7669206
-	mtu: 3994
+	jumbo_frames: false
 telemetry:
   router: msposd
   serial: ttyS2

--- a/general/package/wifibroadcast-ng/files/wfb.yaml
+++ b/general/package/wifibroadcast-ng/files/wfb.yaml
@@ -10,6 +10,7 @@ broadcast:
   stbc: 0
   ldpc: 0
   link_id: 7669206
+	mtu: 3994
 telemetry:
   router: msposd
   serial: ttyS2

--- a/general/package/wifibroadcast-ng/files/wifibroadcast
+++ b/general/package/wifibroadcast-ng/files/wifibroadcast
@@ -62,6 +62,10 @@ load_interface() {
 
 	[ "$driver" = "88XXau" ] && wfb_power=$((txpower * -100)) || wfb_power=$((txpower * 50))
 	iw "$wfb_dev" set txpower fixed "$wfb_power"
+
+	if [ "$jumbo_frames" = "true" ]; then
+		ip link set dev "$wfb_dev" mtu 3994
+	fi
 }
 
 start_broadcast() {

--- a/general/package/wifibroadcast-ng/wifibroadcast-ng.mk
+++ b/general/package/wifibroadcast-ng/wifibroadcast-ng.mk
@@ -21,6 +21,7 @@ define WIFIBROADCAST_NG_INSTALL_TARGET_CMDS
 
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/etc/init.d
 	$(INSTALL) -m 755 -t $(TARGET_DIR)/etc/init.d $(WIFIBROADCAST_NG_PKGDIR)/files/S98wifibroadcast
+	$(INSTALL) -m 755 -t $(TARGET_DIR)/etc/init.d $(WIFIBROADCAST_NG_PKGDIR)/files/S991temp_monitor
 
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/etc/sensors
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/etc/sensors $(WIFIBROADCAST_NG_PKGDIR)/sensor/*
@@ -32,6 +33,8 @@ define WIFIBROADCAST_NG_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 755 -t $(TARGET_DIR)/usr/bin $(@D)/wfb_tun
 	$(INSTALL) -m 755 -t $(TARGET_DIR)/usr/bin $(WIFIBROADCAST_NG_PKGDIR)/files/wfb-cli
 	$(INSTALL) -m 755 -t $(TARGET_DIR)/usr/bin $(WIFIBROADCAST_NG_PKGDIR)/files/wifibroadcast
+
+	$(INSTALL) -m 755 -t $(TARGET_DIR)/usr/bin $(WIFIBROADCAST_NG_PKGDIR)/files/temp_monitor
 
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/var/www
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/var/www $(WIFIBROADCAST_NG_PKGDIR)/www/*

--- a/general/package/wifibroadcast-ng/wifibroadcast-ng.mk
+++ b/general/package/wifibroadcast-ng/wifibroadcast-ng.mk
@@ -35,6 +35,7 @@ define WIFIBROADCAST_NG_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 755 -t $(TARGET_DIR)/usr/bin $(WIFIBROADCAST_NG_PKGDIR)/files/wifibroadcast
 
 	$(INSTALL) -m 755 -t $(TARGET_DIR)/usr/bin $(WIFIBROADCAST_NG_PKGDIR)/files/temp_monitor
+	$(INSTALL) -m 755 -t $(TARGET_DIR)/usr/bin $(WIFIBROADCAST_NG_PKGDIR)/files/channels.sh
 
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/var/www
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/var/www $(WIFIBROADCAST_NG_PKGDIR)/www/*


### PR DESCRIPTION
Add temperature monitor
Add temperature monitor as a startup service and reboot on overheat

add channels.sh
for easier insertion of channel execution by configurators

add jumbo frames support:
Add jumbo frames support in wifibroadcast and wfb.yaml