### PR TITLE
OpenIPC FPV PnP V1.0

### DIFF
--- a/general/package/wifibroadcast-ng/files/wifibroadcast
+++ b/general/package/wifibroadcast-ng/files/wifibroadcast
@@ -129,25 +129,60 @@ start_telemetry() {
 		fi
 		msposd -b 115200 -c 8 -r "$osd_fps" -m /dev/"$serial" \
 			-o 127.0.0.1:"$port_tx" -z "$size" > /dev/null &
+sleep 5
+echo "&L70&F28&G8CPU:&C TEMP:&T\n&B" >/tmp/MSPOSD.msg
 	fi
 }
 
 video_settings() {
-	sensor=$(ipcinfo -s)
-	cli -s .isp.sensorConfig /etc/sensors/"$sensor"_fpv.bin
-	cli -s .isp.exposure 16
-	cli -s .video0.size 1920x1080
-	cli -s .video0.fps 60
-	cli -s .video0.gopSize 1.0
-	cli -s .video0.bitrate 8192
-	cli -s .video0.codec h265
-	cli -s .video0.rcMode cbr
-	cli -s .outgoing.enabled true
-	cli -s .outgoing.wfb true
-	cli -s .fpv.enabled true
-	cli -s .fpv.noiseLevel 1
-	cli -s .records.split 1
-	cli -s .records.notime true
+for card in $(lsusb | awk '{print $6}' | uniq); do
+  case "$card" in
+   "0bda:8812" | "0bda:881a" | "0b05:17d2" | "2357:0101" | "2604:0012")
+    driver=88XXau
+    wifibroadcast cli -s .wireless.txpower 20
+    wifibroadcast cli -s .wireless.wlan_adapter bl-r8812af1
+    wifibroadcast cli -s .broadcast.stbc 1
+    wifibroadcast cli -s .broadcast.ldpc 1
+    ;;
+
+   "0bda:a81a")
+    driver=8812eu
+    wifibroadcast cli -s .wireless.txpower 40
+    wifibroadcast cli -s .wireless.wlan_adapter bl-m8812eu2
+    wifibroadcast cli -s .broadcast.stbc 1
+    wifibroadcast cli -s .broadcast.ldpc 1
+    ;;
+
+   "0bda:f72b" | "0bda:b733")
+    driver=8733bu
+    wifibroadcast cli -s .wireless.txpower 20
+    wifibroadcast cli -s .wireless.wlan_adapter bl-m8731bu4
+    wifibroadcast cli -s .broadcast.stbc 0
+    wifibroadcast cli -s .broadcast.ldpc 0
+    ;;
+  esac
+ done
+sensor=$(ipcinfo -s)
+cli -s .isp.sensorConfig /etc/sensors/"$sensor"_fpv.bin
+cli -s .isp.exposure 16
+cli -s .video0.fps 60
+cli -s .video0.bitrate 8000
+cli -s .video0.codec h265
+cli -s .video0.rcMode cbr
+cli -s .outgoing.enabled true
+cli -s .outgoing.wfb true
+cli -s .records.split 1
+cli -s .records.notime true
+cli -s .fpv.enabled true
+cli -s .fpv.noiseLevel 0
+wifibroadcast cli -s .wireless.mlink 3994
+wifibroadcast cli -s .wireless.link_control alink
+sed -i '/alink_drone &/d' /etc/rc.local && sed -i -e '$i alink_drone &' /etc/rc.local
+if [ "$sensor" = "imx335" ]; then
+cli -s .video0.size 1920x1440
+else
+cli -s .video0.size 1920x1080
+fi
 }
 
 start() {


### PR DESCRIPTION
This version was created after a lot of tests performed by developers and testers of the OpenIPC FPV community. We included tweaked settings and all latest features such as Adaptive Link 6.4, JUMBO WFB-ng packets up to 3994 size, countless tweaks and the latest vtxmenu for easy access to the basic settings for the end-user advanced settings for the experts.

The end-user will only need to change channel, tx power and resolution. Everything else will be set automatically. The only thing that the end-user is required to do is use either the companion or the configurator or the webUI to update their camera to the latest firmware.

Our team hope to enjoy this version and stay tuned for future PnP versions. The version 2.0 is coming soon with new innovative features.

Credits

Developers that worked for this version:
Greg Sparks(https://github.com/sickgreg/)
Joakim (https://github.com/snokvist/)
Ihor (https://github.com/vertexodessa)
Henk Wiedig (https://github.com/henkwiedig)
John Godwin (https://github.com/JohnDGodwin)
MarioFPV (https://github.com/mariofpvdev/

Testers:
Egirl (https://github.com/carabidulebabat)
BlackFox (https://github.com/BlackFox-org)
Paddy (https://github.com/PaddyP90)
Jeremie Lehmann (https://github.com/jeremielehmann)