### PR TITLE
sysupgrade: shield destructive phase from controlling-TTY death

### DIFF
--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -1,6 +1,6 @@
 #!/bin/sh
 # OpenIPC.org | 2025
-scr_version=1.0.48
+scr_version=1.0.49
 
 args="$@"
 LOCK_FILE=/tmp/sysupgrade.lock
@@ -345,6 +345,14 @@ free_resources
 
 [ "1" != "$skip_unmount" ] && check_sdcard
 [ "1" = "$remote_update" ] && download_firmware
+
+# Past this point we erase flash. A controlling-TTY death (SSH session drop,
+# stray Ctrl-C, etc.) must not kill flashcp mid-write — that leaves the rootfs
+# partition partially erased and unbootable. SIG_IGN is inherited across
+# fork+exec, so this also shields the busybox flashcp child. See issue #2024.
+trap '' HUP INT TERM PIPE
+echo_c 37 "\nProtected: flashing continues even if this terminal disconnects."
+
 [ "1" = "$update_kernel" ] && do_update_kernel "$kernel_file"
 [ "1" = "$update_rootfs" ] && do_update_rootfs "$rootfs_file"
 [ "1" = "$clear_overlay" ] && do_wipe_overlay


### PR DESCRIPTION
## Summary
- Set `SIG_IGN` on `HUP`/`INT`/`TERM`/`PIPE` right before the destructive flash phase (after `download_firmware`, before `do_update_kernel`/`do_update_rootfs`/`do_wipe_overlay`).
- Bumps `scr_version` to `1.0.49` so devices auto-pick the fix on next `sysupgrade -r`/`-k`.

`SIG_IGN` is inherited across `fork+exec` (POSIX), so the busybox `flashcp` child is shielded as well — no need to wrap each flashcp call.

Fixes #2024.

## Why
Without this, an SSH session drop (or stray Ctrl-C) mid-`flashcp` sends `SIGHUP` to the foreground process group. Both the shell and `flashcp` get killed, leaving the rootfs MTD partition fully erased but only partially rewritten — unrecoverable without UART/U-Boot intervention. Issue #2024 has the full failure log and a recovery procedure.

## Test plan
Verified end-to-end on a hi3518ev200 (NOR, lite):

- [x] `sh -n` syntax check passes.
- [x] `SIG_IGN` inheritance verified empirically: child `/proc/self/status` shows `SigIgn: 0x5003` (= bits 0,1,12,14 = HUP, INT, PIPE, TERM) after `trap '' HUP INT TERM PIPE` in parent + `exec`.
- [x] On-camera test: ran `sysupgrade-patched -r -f -z` over SSH, then `kill -9` on the local ssh client at 25% of rootfs write (1208/4784 KB).
   - Without the patch this scenario bricks the device (issue #2024).
   - With the patch: rootfs write continued through 44% → 63% → 82% → 100%, then verify 100%, then `Unconditional reboot`. 8 s of progress recorded post-disconnect, ending with a clean reboot. Camera came back up with `VFS: Mounted root (squashfs filesystem) readonly on device 31:3`.

## Test plan for reviewers
- [ ] Try `sysupgrade -r` over SSH and disconnect the client mid-write — flash should still complete.
- [ ] Try `sysupgrade -r` interactively over UART and press Ctrl-C mid-write — flash should still complete.
- [ ] Check that NAND boards still update normally (no behavioural regression for the non-failing path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)