### PR TITLE
sysupgrade: add NAND flash support

### DIFF
--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -44,14 +44,27 @@ do_update_kernel() {
 		fi
 		compare_versions "$kernel_version" "$(get_kernel_version "$x")" && return 0
 	fi
-	set_progress flashcp -v "$x" "$kernel_device"
+	if [ "$flash_type" = "nand" ]; then
+		echo "Erasing kernel partition..."
+		flash_eraseall "$kernel_device"
+		echo "Writing kernel..."
+		nandwrite -p "$kernel_device" "$x"
+	else
+		set_progress flashcp -v "$x" "$kernel_device"
+	fi
 	echo_c 32 "Kernel updated to $(get_kernel_version "$kernel_device")"
 }
 
 do_update_rootfs() {
 	local x=$1
-	[ -z "$x" ] && x="/tmp/rootfs.squashfs.$soc"
 	echo_c 33 "\nRootFS"
+
+	if [ "$flash_type" = "nand" ]; then
+		do_update_rootfs_nand "$x"
+		return $?
+	fi
+
+	[ -z "$x" ] && x="/tmp/rootfs.squashfs.$soc"
 	echo "Update rootfs from $x"
 	[ ! -f "$x" ] && die "File $x not found"
 	local y=/tmp/rootfs
@@ -68,18 +81,100 @@ do_update_rootfs() {
 	echo_c 32 "RootFS updated to $rootfs_version"
 }
 
+do_update_rootfs_nand() {
+	local x=$1
+	[ -z "$x" ] && x="/tmp/rootfs.ubi.$soc"
+	echo "Update rootfs (NAND) from $x"
+	[ ! -f "$x" ] && die "File $x not found"
+
+	# Determine UBI MTD partition number
+	local ubi_dev=$(get_device "ubi")
+	local ubi_mtd_num=$(echo "$ubi_dev" | grep -o '[0-9]*$')
+	[ -z "$ubi_dev" ] || [ -z "$ubi_mtd_num" ] && die "Cannot find UBI MTD partition!"
+	echo "UBI partition: $ubi_dev (mtd$ubi_mtd_num)"
+
+	echo_c 33 "Preparing tmpfs root for NAND upgrade..."
+
+	# Build minimal tmpfs root with busybox + firmware
+	local nr=/tmp/newroot
+	mkdir -p "$nr"
+	mount -t tmpfs tmpfs "$nr"
+	mkdir -p "$nr/bin" "$nr/lib" "$nr/dev" "$nr/proc" "$nr/tmp" "$nr/oldroot"
+
+	cp /bin/busybox "$nr/bin/busybox"
+	cp /lib/ld-musl-arm*.so.1 "$nr/lib/" 2>/dev/null
+	cp "$x" "$nr/tmp/rootfs.ubi"
+
+	# Bind-mount /dev so all MTD device nodes are available
+	mount --bind /dev "$nr/dev"
+	mount -t proc proc "$nr/proc"
+
+	# Write the flash script to run after pivot
+	cat > "$nr/tmp/flash.sh" << FLASHEOF
+#!/bin/busybox sh
+export PATH=/bin
+busybox --install -s /bin
+
+echo "Unmounting old root filesystems..."
+umount -l /oldroot/overlay 2>/dev/null
+umount -l /oldroot/rom 2>/dev/null
+umount -l /oldroot/tmp 2>/dev/null
+umount -l /oldroot/run 2>/dev/null
+umount -l /oldroot/dev/shm 2>/dev/null
+umount -l /oldroot/dev/pts 2>/dev/null
+umount -l /oldroot/sys 2>/dev/null
+umount -l /oldroot 2>/dev/null
+sleep 1
+
+echo "Detaching UBI from mtd${ubi_mtd_num}..."
+ubidetach -m ${ubi_mtd_num} 2>/dev/null
+sleep 1
+
+echo "Erasing /dev/mtd${ubi_mtd_num}..."
+flash_eraseall /dev/mtd${ubi_mtd_num}
+
+echo "Writing rootfs.ubi to /dev/mtd${ubi_mtd_num}..."
+nandwrite -p /dev/mtd${ubi_mtd_num} /tmp/rootfs.ubi
+
+echo "NAND upgrade complete. Rebooting..."
+sync
+reboot -f
+FLASHEOF
+	chmod +x "$nr/tmp/flash.sh"
+
+	if [ "1" = "$skip_reboot" ]; then
+		echo_c 33 "Note: NAND rootfs update requires immediate reboot. -x flag ignored."
+	fi
+
+	echo_c 33 "Performing pivot_root to tmpfs and flashing NAND..."
+	cd "$nr"
+	pivot_root . oldroot
+	exec /bin/busybox sh /tmp/flash.sh
+}
+
 do_wipe_overlay() {
 	echo_c 33 "\nOverlayFS"
 	echo "Erase overlay partition"
-	[ "$flash_type" = "nand" ] || jffs2="-j"
-	set_progress flash_eraseall $jffs2 "$(get_device "rootfs_data")"
+	if [ "$flash_type" = "nand" ]; then
+		# Truncate the rootfs_data UBI volume without destroying rootfs
+		if [ -e /dev/ubi0_1 ]; then
+			ubiupdatevol /dev/ubi0_1 -t
+		else
+			flash_eraseall "$(get_device "rootfs_data")"
+		fi
+	else
+		set_progress flash_eraseall -j "$(get_device "rootfs_data")"
+	fi
 }
 
 download_firmware() {
-	[ "$flash_type" = "nand" ] && echo_c 31 "\nNote: the updater uses the NOR package for updating NAND"
 	echo_c 33 "\nFirmware"
 	osr=$(get_system_build)
-	build="$soc-nor-$osr"
+	if [ "$flash_type" = "nand" ]; then
+		build="$soc-nand-$osr"
+	else
+		build="$soc-nor-$osr"
+	fi
 	if [ -n "$archive" ]; then
 		[ ! -f "$archive" ] && die "File $archive not found"
 		gzip -d "$archive" -c | tar xf - -C /tmp && echo_c 32 "Local archive unpacked" || die "Cannot extract $archive"

--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -93,6 +93,12 @@ do_update_rootfs_nand() {
 	[ -z "$ubi_dev" ] || [ -z "$ubi_mtd_num" ] && die "Cannot find UBI MTD partition!"
 	echo "UBI partition: $ubi_dev (mtd$ubi_mtd_num)"
 
+	# NAND rootfs update erases the entire UBI partition (rootfs + rootfs_data).
+	# Overlay data cannot be preserved because re-attaching UBI after nandwrite
+	# causes image_seq mismatch (the autoresize of rootfs_data writes PEBs with
+	# a different sequence number than the original rootfs.ubi image).
+	echo_c 31 "Warning: NAND rootfs update will erase overlay data"
+
 	echo_c 33 "Preparing tmpfs root for NAND upgrade..."
 
 	# Build minimal tmpfs root with busybox + firmware


### PR DESCRIPTION
## Summary

- `sysupgrade` previously hardcoded NOR/squashfs firmware downloads and used `flashcp` for all flash types, which bricks NAND cameras (boot expects `ubifs`, not `squashfs`)
- `download_firmware()` now selects the correct NAND package (`$soc-nand-$osr`) when `ipcinfo -F` reports `nand`
- `do_update_kernel()` uses `flash_eraseall` + `nandwrite -p` for NAND instead of `flashcp`
- New `do_update_rootfs_nand()` function: pivot_roots to tmpfs, detaches UBI, erases the MTD partition, writes the UBI image with `nandwrite`, and reboots
- `do_wipe_overlay()` uses `ubiupdatevol -t` for NAND overlay wipe instead of `flash_eraseall -j` (JFFS2-specific)

## Known limitation

NAND rootfs update erases the entire UBI partition, which includes both rootfs and rootfs_data (overlay). This means **overlay data (settings, SSH keys, etc.) is lost** during rootfs update. Preserving overlay would require `ubiupdatevol` with a bare UBIFS image, which is not currently included in release packages. Re-attaching UBI after `nandwrite` to restore overlay data is unsafe — it causes `image_seq` mismatch and kernel panic.

## Test log (hi3516av200, 128MB SPI NAND)

<details>
<summary>sysupgrade -k -r -f -z output</summary>

```
OpenIPC System Updater v1.0.48

Vendor  hisilicon
SoC     hi3516av200
Kernel  23:23:49 2026-04-15
RootFS  master+1783691, 2026-04-15

Stop services, sync files, free up memory
Stopping crond: OK
Stopping ntpd: OK
Stopping klogd: OK
Stopping syslogd: OK

Firmware
Download from https://github.com/OpenIPC/firmware/releases/download/latest/openipc.hi3516av200-nand-ultimate.tgz
Received and unpacked

Kernel
Update kernel from /tmp/uImage.hi3516av200
Erasing kernel partition...
Erasing 128 Kibyte @ 300000 - 100% complete.
Writing kernel...
Writing at 0x001c0000
Kernel updated to 11:17:22 2026-04-16

RootFS
Update rootfs (NAND) from /tmp/rootfs.ubi.hi3516av200
UBI partition: /dev/mtd3 (mtd3)
Preparing tmpfs root for NAND upgrade...
Performing pivot_root to tmpfs and flashing NAND...
Unmounting old root filesystems...
Detaching UBI from mtd3...
Erasing /dev/mtd3...
Erasing 128 Kibyte @ 7c00000 - 100% complete.
Writing rootfs.ubi to /dev/mtd3...
Writing at 0x00c00000
NAND upgrade complete. Rebooting...
```
</details>

<details>
<summary>Post-upgrade verification</summary>

```
--- os-release ---
OPENIPC_VERSION=2.6.04.16
GITHUB_VERSION="master+22307c9, 2026-04-16"
BUILD_OPTION=ultimate

--- MTD partitions ---
mtd0: 00040000 00020000 "boot"
mtd1: 000c0000 00020000 "wtf"
mtd2: 00300000 00020000 "kernel"
mtd3: 07c00000 00020000 "ubi"
mtd4: 02017000 0001f000 "rootfs"
mtd5: 05521000 0001f000 "rootfs_data"

--- Mount points ---
ubi0:rootfs on /rom type ubifs (ro,relatime)
ubi0:rootfs_data on /overlay type ubifs (rw,relatime)
overlay on / type overlay (rw,relatime,...)

--- Disk usage ---
ubi0:rootfs    27.8M  9.2M  18.6M  33% /rom
ubi0:rootfs_data 76.8M 28.0K 72.8M  0% /overlay

--- Uptime ---
 11:27:24 up 1 min
```
</details>

## Test plan

- [x] Tested on hi3516av200 with 128MB SPI NAND — upgrade from OpenIPC 2.2 (Nov 2022) to 2.6 (Apr 2026) succeeded
- [x] Tested second upgrade on same board — confirmed `pivot_root` works reliably
- [x] Verified overlay is erased (clean `/overlay` after upgrade)
- [ ] Test on other NAND-based boards
- [ ] Test NOR cameras are unaffected (no code path changes for NOR)
- [ ] Test standalone overlay wipe (`sysupgrade -n`) on NAND

🤖 Generated with [Claude Code](https://claude.com/claude-code)