### PR TITLE
hisilicon-osdrv-hi3516cv100: rmmod open_ssp_* by openhisilicon name

### DIFF
--- a/general/package/hisilicon-osdrv-hi3516cv100/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516cv100/files/script/load_hisilicon
@@ -37,9 +37,9 @@ insert_detect() {
 }
 
 remove_detect() {
-	rmmod -w ssp_sony &>/dev/null
-	rmmod -w ssp_pana &>/dev/null
-	rmmod -w ssp_ad9020 &>/dev/null
+	rmmod -w open_ssp_sony &>/dev/null
+	rmmod -w open_ssp_pana &>/dev/null
+	rmmod -w open_ssp_ad9020 &>/dev/null
 	rmmod -w hi_i2c
 	rmmod -w hi3518_isp
 	rmmod -w hi3518_sys
@@ -149,9 +149,9 @@ insert_sns() {
 remove_sns() {
 	rmmod -w hi_i2c &>/dev/null
 	rmmod -w ssp &>/dev/null
-	rmmod -w ssp_sony &>/dev/null
-	rmmod -w ssp_pana &>/dev/null
-	rmmod -w ssp_ad9020 &>/dev/null
+	rmmod -w open_ssp_sony &>/dev/null
+	rmmod -w open_ssp_pana &>/dev/null
+	rmmod -w open_ssp_ad9020 &>/dev/null
 }
 
 sys_config() {


### PR DESCRIPTION
## Summary

The cv100 SPI sensor-bus drivers `ssp_sony.ko`, `ssp_pana.ko`, and `ssp_ad9020.ko` are built from openhisilicon source. Their files keep the vendor-named paths but their internal `__this_module.name` is `open_ssp_sony` / `open_ssp_pana` / `open_ssp_ad9020` (KBUILD_MODNAME from openhisilicon's `\$(PREFIX)`). `load_hisilicon`'s `rmmod -w ssp_sony` etc. — both in `remove_detect()` and `remove_sns()` — silently miss those modules with "No such file or directory", they stay loaded, and they hold `hi3518_isp` refcount > 0.

## Symptom in CI

The QEMU CI on `OpenIPC/openhisilicon#63` for `hi3516cv100` shows the cascade:

\`\`\`
rmmod: can't unload module 'hi3518_isp': Resource temporarily unavailable
rmmod: can't unload module 'hi3518_base': Resource temporarily unavailable
rmmod: can't unload module 'mmz': Resource temporarily unavailable
\`\`\`

The `ssp_*` rmmod failures themselves are silenced with `&>/dev/null`, so the actual trigger is invisible — but `insert_detect()` runs `SENSOR=imx122 insert_sns` which loads `ssp_sony.ko`, and that pin into ISP is what blocks the unload chain.

## Verification

Extracted `.gnu.linkonce.this_module` from the shipped Apr 28 `latest` cv100 tarball:

\`\`\`
ssp_sony.ko    →  open_ssp_sony
ssp_pana.ko    →  open_ssp_pana
ssp_ad9020.ko  →  open_ssp_ad9020
\`\`\`

…vs vendor-named modules that retain their original names (e.g. `hi3518_isp.ko → hi3518_isp`, `mmz.ko → mmz`, `acodec.ko → acodec`), which is why the rest of the script's `rmmod -w` calls don't change.

## Refs

- `OpenIPC/openhisilicon#62` — root-cause investigation.
- `OpenIPC/openhisilicon#63` — CI assertions; the `hi3516cv100` job is currently RED on the cascade above and will turn GREEN once openipc/firmware re-cuts \`releases/latest\` with this script.
- Sibling cv500 fix: \`OpenIPC/firmware#2026\` (already open).
- Sibling 3519v101 fix: opened in parallel.

## Test plan

- [ ] CI on this PR passes the cv100 build path.
- [ ] After merge + new \`releases/latest\` tarball: re-run `OpenIPC/openhisilicon#63` and confirm `QEMU boot (hi3516cv100)` flips RED → GREEN.
- [ ] On real hi3516cv100 hardware (separate validation, not in lab here): confirm `load_hisilicon -i -sensor <real_sensor>` cleanly loads, `/dev/sys` exists, and `majestic` serves a frame.