### PR TITLE
hisilicon-opensdk: bump to d8b0941 (fix CV500 libisp.so)

### DIFF
--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = 6fe935a
+HISILICON_OPENSDK_VERSION = d8b0941
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Fixes Majestic crash on hi3516av300/cv500: `undefined symbol: isp_alg_register_af`

The previous opensdk version excluded ISP AF algorithm from libisp.so. This bump includes the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)