### PR TITLE
uclibc-compat: fix __aeabi_d2iz infinite recursion

### DIFF
--- a/general/package/uclibc-compat/src/uclibc-compat.c
+++ b/general/package/uclibc-compat/src/uclibc-compat.c
@@ -134,11 +134,25 @@ size_t _stdlib_mb_cur_max(void)
 	return 1;
 }
 
-/* __aeabi_d2iz -- ARM EABI double-to-int, missing from musl */
+/* __aeabi_d2iz -- ARM EABI double-to-int, missing from musl.
+ * Cannot use C cast (int)x because GCC emits __aeabi_d2iz for it,
+ * causing infinite recursion.  Implement the conversion manually
+ * by extracting the IEEE 754 double fields. */
 __attribute__((visibility("default")))
 int __aeabi_d2iz(double x)
 {
-	return (int)x;
+	union { double d; unsigned long long u; } u = { .d = x };
+	int sign = (u.u >> 63) ? -1 : 1;
+	int exp = ((u.u >> 52) & 0x7FF) - 1023;
+	if (exp < 0) return 0;
+	if (exp > 30) return sign > 0 ? 0x7FFFFFFF : (int)0x80000000;
+	unsigned long long mantissa = (u.u & 0x000FFFFFFFFFFFFFULL) | 0x0010000000000000ULL;
+	int result;
+	if (exp >= 52)
+		result = (int)(mantissa << (exp - 52));
+	else
+		result = (int)(mantissa >> (52 - exp));
+	return sign * result;
 }
 
 /* ======================================================================


### PR DESCRIPTION
## Problem

`__aeabi_d2iz` in `libuclibc-compat.so` caused a stack overflow (infinite recursion). GCC converts `(int)x` to a call to `__aeabi_d2iz` — which is the function itself.

Found via AddressSanitizer on hi3516cv100 hardware (128MB RAM, osmem=96M for ASAN headroom):
```
==821==ERROR: AddressSanitizer: stack-overflow on address 0xbe520ff8
    #0 0x400b4894  (/usr/lib/libuclibc-compat.so+0x894)
```

Disassembly confirmed the recursion:
```asm
__aeabi_d2iz:
    push {r4, lr}
    bl   __aeabi_d2iz@plt    ; calls itself!
    pop  {r4, pc}
```

## Fix

Replace with manual IEEE 754 double field extraction using only integer operations.

## Test plan

- [x] ASAN build of majestic passes `hisi_free_mem_ex` (was crashing here)
- [x] Sensor initializes: "Sony IMX122 Sensor Initial OK!"
- [x] SDK starts: "HiSilicon SDK started"
- [ ] Full hardware test after toolchain rebuild + firmware build

Ref: #1992