### PR TITLE
hisilicon-opensdk: re-apply overlay in target-finalize to beat osdrv

### DIFF
--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -255,3 +255,15 @@ define HISILICON_OPENSDK_CLEANUP_EXTRA
 endef
 HISILICON_OPENSDK_POST_INSTALL_TARGET_HOOKS += HISILICON_OPENSDK_CLEANUP_EXTRA
 endif
+
+# In per-package mode, target-finalize merges per-package/*/target/ into
+# output/target/ in alphabetical order ($(sort $(PACKAGES))), not dependency
+# order. That makes hisilicon-osdrv-* clobber files we install here, even
+# though HISILICON_OPENSDK_DEPENDENCIES sequences us after osdrv during build.
+# Re-apply our per-package overlay onto the merged target after the rsync.
+ifeq ($(BR2_PACKAGE_HISILICON_OPENSDK)$(BR2_PER_PACKAGE_DIRECTORIES),yy)
+define HISILICON_OPENSDK_FINAL_OVERLAY
+	rsync -a $(PER_PACKAGE_DIR)/hisilicon-opensdk/target/ $(TARGET_DIR)/
+endef
+TARGET_FINALIZE_HOOKS += HISILICON_OPENSDK_FINAL_OVERLAY
+endif

--- a/general/scripts/excludes/gk7202v300_lite.list
+++ b/general/scripts/excludes/gk7202v300_lite.list
@@ -1,1 +1,0 @@
-/usr/lib/sensors/libsns_imx307.so

--- a/general/scripts/excludes/gk7205v200_lite.list
+++ b/general/scripts/excludes/gk7205v200_lite.list
@@ -1,2 +1,0 @@
-/usr/lib/sensors/libsns_imx307.so
-/usr/lib/sensors/libsns_imx335.so

--- a/general/scripts/excludes/hi3516ev200_lite.list
+++ b/general/scripts/excludes/hi3516ev200_lite.list
@@ -1,2 +1,0 @@
-/usr/lib/sensors/libsns_imx307.so
-/usr/lib/sensors/libsns_imx335.so

--- a/general/scripts/excludes/hi3518ev300_lite.list
+++ b/general/scripts/excludes/hi3518ev300_lite.list
@@ -1,2 +1,0 @@
-/usr/lib/sensors/libsns_imx307.so
-/usr/lib/sensors/libsns_imx335.so


### PR DESCRIPTION
## Summary

Two related fixes for `hisilicon-opensdk` on hi3519v101 / hi3516cv500 / hi3516ev200 / gk7205v200 (and the boards that share their SDKs):

1. **(makefile)** Make the opensdk overlay actually win in `output/target/`. Buildroot's per-package `target-finalize` merges in **alphabetical** order, not dependency order, so `hisilicon-osdrv-*` always clobbers files we install at the same path, even though `HISILICON_OPENSDK_DEPENDENCIES` sequences us after osdrv during build. Net effect: every overlapping file ends up as the **osdrv vendor blob** in the shipped image.
2. **(excludes)** Stop deleting `libsns_imx307.so` / `libsns_imx335.so` from `*_lite` rootfs after we just built them from source — that was bricking IMX307/IMX335 cameras on those variants.

## Root cause for (1)

```make
# buildroot-2023.02.1/Makefile:723
$(call per-package-rsync,$(sort $(PACKAGES)),target,$(TARGET_DIR))
```

`$(sort …)` is alphabetical → `hisilicon-opensdk` rsyncs first, `hisilicon-osdrv-*` rsyncs after and overwrites. `_DEPENDENCIES` only orders the build/install phase.

Surfaced as IMX385 still broken on a Hi3516AV200 (hi3519v101 SDK) test camera **after** #2010 + #2011:

```
sensor_getsnsobj@101 Cannot load symbol 'stSnsImx385Obj' from driver
Cannot init sensor
Cannot start SDK
```

The fixed-up `imx385_i2c_1080p.ini` looks for symbol `stSnsImx385Obj` (opensdk source-built), but `/usr/lib/sensors/libsns_imx385.so` on the camera was the vendor blob (`stSnsObj`).

| Source | Size | Symbol |
|---|---|---|
| `output/per-package/hisilicon-opensdk/target/.../libsns_imx385.so` | 27 160 B | `stSnsImx385Obj` ✅ |
| `output/per-package/hisilicon-osdrv-hi3519v101/target/.../libsns_imx385.so` | 48 608 B | `stSnsObj` ❌ |
| `output/target/.../libsns_imx385.so` (final, post-strip) | 41 152 B | `stSnsObj` ❌ |

Same trap silently disables PR #2010's open `.ko`s — on the test camera `hi_mipi.ko` md5 = osdrv vendor blob, not opensdk's `open_mipi_rx.ko`. Same overlap exists on hi3516cv500 (imx335/307/415).

## Fix for (1)

Register a `TARGET_FINALIZE_HOOK` that re-rsyncs `per-package/hisilicon-opensdk/target/` onto `output/target/` after buildroot's alphabetical merge. Opensdk's per-package staging is already exactly *"osdrv contents + opensdk overlay"* (because of the existing `_DEPENDENCIES`), so a plain `rsync -a` of it is the correct thing to apply on top. Gated on `BR2_PER_PACKAGE_DIRECTORIES=y`; without per-package, install ordering already does the right thing.

## Why (2) needs to be in the same PR

Even with (1) installing `libsns_imx307.so` / `libsns_imx335.so` correctly, `general/scripts/rootfs_script.sh` would still strip them out of the lite rootfs via:

```
general/scripts/excludes/hi3516ev200_lite.list
general/scripts/excludes/gk7205v200_lite.list
general/scripts/excludes/gk7202v300_lite.list   (uses hi3516ev200 SDK)
general/scripts/excludes/hi3518ev300_lite.list  (uses gk7205v200 SDK)
```

Each list only contained those two sensor entries — pre-existing size optimisation. With opensdk now building them from source (small: ~45 KB / ~150 KB stripped), keeping the exclusion **bricks any of those four lite-variant boards equipped with IMX307 or IMX335**. The lists are removed entirely; `rootfs_script.sh`'s `if [ -f ${LIST} ]` guard handles missing files.

## Test plan

- [x] Build `hi3516av200_lite` (hi3519v101 SDK), confirm `output/target/usr/lib/sensors/libsns_imx385.so` exports `stSnsImx385Obj` and md5 matches the source-built `.so`.
- [x] On a live Hi3516AV200 + IMX385 rig, with the corrected `libsns_imx385.so` in place, majestic logs:
  ```
  sensor stSnsImx385Obj
  Sensor driver loaded
  -------Sony IMX385 Sensor 1080p30 Initial OK!-------
  RTSP server started on port 554
  ```
  and `/image.jpg` returns a valid 1920×1080 JPEG.
- [x] Build `hi3516cv500_lite`: source-built `libsns_imx335/307/415.so` (with `stSns{Imx335,Imx307,Imx415}Obj`) and `hi3516cv500_isp.ko` (md5 of opensdk's `open_isp.ko`) now in `output/target/`.
- [x] Build `hi3516ev200_lite`: `libsns_h63.so` (`stSnsSoiH63Obj`), `libsns_imx307.so` (`stSnsImx307Obj`), `libsns_imx335.so` (`stSnsImx335Obj`) all shipped. `rootfs.squashfs.hi3516ev200` 4476 KB / 5120 KB (~80 KB added vs pre-fix; comfortably within budget).
- [ ] CI / OpenIPC build farm to validate gk7205v200_lite, gk7202v300_lite, hi3518ev300_lite size budgets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)