### PR TITLE
hisilicon-osdrv-hi3516cv500: rmmod by openhisilicon module names

### DIFF
--- a/general/package/hisilicon-osdrv-hi3516cv500/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516cv500/files/script/load_hisilicon
@@ -47,12 +47,12 @@ insert_detect() {
 }
 
 remove_detect() {
-    rmmod -w hi_sensor_spi
-    rmmod -w hi_sensor_i2c
-    rmmod -w hi3516cv500_isp
-    rmmod -w hi3516cv500_base
-    rmmod -w sys_config
-    rmmod -w hi_osal &> /dev/null
+    rmmod -w open_sensor_spi
+    rmmod -w open_sensor_i2c
+    rmmod -w open_isp
+    rmmod -w open_base
+    rmmod -w open_sys_config
+    rmmod -w open_osal &> /dev/null
     rmmod -w cma_osal &> /dev/null
 }
 
@@ -68,13 +68,13 @@ insert_audio() {
 }
 
 remove_audio() {
-    rmmod -w hi3516cv500_acodec
+    rmmod -w open_acodec
     #    rmmod -w hi_tlv320aic31.ko
-    rmmod -w hi3516cv500_adec
-    rmmod -w hi3516cv500_aenc
-    rmmod -w hi3516cv500_ao
-    rmmod -w hi3516cv500_ai
-    rmmod -w hi3516cv500_aio
+    rmmod -w open_adec
+    rmmod -w open_aenc
+    rmmod -w open_ao
+    rmmod -w open_ai
+    rmmod -w open_aio
 
     echo "remove audio"
 }
@@ -165,46 +165,46 @@ insert_ko() {
 }
 
 remove_ko() {
-    rmmod -w hi3516cv500_wdt
+    rmmod -w open_wdt
     # rmmod_gyro
     # rmmod -w hi_user
     remove_audio
     # rmmod -w hi_mipi_tx
-    rmmod -w hi_mipi_rx
+    rmmod -w open_mipi_rx
     #rmmod -w hi_sil9136 &> /dev/null
-    rmmod -w hi_piris
-    rmmod -w hi_pwm
+    rmmod -w open_piris
+    rmmod -w open_pwm
 
     # rmmod -w hi3516cv500_nnie nnie_save_power=1 nnie_max_tskbuf_num=32
     # rmmod -w hi_ipcm
-    rmmod -w hi3516cv500_ive
-    rmmod -w hi3516cv500_rc
-    rmmod -w hi3516cv500_jpege
-    rmmod -w hi3516cv500_h264e
-    rmmod -w hi3516cv500_h265e
-    rmmod -w hi3516cv500_venc
-    rmmod -w hi3516cv500_vedu
-    rmmod -w hi3516cv500_chnl
+    rmmod -w open_ive
+    rmmod -w open_rc
+    rmmod -w open_jpege
+    rmmod -w open_h264e
+    rmmod -w open_h265e
+    rmmod -w open_venc
+    rmmod -w open_vedu
+    rmmod -w open_chnl
     # rmmod -w hifb
     # rmmod -w hi3516cv500_vo
-    rmmod -w hi3516cv500_vpss
-    rmmod -w hi3516cv500_isp
-    rmmod -w hi3516cv500_vi
-    rmmod -w hi3516cv500_gdc
-    rmmod -w hi3516cv500_dis
-    rmmod -w hi3516cv500_vgs
-    rmmod -w hi3516cv500_rgn
-    rmmod -w hi3516cv500_tde
+    rmmod -w open_vpss
+    rmmod -w open_isp
+    rmmod -w open_vi
+    rmmod -w open_gdc
+    rmmod -w open_dis
+    rmmod -w open_vgs
+    rmmod -w open_rgn
+    rmmod -w open_tde
 
-    rmmod -w hi_sensor_i2c &>/dev/null
-    rmmod -w hi_sensor_spi &>/dev/null
+    rmmod -w open_sensor_i2c &>/dev/null
+    rmmod -w open_sensor_spi &>/dev/null
 
     # rmmod -w mpu_bosch
-    rmmod -w hi3516cv500_sys
-    rmmod -w hi3516cv500_base
+    rmmod -w open_sys
+    rmmod -w open_base
     # rmmod -w hi_tzasc
-    rmmod -w sys_config
-    rmmod -w hi_osal
+    rmmod -w open_sys_config
+    rmmod -w open_osal
 }
 
 sys_restore() {


### PR DESCRIPTION
## Summary

`load_hisilicon` for hi3516cv500 issues `rmmod -w` against vendor module names (`hi_osal`, `sys_config`, `hi3516cv500_*`, `hi_sensor_*`, `hi_pwm`, `hi_piris`, `hi_mipi_rx`), but openhisilicon ships those modules with `KBUILD_MODNAME=open_*`. The `hisilicon-opensdk` install rule renames *files* (e.g., `open_osal.ko → hi_osal.ko`) but the internal `__this_module.name` baked at compile time still reads `open_osal` — and that's what `/proc/modules` records and what `rmmod` resolves against.

Result on a real cv500 boot: every `rmmod` in `remove_detect()` / `remove_audio()` / `remove_ko()` fails silently with `No such file or directory`, then `insert_ko()` hits "module already loaded" on its first `insmod`, calls `report_error`, exits the script. `/dev/sys` never appears, `majestic` dies with `Cannot get chip id`.

This matches V4 (`hi3516ev200`, `gk7205v200`), whose `load_hisilicon` scripts already use `open_*` rmmod targets for the same reason — V4 just got there first.

## Verification

Extracted `.gnu.linkonce.this_module` from the shipped Apr 28 `latest` tarball:

```
hi_osal.ko             →  open_osal
sys_config.ko          →  open_sys_config
hi_sensor_i2c.ko       →  open_sensor_i2c
hi3516cv500_base.ko    →  open_base
hi3516cv500_sys.ko     →  open_sys
hi3516cv500_isp.ko     →  open_isp
```

…confirming that on cv500, both Strategy C source modules **and** Strategy B blob-wrapped modules end up as `open_<base>` regardless of file name. So the rename is uniform.

`insmod` calls take file names and don't need to change.

Non-openhisilicon modules are kept under their existing names: `cma_osal`, `motionsensor_chip`, `motionsensor_mng`, `hi3516cv500_motionfusion`, `hi3516cv500_gyrodis`, `hi_spi`.

## Scope

This PR is hi3516cv500 only — keeping the diff small per platform so each lands with its own review/validation cycle. Sibling fixes will follow for `hi3516cv100`, `hi3516cv200`, `hi3516av100`, `hi3516cv300`, and `hi3519v101`. Each of those needs more selective edits because their Strategy B blobs **do** retain vendor module names (cv500 is the outlier where they don't).

## Refs

- `OpenIPC/openhisilicon#62` — root-cause investigation; user's hi3518ev200 camera bricked majestic startup after PR #2021 made openhisilicon overlays actually win at install time.
- `OpenIPC/openhisilicon#63` — CI assertions added so silent module-load regressions can't ship green again. The `QEMU boot (hi3516cv500)` job there is currently RED on `rmmod: can't unload module 'hi_sensor_spi': No such file or directory`. Once this PR merges, openipc/firmware re-cuts the \`releases/latest\` tarball, and openhisilicon's QEMU CI re-pulls it, that job should turn GREEN.

## Test plan

- [ ] CI on this PR passes the cv500 build path.
- [ ] After merge + new \`releases/latest\` tarball: re-run \`OpenIPC/openhisilicon#63\` and confirm \`QEMU boot (hi3516cv500)\` flips RED → GREEN.
- [ ] On real hi3516cv500 hardware (not in lab here — needs separate validation): \`load_hisilicon -i -sensor <real_sensor>\` cleanly loads, \`/dev/sys\` exists, \`majestic\` serves a frame, no \`rmmod\`/\`insmod\` errors in dmesg.