### PR TITLE
Fix if syntax error in load_sigmastar

### DIFF
--- a/general/package/sigmastar-osdrv-infinity6e/files/script/load_sigmastar
+++ b/general/package/sigmastar-osdrv-infinity6e/files/script/load_sigmastar
@@ -15,7 +15,7 @@ detect_sensor() {
 	fi
 
 	SENSOR=$(ipcinfo -s)
-	if [ "$BUILD" != "fpv" ]
+	if [ "$BUILD" != "fpv" ]; then
 		fw_setenv sensor "$SENSOR"
 	fi
 }


### PR DESCRIPTION
This [commit ](https://github.com/OpenIPC/firmware/commit/c80e5b86488213be6eb9197ace814932e118d016)introduced the wrong code, missing `;then` in this [line ](https://github.com/OpenIPC/firmware/blob/master/general/package/sigmastar-osdrv)