### PR TITLE
hisilicon-opensdk: bump to a416f9e (CV300 sensor_spi exports)

### DIFF
--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = 8889317
+HISILICON_OPENSDK_VERSION = a416f9e
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Bump opensdk to pick up openhisilicon#59 — EXPORT_SYMBOL for `ssp_drv_init/exit/get_ops` in CV300 sensor_spi driver.

Without this, `open_sensor_i2c.ko` can't resolve SSP symbols when loaded as a separate module from `open_sensor_spi.ko`.

Tested on hi3516cv300 hardware (IMX291): sysupgrade, SDK starts, snapshot OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)