### PR TITLE
hisilicon-osdrv-hi3519v101: fix IMX385 sensor config for real hardware

### DIFF
--- a/general/package/hisilicon-osdrv-hi3519v101/files/sensor/config/imx385_i2c_1080p.ini
+++ b/general/package/hisilicon-osdrv-hi3519v101/files/sensor/config/imx385_i2c_1080p.ini
@@ -1,6 +1,6 @@
 [sensor]
-Sensor_type=stSnsObj
-Mode=WDR_MODE_NONE
+Sensor_type=stSnsImx385Obj
+Mode=0
 DllFile=libsns_imx385.so
 
 [mode]
@@ -8,15 +8,16 @@ input_mode=INPUT_MODE_MIPI
 dev_attr=0
 
 [mipi]
-data_type=RAW_DATA_10BIT
+data_type=RAW_DATA_12BIT
 lane_id = 0|1|2|3|-1|-1|-1|-1|      ;lane_id: -1 - disable
+wdr_type = DOL
 
 [isp_image]
 Isp_x      =0
 Isp_y      =0
 Isp_W      =1920
 Isp_H      =1080
-Isp_FrameRate=25
+Isp_FrameRate=60
 Isp_Bayer=BAYER_RGGB
 
 [vi_dev]
@@ -80,8 +81,8 @@ FieldPolar=0
 DataPath=1
 InputDataType=1 ;VI_DATA_TYPE_YUV = 0,VI_DATA_TYPE_RGB = 1,
 DataRev      =FALSE ;Data reverse. FALSE = 0; TRUE = 1
-DevRect_x=4
-DevRect_y=4
+DevRect_x=0
+DevRect_y=0
 DevRect_w=1920
 DevRect_h=1080
 


### PR DESCRIPTION
## Summary

Fix IMX385 sensor bring-up on hi3519v101 by (1) matching the sensor ini to the driver's exported symbol and real-hardware values, and (2) building the sensor \`libsns_imx385.so\` from openhisilicon source instead of shipping a prebuilt blob — the same pattern hi3516ev200 / gk7205v200 / hi3516cv500 already use.

## Commits

### 1. \`hisilicon-osdrv-hi3519v101\`: fix IMX385 sensor config for real hardware

Default \`imx385_i2c_1080p.ini\` ships values that don't produce a working image on a real IMX385 rig (Hi3516AV200 DEMO, 4-lane MIPI, 1080p60 linear):

| Field | Before | After | Reason |
|---|---|---|---|
| \`Sensor_type\` | \`stSnsObj\` | \`stSnsImx385Obj\` | Matches the symbol exported by the source-built \`libsns_imx385.so\` (see commit 2) |
| \`Mode\` | \`WDR_MODE_NONE\` | \`0\` | Numeric form the parser actually reads |
| \`data_type\` | \`RAW_DATA_10BIT\` | \`RAW_DATA_12BIT\` | IMX385 is 12-bit native |
| \`[mipi] wdr_type\` | — | \`DOL\` | Required for DOL-WDR handling path |
| \`Isp_FrameRate\` | \`25\` | \`60\` | Matches the sensor's 1080p60 linear mode |
| \`DevRect_x/y\` | \`4\`/\`4\` | \`0\`/\`0\` | Full 1920x1080 without pixel offset |

### 2. \`hisilicon-opensdk\`: build IMX385 sensor from source for hi3519v101

Add hi3519v101 to the same opensdk-builds-sensor-from-source pattern used by hi3516ev200 / gk7205v200 / hi3516cv500:

- \`hisilicon-opensdk.mk\`: add dependency on \`hisilicon-osdrv-hi3519v101\` (so opensdk installs **after** osdrv and its source-built \`libsns_imx385.so\` overrides the blob in \`files/sensor/\`), declare \`SDK_CODE=0x3519101\`, and list \`sony_imx385/libsns_imx385\` as the sensor to build.
- \`hi3519v101_lite_defconfig\`, \`hi3516av200_{lite,ultimate}_defconfig\`: turn on \`BR2_PACKAGE_HISILICON_OPENSDK=y\`.

The source already exists at \`openhisilicon/libraries/sensor/hi3519v101/sony_imx385/\` in the commit tracked by \`HISILICON_OPENSDK_VERSION\` (8889317). No version bump needed.

**No binary blobs added to the tree.** The libsns_imx385.so at \`files/sensor/\` remains as fallback for builds that don't enable opensdk.

## Test

Verified end-to-end on a Hi3516AV200 DEMO board (hi3519v101 SDK) running OpenIPC firmware with IMX385 + fixed lens (no iris). Side-by-side, same scene:

| | Prebuilt \`libsns_imx385.so\` (pre-patch) | Source-built \`libsns_imx385.so\` (post-patch) |
|---|---|---|
| Exported symbol | \`stSnsObj\` | \`stSnsImx385Obj\` |
| Stripped size | 48 608 B | 31 644 B |
| AE Iso | 312 | **134** |
| AE Again | 3099 | **1381** |
| Image | visible magenta cast, blown highlights | neutral WB, clean shadow/highlight detail |

- Sensor init log: \`-------Sony IMX385 Sensor 1080p30 Initial OK!-------\`
- MIPI 4-lane RAW12 streaming valid data
- JPEG snapshot returns valid frames at 1080p60 linear

🤖 Generated with [Claude Code](https://claude.com/claude-code)