### PR TITLE
Video Encoder synced to injection rate of wfb-ng when using patched 8812xx driver

### DIFF
--- a/general/package/wifibroadcast-ng/files/wifibroadcast
+++ b/general/package/wifibroadcast-ng/files/wifibroadcast
@@ -57,7 +57,8 @@ load_modules() {
 		opt2="rtw_tx_pwr_lmt_enable=0"
 	fi
 
-	modprobe "$driver" "$opt1" "$opt2"
+	
+	modprobe "$driver" "$opt1" "$opt2" MaxTxBufLen=32
 	sleep 3
 
 	if ! ifconfig "$wfb_dev" up; then
@@ -101,7 +102,7 @@ load_wfb() {
 start_broadcast() {
 	echo_log "Starting wfb_tx"
 	wfb_tx -K "$wfb_key" -M "$mcs_index" -B "$width" -k "$fec_k" -n "$fec_n" -U rtp_local \
-		-S "$stbc" -L "$ldpc" -i "$link_id" -C 8000 "$wfb_dev" &> /dev/null &
+		-S "$stbc" -L "$ldpc" -i "$link_id" -C 8000 -J 10 -E 5000 "$wfb_dev" &> /dev/null &
 }
 
 start_tunnel() {

--- a/general/package/wifibroadcast-ng/wifibroadcast-ng.mk
+++ b/general/package/wifibroadcast-ng/wifibroadcast-ng.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-WIFIBROADCAST_NG_VERSION = 7ffc689e3f1194dca79dca4b5b56ee560c0cc3be
+WIFIBROADCAST_NG_VERSION = ae2122c1fb70cd215bbc2e1b517b7b91f9401220
 WIFIBROADCAST_NG_SITE = $(call github,svpcom,wfb-ng,$(WIFIBROADCAST_NG_VERSION))
 WIFIBROADCAST_NG_LICENSE = GPL-3.0
 


### PR DESCRIPTION
This PR configures the use of wfb-ng latest feature
https://github.com/svpcom/wfb-ng/commit/ae2122c1fb70cd215bbc2e1b517b7b91f9401220
and patched drivers for 8812au
https://github.com/OpenIPC/realtek-wlan/pull/8
and 8812eu2
https://github.com/libc0607/rtl88x2eu-20230815/commit/bbdd94a38eae4f80a51c604253897fd12ab3d9ed

The `MaxTxBufLen `is set to 32. A lower value will put more stress on the encoder to keep the CBR at the cost of lost frames. Higher value (up to 64) will cache video spikes and will result with delayed frames and latency spikes.
To make use of this feature it is recommended to increase the bitrate per given MCS index and reduce the FEC.
Recommended bitrates for 20Mhz BW and FEC 8:10 are:
```
MCS0 - bitrate: 4000
MCS1 - bitrate: 8000
MCS2 - bitrate: 12000
MCS3 - bitrate: 16000
MCS4 - bitrate: 22000
```
These can be reduced somewhat (some 5~10%) if the video is not CBR in order to address micro latency spikes.

