### PR TITLE
hisilicon-opensdk: add hi3516cv500 support

### DIFF
--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -22,6 +22,8 @@ ifeq ($(OPENIPC_SOC_FAMILY),hi3516ev200)
 	HISILICON_OPENSDK_SDK_CODE = 0x3516E200
 else ifeq ($(OPENIPC_SOC_FAMILY),gk7205v200)
 	HISILICON_OPENSDK_SDK_CODE = 0x7205200
+else ifeq ($(OPENIPC_SOC_FAMILY),hi3516cv500)
+	HISILICON_OPENSDK_SDK_CODE = 0x3516C500
 endif
 
 # for userspace libraries
@@ -29,14 +31,18 @@ define HISILICON_OPENSDK_BUILD_CMDS
 	$(MAKE) $(TARGET_CONFIGURE_OPTS) CHIPARCH=$(OPENIPC_SOC_FAMILY) SDK_CODE=$(HISILICON_OPENSDK_SDK_CODE) -C $(@D)/libraries all
 endef
 
+# Sensor install list per SoC family
+HISILICON_OPENSDK_SENSORS_hi3516ev200 = sony_imx335/libsns_imx335 sony_imx307/libsns_imx307 soi_h63/libsns_h63
+HISILICON_OPENSDK_SENSORS_gk7205v200 = sony_imx335/libsns_imx335 sony_imx307/libsns_imx307 soi_h63/libsns_h63
+HISILICON_OPENSDK_SENSORS_hi3516cv500 = sony_imx335/libsns_imx335 sony_imx307/libsns_imx307 sony_imx415/libsns_imx415
+
+HISILICON_OPENSDK_SENSORS = $(HISILICON_OPENSDK_SENSORS_$(OPENIPC_SOC_FAMILY))
+
 define HISILICON_OPENSDK_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/usr/lib/sensors
-	$(INSTALL) -D -m 0644 $(@D)/libraries/sensor/$(OPENIPC_SOC_FAMILY)/sony_imx335/libsns_imx335.so $(TARGET_DIR)/usr/lib/sensors
-	$(INSTALL) -D -m 0644 $(@D)/libraries/sensor/$(OPENIPC_SOC_FAMILY)/sony_imx307/libsns_imx307.so $(TARGET_DIR)/usr/lib/sensors
-	$(INSTALL) -D -m 0644 $(@D)/libraries/sensor/$(OPENIPC_SOC_FAMILY)/soi_h63/libsns_h63.so $(TARGET_DIR)/usr/lib/sensors
-	#
-	# Using non-original SDK causes a lot of noise, the problem is not solved yet. Please use binary module or build this driver with original SDK from HiSilicon/Goke.
-  # $(INSTALL) -D -m 0644 $(@D)/libraries/sensor/$(OPENIPC_SOC_FAMILY)/imagedesign_mis2008/libsns_mis2008.so $(TARGET_DIR)/usr/lib/sensors
+	$(foreach s,$(HISILICON_OPENSDK_SENSORS), \
+		$(INSTALL) -D -m 0644 $(@D)/libraries/sensor/$(OPENIPC_SOC_FAMILY)/$(s).so $(TARGET_DIR)/usr/lib/sensors ; \
+	)
 endef
 
 $(eval $(kernel-module))


### PR DESCRIPTION
## Summary

- Add `SDK_CODE = 0x3516C500` for hi3516cv500 SoC family
- Add CV500 sensor install list (imx335, imx307, imx415)
- Keep existing EV200/GK7205V200 sensor list unchanged

## Companion PR

OpenIPC/openhisilicon#36 — adds hi3516cv500 SoC family support (38 kernel modules, ISP library, 20 sensor drivers from source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)