### PR TITLE
hisilicon-opensdk: fix missing CV500 modules (tde, vo, pwm, piris, sensors)

### DIFF
--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = d8b0941
+HISILICON_OPENSDK_VERSION = 2001d3b
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE
@@ -19,9 +19,12 @@ HISILICON_OPENSDK_MODULE_SUBDIRS = kernel
 HISILICON_OPENSDK_MODULE_MAKE_OPTS = \
 	DISABLE_IST=1 \
 	DISABLE_PM=1 \
-	DISABLE_TDE=1 \
-	DISABLE_VO=1 \
 	CHIPARCH=$(OPENIPC_SOC_FAMILY)
+
+# CV500 has TDE/VO blobs; other platforms don't support them yet
+ifneq ($(OPENIPC_SOC_FAMILY),hi3516cv500)
+HISILICON_OPENSDK_MODULE_MAKE_OPTS += DISABLE_TDE=1 DISABLE_VO=1
+endif
 
 ifeq ($(OPENIPC_SOC_FAMILY),hi3516ev200)
 	HISILICON_OPENSDK_SDK_CODE = 0x3516E200
@@ -60,6 +63,10 @@ define HISILICON_OPENSDK_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 644 $(@D)/kernel/open_mipi_rx.ko     $(HISILICON_OPENSDK_KMOD_DST)/hi_mipi_rx.ko
 	$(INSTALL) -m 644 $(@D)/kernel/open_mipi_tx.ko     $(HISILICON_OPENSDK_KMOD_DST)/hi_mipi_tx.ko
 	$(INSTALL) -m 644 $(@D)/kernel/open_cipher.ko      $(HISILICON_OPENSDK_KMOD_DST)/hi_cipher.ko
+	$(INSTALL) -m 644 $(@D)/kernel/open_pwm.ko         $(HISILICON_OPENSDK_KMOD_DST)/hi_pwm.ko
+	$(INSTALL) -m 644 $(@D)/kernel/open_piris.ko       $(HISILICON_OPENSDK_KMOD_DST)/hi_piris.ko
+	$(INSTALL) -m 644 $(@D)/kernel/open_sensor_i2c.ko  $(HISILICON_OPENSDK_KMOD_DST)/hi_sensor_i2c.ko
+	$(INSTALL) -m 644 $(@D)/kernel/open_sensor_spi.ko  $(HISILICON_OPENSDK_KMOD_DST)/hi_sensor_spi.ko
 	for mod in base sys isp vi vpss venc vedu h264e h265e jpege jpegd rc rgn vgs ive chnl \
 		tde vo hdmi vdec vfmw aio ai ao aenc adec acodec gdc dis nnie wdt; do \
 		[ -f $(@D)/kernel/open_$${mod}.ko ] && \


### PR DESCRIPTION
## Problem

Boot errors on hi3516av300/cv500/dv300:
```
insmod: can't insert 'hi3516cv500_tde.ko': No such file or directory
insmod: can't insert 'hi3516cv500_vo.ko': No such file or directory
insmod: can't insert 'hi_pwm.ko': No such file or directory
insmod: can't insert 'hi_piris.ko': No such file or directory
insmod: can't insert 'hi_sensor_i2c.ko': No such file or directory
insmod: can't insert 'hi_sensor_spi.ko': No such file or directory
```

Fixes: https://github.com/OpenIPC/openhisilicon/issues/43

## Fix

1. `DISABLE_TDE=1 DISABLE_VO=1` only for non-CV500 (CV500 has blobs)
2. Add install rename rules for `hi_pwm`, `hi_piris`, `hi_sensor_i2c`, `hi_sensor_spi`

Tested on hi3516av300 + imx415: zero insmod errors, Majestic OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)