### PR TITLE
hisilicon-osdrv-hi3516cv200: rmmod openhisilicon source modules by open_* name

### DIFF
--- a/general/package/hisilicon-osdrv-hi3516cv200/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516cv200/files/script/load_hisilicon
@@ -39,14 +39,14 @@ insert_detect() {
 }
 
 remove_detect() {
-        rmmod -w sensor_spi
-        rmmod -w sensor_i2c
-        rmmod -w hi3518e_isp
+        rmmod -w open_sensor_spi
+        rmmod -w open_sensor_i2c
+        rmmod -w open_isp
         rmmod -w hi3518e_sys
         rmmod -w hi3518e_base
-        rmmod -w hi_media
-        rmmod -w mmz
-        rmmod -w sys_config.ko
+        rmmod -w open_himedia
+        rmmod -w open_mmz
+        rmmod -w open_sys_config
 }
 
 insert_audio() {
@@ -72,8 +72,8 @@ remove_audio() {
 }
 
 remove_sns() {
-        rmmod -w sensor_spi &>/dev/null
-        rmmod -w sensor_i2c &>/dev/null
+        rmmod -w open_sensor_spi &>/dev/null
+        rmmod -w open_sensor_i2c &>/dev/null
 }
 
 insert_isp() {
@@ -225,12 +225,12 @@ insert_ko() {
 }
 
 remove_ko() {
-        rmmod -w wdt
-        rmmod -w sys_config.ko
+        rmmod -w open_wdt
+        rmmod -w open_sys_config
         remove_audio
         remove_sns
 
-        rmmod -w pwm
+        rmmod -w open_pwm
 
         rmmod -w hi3518e_ive
 
@@ -244,18 +244,18 @@ remove_ko() {
         #rmmod -w hi3518e_vou
         rmmod -w hi3518e_vpss
         rmmod -w hi3518e_viu
-        rmmod -w hi_mipi
+        rmmod -w open_mipi_rx
 
         rmmod -w hi3518e_vgs
         rmmod -w hi3518e_region
         rmmod -w hi3518e_tde
 
         #rmmod -w piris
-        rmmod -w hi3518e_isp
+        rmmod -w open_isp
         rmmod -w hi3518e_sys
         rmmod -w hi3518e_base
-        rmmod -w hi_media
-        rmmod -w mmz
+        rmmod -w open_himedia
+        rmmod -w open_mmz
 }
 
 load_usage() {


### PR DESCRIPTION
## Summary

`load_hisilicon` for hi3516cv200 (V2; covers hi3516cv200 / hi3518ev200 / hi3518ev201) issued `rmmod -w` against vendor file names (`mmz`, `hi_media`, `sys_config`, `sensor_i2c`, `sensor_spi`, `hi3518e_isp`, `hi_mipi`, `pwm`, `wdt`) for modules openhisilicon ships with `KBUILD_MODNAME=open_*`. Those rmmods miss silently with "No such file or directory".

The cv200 failure path is more visible than other platforms: when `fw_env.config` isn't readable (or the env has no `sensor` key), `load_hisilicon` falls through to autodetect. Partial unload from name-mismatched rmmods leaves `open_mmz` loaded; `insert_ko`'s `insmod mmz.ko … || report_error` then hits "module already loaded", calls `report_error`, **exits the script**. `/dev/sys` never re-appears, `majestic` dies with `Cannot get chip id`.

This is exactly the regression originally reported by a XiongMai X50H20L_18EV200_S38 user on OpenIPC 2.6.04.27-lite — see `OpenIPC/openhisilicon#62` for the full investigation.

## Why cv200 needs only a partial rename

Verified by extracting `.gnu.linkonce.this_module` from a live cv200 rootfs:

| File | Internal name |
|---|---|
| `mmz.ko` | `open_mmz` |
| `hi_media.ko` | `open_himedia` |
| `sys_config.ko` | `open_sys_config` |
| `sensor_i2c.ko` | `open_sensor_i2c` |
| `sensor_spi.ko` | `open_sensor_spi` |
| `hi3518e_isp.ko` | `open_isp` |
| `hi_mipi.ko` | `open_mipi_rx` |
| `pwm.ko` | `open_pwm` |
| `wdt.ko` | `open_wdt` |
| `hi3518e_base.ko` | **`hi3518e_base`** |
| `hi3518e_sys.ko` | **`hi3518e_sys`** |
| `hi3518e_{adec,aenc,ai,ao,aio}.ko` | **`hi3518e_{...}`** |
| `hi3518e_{venc,h264e,...,vpss,viu,vgs,region,tde,ive,chnl,jpege,rc}.ko` | **`hi3518e_{...}`** |
| `acodec.ko` | **`acodec`** |

Strategy B blob-wrapped modules (everything in **bold**) keep their vendor names because the vendor `.o`'s `.gnu.linkonce.this_module` wins the link, so their `rmmod -w` calls don't change. Only Strategy C source-built modules need the rename.

## Live verification

Tested on real hi3516cv200 hardware (`hi3518ev200`, OpenIPC 2.6.04.28, JXF22 sensor, MMZ 32M):

```
$ load_hisilicon -r 2>&1     # with patched script
...
rmmod: can't unload module 'tlv_320aic31': No such file or directory  # expected
rmmod: can't unload module 'hifb': No such file or directory          # expected
$ lsmod | grep -v '^(8188fu|cfg80211|vfat|fat)' | wc -l
5    # all camera modules cleanly unloaded

$ load_hisilicon -i 2>&1
==== Your input Sensor type is jxf22 ====    # success marker
$ ls /dev/sys
/dev/sys
$ lsmod | wc -l
32
$ majestic
... [sdk] start_sdk@557: HiSilicon SDK started
... [rtsp] rtsp_init@28: RTSP server started on port 554
```

Two consecutive `-r`/`-i` cycles ran without errors.

For comparison, with the **original** script the same `-r` leaves `open_mmz` / `open_himedia` / `open_sys_config` / `open_sensor_i2c` / `open_isp` / `open_mipi_rx` / `open_pwm` / `open_wdt` orphaned in `lsmod`, and the next `-i` hits `report_error` at `insert_mmz`'s `insmod mmz.ko ... || report_error` — bricking majestic.

## Refs

- `OpenIPC/openhisilicon#62` — root-cause investigation, includes the user's original XiongMai X50H20L_18EV200_S38 failure log.
- `OpenIPC/openhisilicon#63` — CI assertions PR. CV200 stays masked there by `OpenIPC/openhisilicon#64` (sys.ko EPERM in qemu-hisilicon's cv200 emulation), so the QEMU CI loop won't catch this — real-hardware test above is the validation.
- Sibling fixes opened earlier: `OpenIPC/firmware#2026` (cv500), `#2027` (cv100), `#2028` (3519v101).

## Scope and follow-ups

15 rmmod call sites updated. Strategy B blobs and external modules (`tlv_320aic31`, `hifb`, audio Strategy B, video Strategy B, `acodec`) preserved.

Sibling cv200-family platforms still TODO: `hi3516av100` (V2A; blocked by `#65` in CI but the rename pattern should mirror this). `hi3516cv300` (V3; blocked by `#66`).