### PR TITLE
[no ci] fix(wireguard): elide empty PresharedKey

### DIFF
--- a/general/overlay/usr/sbin/wireguard
+++ b/general/overlay/usr/sbin/wireguard
@@ -4,6 +4,7 @@ modprobe wireguard || { echo "Error: Failed to load wireguard module." >&2; exit
 ip link add dev wg0 type wireguard || { echo "Error: Failed to create wg0 interface." >&2; exit 1; }
 
 WG_PRIVKEY="$(fw_printenv -n wg_privkey)"
+WG_PRESHARED_KEY="$(fw_printenv -n wg_sharkey)"
 ( echo "#"
   echo "[Interface]"
   echo "PrivateKey = $WG_PRIVKEY"
@@ -12,12 +13,12 @@ WG_PRIVKEY="$(fw_printenv -n wg_privkey)"
   echo "Endpoint = $(fw_printenv -n wg_endpoint)"
   echo "PersistentKeepalive = $(fw_printenv -n wg_alive)"
   echo "PublicKey = $(fw_printenv -n wg_pubkey)"
-  echo "PresharedKey = $(fw_printenv -n wg_sharkey)"
+  [ -n "$WG_PRESHARED_KEY" ] && echo "PresharedKey = $WG_PRESHARED_KEY"
   echo "AllowedIPs = $(fw_printenv -n wg_allowed)"
   echo "#"
 ) >>/tmp/wireguard.conf
 
-wg setconf wg0 /tmp/wireguard.conf
+wg setconf wg0 /tmp/wireguard.conf || { echo "Error: Failed to apply wireguard configuration." >&2; exit 1; }
 wg_address="$(fw_printenv -n wg_address)"
 if [ -z "$wg_address" ]; then
     echo "Error: wg_address environment variable is not set or empty." >&2


### PR DESCRIPTION
The current WireGuard script implementation fails to produce a working WireGuard connection if pre-shared key is empty or unset.

If wg_sharkey env var is empty, the script prints:
```
...
[Peer]
PresharedKey = # <- no value here
...
```
, which makes `wg setconf` utility return an error due to an invalid config and no connection is established.

The lack of a pre-shared key, while (maybe?) somewhat uncommon in practice, is a valid mode of operation according to the WireGuard docs and their [whitepaper](https://www.wireguard.com/papers/wireguard.pdf) (see section `5.2 Optional Pre-shared Symmetric Key Mode`).

This PR modifies the script, so that it omits the `PresharedKey = ` line if the key is empty.

In addition, if `wg setconf` fails with an error, the script does not fail silently anymore - it echoes a message instead.