### PR TITLE
hisilicon-osdrv-hi3519v101: rmmod openhisilicon source modules by open_* name

### DIFF
--- a/general/package/hisilicon-osdrv-hi3519v101/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3519v101/files/script/load_hisilicon
@@ -45,11 +45,11 @@ insert_detect() {
 
 remove_detect() {
 	rmmod -w hi_ssp_sony
-	rmmod -w hi_sensor_i2c
+	rmmod -w open_sensor_i2c
 	rmmod -w hi3519v101_isp
 	rmmod -w hi3519v101_sys
 	rmmod -w hi3519v101_base
-	rmmod -w hi_osal
+	rmmod -w open_osal
 }
 
 insert_audio() {
@@ -607,7 +607,7 @@ insert_sns() {
 
 remove_sns() {
 	rmmod -w hi_ssp_sony &>/dev/null
-	rmmod -w hi_sensor_spi &>/dev/null
+	rmmod -w open_sensor_spi &>/dev/null
 }
 
 insert_isp() {
@@ -687,8 +687,8 @@ remove_ko() {
 	remove_audio
 	remove_sns
 	#rmmod -w hi_user
-	rmmod -w hi_pwm
-	rmmod -w hi_piris
+	rmmod -w open_pwm
+	rmmod -w open_piris
 
 	rmmod -w hi3519v101_photo
 	#rmmod -w hi3519v101_ive
@@ -706,19 +706,19 @@ remove_ko() {
 	rmmod -w hi3519v101_vpss
 	rmmod -w hi3519v101_isp
 	rmmod -w hi3519v101_viu
-	rmmod -w hi_mipi
+	rmmod -w open_mipi_rx
 	#rmmod -w hi3519v101_fisheye
 
 	#rmmod -w hi3519v101_vgs
 	rmmod -w hi3519v101_region
 	#rmmod -w hi3519v101_tde
 
-	rmmod -w hi_sensor_i2c &>/dev/null
+	rmmod -w open_sensor_i2c &>/dev/null
 	rmmod -w hi_ssp_3wire.ko &>/dev/null
 
 	rmmod -w hi3519v101_sys
 	rmmod -w hi3519v101_base
-	rmmod -w hi_osal
+	rmmod -w open_osal
 }
 
 sys_restore() {


### PR DESCRIPTION
## Summary

`load_hisilicon` for hi3519v101 issues `rmmod -w` against vendor file names (`hi_sensor_i2c`, `hi_sensor_spi`, `hi_osal`, `hi_pwm`, `hi_piris`, `hi_mipi`) for modules openhisilicon ships with `KBUILD_MODNAME=open_*`. Those rmmods miss silently with "No such file or directory", and the failure cascades — `hi_sensor_i2c` (loaded as `open_sensor_i2c`) holds a reference into `hi3519v101_isp`, so `rmmod -w hi3519v101_base` later fails with "Resource temporarily unavailable" because base is still pinned by isp.

## Symptom in CI

The QEMU CI on `OpenIPC/openhisilicon#63` for `hi3519v101` shows this directly:

\`\`\`
rmmod: can't unload module 'hi_sensor_i2c': No such file or directory
rmmod: can't unload module 'hi3519v101_base': Resource temporarily unavailable
rmmod: can't unload module 'hi_osal': No such file or directory
\`\`\`

## Verification

Extracted `.gnu.linkonce.this_module` from the shipped Apr 28 `latest` 3519v101 tarball:

\`\`\`
hi_osal.ko          →  open_osal
hi_sensor_i2c.ko    →  open_sensor_i2c
hi_sensor_spi.ko    →  open_sensor_spi
hi_pwm.ko           →  open_pwm
hi_piris.ko         →  open_piris
hi_mipi.ko          →  open_mipi_rx
sys_config.ko       →  open_sys_config
\`\`\`

…vs Strategy B blob-wrapped modules that retain vendor names (`hi3519v101_base.ko → hi3519v101_base`, `hi3519v101_sys.ko → hi3519v101_sys`, `hi3519v101_isp.ko → hi3519v101_isp`, …), which is why those `rmmod -w` calls don't change.

## Scope

8 rmmod call sites updated. Insmod calls operate on file names and don't need to change.

## Refs

- `OpenIPC/openhisilicon#62` — root-cause investigation.
- `OpenIPC/openhisilicon#63` — CI assertions; the `hi3519v101` job is currently RED and will turn GREEN once openipc/firmware re-cuts \`releases/latest\` with this script.
- Sibling cv500 fix: `OpenIPC/firmware#2026`.
- Sibling cv100 fix: opened in parallel.

## Test plan

- [ ] CI on this PR passes the 3519v101 build path.
- [ ] After merge + new \`releases/latest\` tarball: re-run `OpenIPC/openhisilicon#63` and confirm `QEMU boot (hi3519v101)` flips RED → GREEN.
- [ ] On real hi3519v101 / hi3516av200 hardware (separate validation, not in lab here): confirm `load_hisilicon -i -sensor <real_sensor>` cleanly loads, `/dev/sys` exists, and `majestic` serves a frame.