### PR TITLE
Add optional ASAN toolchain support for musl platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,17 @@ endif
 	@$(BR_MAKE) sdk -j$(shell nproc)
 	@$(call BUNDLE_SDK)
 
+toolchain-asan: defconfig
+ifeq ($(BR2_TOOLCHAIN_EXTERNAL),y)
+	@cp -rf $(PWD)/general/package/gcc $(TARGET)/buildroot-$(BR_VER)/package
+	@$(MAKE) -f $(PWD)/general/toolchain.mk BR_CONF=$(BR_CONF) CONFIG=$(PWD)/$(CONFIG)
+	@$(BR_MAKE) BR2_DEFCONFIG=$(BR_CONF) defconfig
+endif
+	@echo 'BR2_EXTRA_GCC_CONFIG_OPTIONS="--enable-libsanitizer"' >> $(BR_CONF)
+	@$(BR_MAKE) BR2_DEFCONFIG=$(BR_CONF) defconfig
+	@$(BR_MAKE) sdk -j$(shell nproc)
+	@$(call BUNDLE_SDK)
+
 repack:
 ifeq ($(BR2_TARGET_ROOTFS_SQUASHFS),y)
 ifeq ($(BR2_OPENIPC_SOC_VENDOR),"rockchip")

--- a/general/package/all-patches/gcc/0001-libsanitizer-musl-compat.patch
+++ b/general/package/all-patches/gcc/0001-libsanitizer-musl-compat.patch
@@ -1,0 +1,106 @@
+libsanitizer: guard musl-incompatible headers and structs
+
+musl libc headers conflict with kernel headers (struct sysinfo,
+linux/if_ppp.h, linux/sysctl.h).  Guard these with SANITIZER_GLIBC
+and provide zero-value fallbacks so libsanitizer builds on musl.
+
+These changes are harmless when libsanitizer is disabled (the patched
+files are only compiled when --enable-libsanitizer is active).
+
+Signed-off-by: Dmitry Ilyin <6576495+widgetii@users.noreply.github.com>
+
+--- a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp	2026-04-13 23:37:27.004985453 +0300
++++ b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp	2026-04-13 23:37:27.022582860 +0300
+@@ -69,7 +69,9 @@
+ #include <malloc.h>
+ #include <mntent.h>
+ #include <netinet/ether.h>
++#if SANITIZER_GLIBC
+ #include <sys/sysinfo.h>
++#endif
+ #include <sys/vt.h>
+ #include <linux/cdrom.h>
+ #include <linux/fd.h>
+@@ -80,7 +82,9 @@
+ #include <linux/input.h>
+ #include <linux/ioctl.h>
+ #include <linux/soundcard.h>
++#if SANITIZER_GLIBC
+ #include <linux/sysctl.h>
++#endif
+ #include <linux/utsname.h>
+ #include <linux/posix_types.h>
+ #include <net/if_arp.h>
+@@ -126,9 +130,11 @@
+ #endif
+ #include <scsi/scsi.h>
+ #else
++#if SANITIZER_GLIBC
+ #include <linux/if_ppp.h>
+ #include <linux/kd.h>
+ #include <linux/ppp_defs.h>
++#endif
+ #endif  // SANITIZER_GLIBC
+ 
+ #if SANITIZER_ANDROID
+@@ -244,7 +250,11 @@
+ 
+ #  if SANITIZER_LINUX
+   unsigned struct_epoll_event_sz = sizeof(struct epoll_event);
++#if SANITIZER_GLIBC
+   unsigned struct_sysinfo_sz = sizeof(struct sysinfo);
++#else
++  unsigned struct_sysinfo_sz = 0;
++#endif
+   unsigned __user_cap_header_struct_sz =
+       sizeof(struct __user_cap_header_struct);
+   unsigned __user_cap_data_struct_sz = sizeof(struct __user_cap_data_struct);
+@@ -518,7 +528,11 @@
+   unsigned struct_unimapinit_sz = sizeof(struct unimapinit);
+ 
+   unsigned struct_audio_buf_info_sz = sizeof(struct audio_buf_info);
++#if SANITIZER_GLIBC
+   unsigned struct_ppp_stats_sz = sizeof(struct ppp_stats);
++#else
++  unsigned struct_ppp_stats_sz = 0;
++#endif
+ #endif  // SANITIZER_GLIBC
+ 
+ #if !SANITIZER_ANDROID && !SANITIZER_APPLE
+@@ -678,6 +692,7 @@
+   unsigned IOCTL_HDIO_SET_NOWERR = HDIO_SET_NOWERR;
+   unsigned IOCTL_HDIO_SET_UNMASKINTR = HDIO_SET_UNMASKINTR;
+   unsigned IOCTL_MTIOCPOS = MTIOCPOS;
++#if SANITIZER_GLIBC
+   unsigned IOCTL_PPPIOCGASYNCMAP = PPPIOCGASYNCMAP;
+   unsigned IOCTL_PPPIOCGDEBUG = PPPIOCGDEBUG;
+   unsigned IOCTL_PPPIOCGFLAGS = PPPIOCGFLAGS;
+@@ -689,6 +704,19 @@
+   unsigned IOCTL_PPPIOCSMAXCID = PPPIOCSMAXCID;
+   unsigned IOCTL_PPPIOCSMRU = PPPIOCSMRU;
+   unsigned IOCTL_PPPIOCSXASYNCMAP = PPPIOCSXASYNCMAP;
++#else
++  unsigned IOCTL_PPPIOCGASYNCMAP = 0;
++  unsigned IOCTL_PPPIOCGDEBUG = 0;
++  unsigned IOCTL_PPPIOCGFLAGS = 0;
++  unsigned IOCTL_PPPIOCGUNIT = 0;
++  unsigned IOCTL_PPPIOCGXASYNCMAP = 0;
++  unsigned IOCTL_PPPIOCSASYNCMAP = 0;
++  unsigned IOCTL_PPPIOCSDEBUG = 0;
++  unsigned IOCTL_PPPIOCSFLAGS = 0;
++  unsigned IOCTL_PPPIOCSMAXCID = 0;
++  unsigned IOCTL_PPPIOCSMRU = 0;
++  unsigned IOCTL_PPPIOCSXASYNCMAP = 0;
++#endif
+   unsigned IOCTL_SIOCADDRT = SIOCADDRT;
+   unsigned IOCTL_SIOCDARP = SIOCDARP;
+   unsigned IOCTL_SIOCDELRT = SIOCDELRT;
+@@ -1122,7 +1150,7 @@
+ CHECK_STRUCT_SIZE_AND_OFFSET(sigaction, sa_restorer);
+ #endif
+ 
+-#if SANITIZER_LINUX
++#if SANITIZER_GLIBC
+ CHECK_TYPE_SIZE(__sysctl_args);
+ CHECK_SIZE_AND_OFFSET(__sysctl_args, name);
+ CHECK_SIZE_AND_OFFSET(__sysctl_args, nlen);


### PR DESCRIPTION
## Summary

Add `make BOARD=<platform> toolchain-asan` that builds a toolchain with AddressSanitizer support. Same toolchain, no separate artifact — just adds `libasan.a`/`libasan.so` to the output.

## How it works

Buildroot's gcc-final.mk appends `BR2_EXTRA_GCC_CONFIG_OPTIONS` last, so `--enable-libsanitizer` overrides the earlier `--disable-libsanitizer` for musl. No gcc.mk modification needed.

A GCC patch guards musl-incompatible headers in libsanitizer (`struct sysinfo`, `linux/sysctl.h`, `linux/if_ppp.h`). The patch is harmless when libsanitizer is disabled.

## Usage

```bash
# Build ASAN toolchain
make BOARD=hi3516cv100_lite toolchain-asan

# Compile with ASAN (static libasan to avoid deploying .so)
arm-openipc-linux-musleabi-gcc -fsanitize=address -static-libasan \
  -fno-omit-frame-pointer -g -latomic -o myapp myapp.c

# Run on device (increase osmem for headroom)
fw_setenv osmem 96M
ASAN_OPTIONS="quarantine_size_mb=1:detect_leaks=0:stack_use_after_return=0:symbolize=0" ./myapp
```

## Known limitation: vendor SDK MMZ memory

ASAN's shadow memory does not cover hardware-mapped regions (MMZ/Media Memory Zone used by HiSilicon, Sigmastar, etc). When vendor SDK functions map device memory via `/dev/mmz`, ASAN's `__asan_unpoison_stack_memory` receives addresses outside its shadow range, causing:

```
AddressSanitizer: CHECK failed: asan_poisoning.cpp:37
  "((AddrIsAlignedByGranularity(addr))) != (0)" (0x0, 0x0)
```

**Workaround**: exclude vendor SDK interaction files from ASAN instrumentation. For majestic:

```bash
# After cmake build, recompile SDK files without ASAN and relink:
python3 -c "
import json, subprocess
with open('build/compile_commands.json') as f:
    cmds = json.load(f)
for c in cmds:
    if c['file'].endswith(('sdk.c', 'hal.c', 'mmap.c')):
        cmd = c['command'].replace('-fsanitize=address', '').replace('-fno-omit-frame-pointer', '')
        subprocess.run(cmd, shell=True, cwd=c['directory'])
"
cmake --build build --target majestic
```

Or in source code, annotate functions that call vendor SDK mmap:
```c
__attribute__((no_sanitize("address")))
int init_vpss(...) { /* calls HI_MPI_VB_MmapPool etc */ }
```

## Test plan

- [x] `make BOARD=hi3516cv100_lite toolchain-asan` builds successfully
- [x] `libasan.a` and `libasan.so` present in output
- [x] Test program compiles with `-fsanitize=address -static-libasan -latomic`
- [x] ASAN detects buffer overflow under qemu-arm-static
- [x] Regular `make BOARD=hi3516cv100_lite toolchain` still works (patch is harmless)
- [x] Used to find real bug: `__aeabi_d2iz` infinite recursion (#2002)
- [x] ASAN majestic on hi3516cv100 hardware: SDK init, sensor load, JPEG serving — zero ASAN errors under k6 load test (100 requests, 5 concurrent users)

Ref: #1992

🤖 Generated with [Claude Code](https://claude.ai/claude-code)