### PR TITLE
Fix HOST_CFLAGS breaking C++ on GCC 13 and add multi-GCC CI

### DIFF
--- a/.github/workflows/gcc-compat.yml
+++ b/.github/workflows/gcc-compat.yml
@@ -41,3 +41,5 @@ jobs:
 
       - name: Build firmware
         run: make BOARD=gk7205v200_lite
+        env:
+          FORCE_UNSAFE_CONFIGURE: 1

--- a/.github/workflows/gcc-compat.yml
+++ b/.github/workflows/gcc-compat.yml
@@ -1,0 +1,43 @@
+name: gcc-compat
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'Makefile'
+      - 'general/package/**/*.mk'
+      - 'general/package/all-patches/**'
+      - '.github/workflows/gcc-compat.yml'
+  schedule:
+    - cron: '0 6 * * 0'
+  workflow_dispatch:
+
+jobs:
+  gcc-compat:
+    name: GCC ${{matrix.gcc}}
+    runs-on: ubuntu-latest
+    container:
+      image: gcc:${{matrix.gcc}}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        gcc:
+          - 12
+          - 13
+          - 14
+          - 15
+
+    steps:
+      - name: Install build dependencies
+        run: |
+          apt-get update
+          apt-get install -y automake autotools-dev bc build-essential cpio \
+            curl file git libncurses-dev libtool lzop make rsync unzip wget \
+            libssl-dev
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Build firmware
+        run: make BOARD=gk7205v200_lite

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ BR_FILE = /tmp/buildroot-$(BR_VER).tar.gz
 BR_CONF = $(TARGET)/openipc_defconfig
 TARGET ?= $(PWD)/output
 export CMAKE_POLICY_VERSION_MINIMUM := 3.5
-export HOST_CFLAGS ?= -O2 -std=gnu11
 
 CONFIG = $(error variable BOARD not defined)
 TIMER := $(shell date +%s)

--- a/general/package/all-patches/cmake/0001-fix-cmcppdap-missing-cstdint-gcc15.patch
+++ b/general/package/all-patches/cmake/0001-fix-cmcppdap-missing-cstdint-gcc15.patch
@@ -1,0 +1,18 @@
+From: Dmitry Ilyin <6576495+widgetii@users.noreply.github.com>
+Subject: [PATCH] Utilities/cmcppdap: add missing cstdint include for GCC 15
+
+GCC 15 defaults to C++23 where <cstdint> is no longer transitively
+included through other headers. This causes a build failure:
+
+  dap/network.h: error: 'uint32_t' has not been declared
+
+--- a/Utilities/cmcppdap/include/dap/network.h
++++ b/Utilities/cmcppdap/include/dap/network.h
+@@ -17,6 +17,7 @@
+ #define dap_network_h
+
+ #include <memory>
++#include <cstdint>
+
+ #include "dap/io.h"
+


### PR DESCRIPTION
## Summary

- Remove `export HOST_CFLAGS ?= -O2 -std=gnu11` from Makefile — Buildroot appends `HOST_CFLAGS` into `HOST_CXXFLAGS`, so the C-only `-std=gnu11` flag leaks into C++ host tool compilation, breaking CMake's C++11 feature check on GCC 13.3.0 (Ubuntu 24.04 / WSL). The unifdef patches already fix the GCC 15 `constexpr` issue at source level.
- Add `gcc-compat` CI workflow that builds `gk7205v200_lite` inside GCC 12–15 Docker containers, triggered on PRs touching build-system files, weekly on Sundays, and on manual dispatch.

Closes #2007

## Test plan

- [ ] gcc-compat workflow runs on this PR (touches `Makefile`)
- [ ] All 4 GCC versions (12, 13, 14, 15) build successfully
- [ ] Existing `build` workflow still passes on ubuntu-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)