### PR TITLE
hisilicon-opensdk: bump to 8889317, add CV100 SSP source modules

### DIFF
--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = e6e5e08
+HISILICON_OPENSDK_VERSION = 8889317
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE
@@ -111,6 +111,9 @@ define HISILICON_OPENSDK_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 644 $(@D)/kernel/open_vi.ko      $(HISILICON_OPENSDK_KMOD_DST)/hi3518_viu.ko
 	$(INSTALL) -m 644 $(@D)/kernel/open_rgn.ko     $(HISILICON_OPENSDK_KMOD_DST)/hi3518_region.ko
 	$(INSTALL) -m 644 $(@D)/kernel/open_vgs.ko     $(HISILICON_OPENSDK_KMOD_DST)/hi3518_dsu.ko
+	$(INSTALL) -m 644 $(@D)/kernel/open_ssp_sony.ko    $(HISILICON_OPENSDK_KMOD_DST)/ssp_sony.ko
+	$(INSTALL) -m 644 $(@D)/kernel/open_ssp_pana.ko    $(HISILICON_OPENSDK_KMOD_DST)/ssp_pana.ko
+	$(INSTALL) -m 644 $(@D)/kernel/open_ssp_ad9020.ko  $(HISILICON_OPENSDK_KMOD_DST)/ssp_ad9020.ko
 endef
 
 # For hi3516cv200: install opensdk .ko to hisilicon/ with vendor names,


### PR DESCRIPTION
## Summary

- Bump opensdk to `8889317` (includes openhisilicon#52)
- Install source-built SSP sensor bus drivers for CV100: `ssp_sony`, `ssp_pana`, `ssp_ad9020`
- These replace the last vendor-only binary .ko modules for CV100's SPI sensor interface

## Test plan

- [x] `make BOARD=hi3516cv100_lite all` builds (4724KB < 5120KB limit)
- [x] SSP modules installed as `ssp_sony.ko`, `ssp_pana.ko`, `ssp_ad9020.ko` in `hisilicon/`
- [x] Sysupgrade to hi3516cv100 hardware (IMX323 sensor)
- [x] `ssp_sony` loads, ISP depends on it, SDK starts
- [x] JPEG snapshot captured (69KB)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)