### PR TITLE
Allow changing TX power dynamically on 8812eu and 8733bu

### DIFF
--- a/general/package/wifibroadcast-ng/files/wifibroadcast
+++ b/general/package/wifibroadcast-ng/files/wifibroadcast
@@ -50,8 +50,8 @@ load_modules() {
 	sleep 1
 
 	if [ "$driver" != "88XXau" ]; then
-		opt1="rtw_tx_pwr_by_rate=2"
-		opt2="rtw_tx_pwr_lmt_enable=2"
+		opt1="rtw_tx_pwr_by_rate=0"
+		opt2="rtw_tx_pwr_lmt_enable=0"
 	fi
 
 	modprobe "$driver" "$opt1" "$opt2"


### PR DESCRIPTION
Now when loading the 8812eu and 8733bu drivers, use `rtw_tx_pwr_by_rate=2` and `rtw_tx_pwr_lmt_enable=2` parameters, which will cause the user to be unable to modify the tx power to the expected value. Please check @viktorxda 

https://github.com/libc0607/rtl88x2eu-20230815/blob/v5.15.0.1/README.md?plain=1#L46-L47
https://github.com/OpenIPC/firmware/blob/master/general/package/legacy/wifibroadcast/files/wifibroadcast#L44