### PR TITLE
hisilicon-{opensdk,osdrv-hi3516cv300}: ship+load sensor_spi, rmmod by open_*

### DIFF
--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = 75fac96
+HISILICON_OPENSDK_VERSION = 0f35151
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE

--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = a37021d
+HISILICON_OPENSDK_VERSION = 74d4fcf
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE

--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = 908ae42
+HISILICON_OPENSDK_VERSION = a37021d
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE

--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = a416f9e
+HISILICON_OPENSDK_VERSION = 75fac96
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE

--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = 0f35151
+HISILICON_OPENSDK_VERSION = 94c7863
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE

--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = 94c7863
+HISILICON_OPENSDK_VERSION = bb3b2c5
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE

--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = df181c0
+HISILICON_OPENSDK_VERSION = 9698276
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE

--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = 74d4fcf
+HISILICON_OPENSDK_VERSION = df181c0
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE

--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = bb3b2c5
+HISILICON_OPENSDK_VERSION = 908ae42
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE

--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -78,6 +78,7 @@ define HISILICON_OPENSDK_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 644 $(@D)/kernel/open_osal.ko          $(HISILICON_OPENSDK_KMOD_DST)/hi_osal.ko
 	$(INSTALL) -m 644 $(@D)/kernel/open_sys_config.ko     $(HISILICON_OPENSDK_KMOD_DST)/sys_config.ko
 	$(INSTALL) -m 644 $(@D)/kernel/open_mipi_rx.ko        $(HISILICON_OPENSDK_KMOD_DST)/hi_mipi.ko
+	$(INSTALL) -m 644 $(@D)/kernel/open_sensor_spi.ko     $(HISILICON_OPENSDK_KMOD_DST)/hi_sensor_spi.ko
 	$(INSTALL) -m 644 $(@D)/kernel/open_sensor_i2c.ko     $(HISILICON_OPENSDK_KMOD_DST)/hi3516cv300_sensor.ko
 	$(INSTALL) -m 644 $(@D)/kernel/open_wdt.ko            $(HISILICON_OPENSDK_KMOD_DST)/hi3516cv300_wdt.ko
 	$(INSTALL) -m 644 $(@D)/kernel/open_ir.ko             $(HISILICON_OPENSDK_KMOD_DST)/hi3516cv300_ir.ko

--- a/general/package/hisilicon-osdrv-hi3516cv300/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516cv300/files/script/load_hisilicon
@@ -61,11 +61,11 @@ insert_detect()
 
 remove_detect()
 {
-	rmmod -w hi3516cv300_sys
-	rmmod -w hi3516cv300_base
-	rmmod -w hi_osal &> /dev/null
+	rmmod -w open_sys
+	rmmod -w open_base
+	rmmod -w open_osal &> /dev/null
 	rmmod -w cma_osal &> /dev/null
-	rmmod -w sys_config.ko
+	rmmod -w open_sys_config
 }
 
 insert_audio()
@@ -83,12 +83,12 @@ insert_audio()
 remove_audio()
 {
 	#rmmod -w hi_tlv320aic31.ko
-	rmmod -w hi3516cv300_adec
-	rmmod -w hi3516cv300_aenc
-	rmmod -w hi3516cv300_ao
-	rmmod -w hi3516cv300_ai
-	rmmod -w hi_acodec
-	rmmod -w hi3516cv300_aio
+	rmmod -w open_adec
+	rmmod -w open_aenc
+	rmmod -w open_ao
+	rmmod -w open_ai
+	rmmod -w open_acodec
+	rmmod -w open_aio
 	echo "remove audio"
 }
 
@@ -381,6 +381,7 @@ insert_ko()
 	insmod hi3516cv300_h265e.ko
 	insmod hi3516cv300_jpege.ko
 	insmod hi3516cv300_ive.ko save_power=1 ive_clk_frequency=$ive_frequency
+	insmod hi_sensor_spi.ko
 	insmod hi3516cv300_sensor.ko sensor_bus_type=$bus_type sensor_clk_frequency=$sensor_clk_freq sensor_pinmux_mode=$pinmux_mode
 	#insmod hi_adc.ko
 	#insmod hi_gpio.ko
@@ -403,35 +404,36 @@ remove_ko()
 {
 	remove_audio
 
-	rmmod -w hi3516cv300_pwm
+	rmmod -w open_pwm
 	rmmod -w hi_piris
 
-	rmmod -w hi3516cv300_sensor
+	rmmod -w open_sensor_i2c
+	rmmod -w open_sensor_spi
 
-	rmmod -w hi3516cv300_ive
+	rmmod -w open_ive
 
-	rmmod -w hi3516cv300_rc
-	rmmod -w hi3516cv300_jpege
-	rmmod -w hi3516cv300_h264e
-	rmmod -w hi3516cv300_h265e
-	rmmod -w hi3516cv300_vedu
-	rmmod -w hi3516cv300_chnl
-	rmmod -w hi3516cv300_venc
+	rmmod -w open_rc
+	rmmod -w open_jpege
+	rmmod -w open_h264e
+	rmmod -w open_h265e
+	rmmod -w open_vedu
+	rmmod -w open_chnl
+	rmmod -w open_venc
 
 	rmmod -w hi3516cv300_vou
-	rmmod -w hi3516cv300_vpss
-	rmmod -w hi3516cv300_isp
-	rmmod -w hi3516cv300_viu
-	rmmod -w hi_mipi
+	rmmod -w open_vpss
+	rmmod -w open_isp
+	rmmod -w open_vi
+	rmmod -w open_mipi_rx
 	
-	rmmod -w hi3516cv300_vgs
-	rmmod -w hi3516cv300_region
+	rmmod -w open_vgs
+	rmmod -w open_rgn
 
-	rmmod -w hi3516cv300_sys
-	rmmod -w hi3516cv300_base
-	rmmod -w hi3516cv300_wdt
-	rmmod -w hi_osal
-	rmmod -w sys_config
+	rmmod -w open_sys
+	rmmod -w open_base
+	rmmod -w open_wdt
+	rmmod -w open_osal
+	rmmod -w open_sys_config
 }
 
 load_usage()


### PR DESCRIPTION
## Summary

User-reported failure on real `hi3516cv300` hardware (IMX323 over I2C, OpenIPC `2.6.04.28-lite`):

> `Cannot init sensor` / `Cannot start SDK` / `warning: open hi_mipi dev failed`

syslog isolates the trigger:

```
open_sensor_i2c: Unknown symbol i2c_new_device (err 0)
open_sensor_i2c: Unknown symbol ssp_drv_exit (err 0)
open_sensor_i2c: Unknown symbol ssp_drv_init (err 0)
open_sensor_i2c: Unknown symbol ssp_get_ops (err 0)
open_sensor_i2c: Unknown symbol i2c_unregister_device (err 0)
```

## Root cause

The vendor shipped a single combined `hi3516cv300_sensor.ko` containing both I2C and SPI drivers. openhisilicon split them into `open_sensor_i2c` and `open_sensor_spi` (`kernel/sensor_*/hi3516cv300/`), with the i2c side keeping `extern` references to `ssp_drv_init/exit/get_ops` in the spi side. `OpenIPC/openhisilicon#59` (a416f9e) added `EXPORT_SYMBOL` for those three so the split would actually work.

But on the firmware side, the cv300 install block in `hisilicon-opensdk.mk` only ever installed `open_sensor_i2c.ko` (renamed to `hi3516cv300_sensor.ko`) — `open_sensor_spi.ko` was built by `kernel/hi3516cv300.kbuild` line 159 then discarded by the install rule. So cv300 cameras ship a `hi3516cv300_sensor.ko` that demands `ssp_drv_*` with nothing exporting them, and resolution stops at the first missing symbol — surfacing as the `i2c_new_device` / `i2c_unregister_device` "Unknown symbol" lines too.

The IMX291 test in #59 happened to work because that path also loaded an SPI-side module (Sony sensor i.e. `hi_ssp_sony.ko`); IMX323 over I2C hits the bare hole.

## Two coordinated changes

1. **`general/package/hisilicon-opensdk/hisilicon-opensdk.mk`**: install `open_sensor_spi.ko` as `hi_sensor_spi.ko` in the cv300 block. Matches V3A (3519v101) and V3.5 (cv500) naming for the same module.

2. **`general/package/hisilicon-osdrv-hi3516cv300/files/script/load_hisilicon`**:
   - `insmod hi_sensor_spi.ko` immediately before `insmod hi3516cv300_sensor.ko` so `ssp_drv_*` symbols are resolved when sensor_i2c links.
   - Add `rmmod -w open_sensor_spi` in `remove_ko`.
   - Apply the same `#62` rmmod-by-`open_*`-name rename pattern that already shipped for cv500/cv100/3519v101/cv200 — verified per-module against `/proc/modules` on the actual cv300 camera (172.17.32.126):

| Script target | Loaded as (per `.gnu.linkonce.this_module`) |
|---|---|
| `hi3516cv300_{base,sys,isp,vpss,venc,vedu,h264e,h265e,jpege,rc,chnl,ive,vgs,wdt,adec,aenc,ai,ao,aio,pwm}` | `open_<base>` |
| `hi3516cv300_region` | `open_rgn` |
| `hi3516cv300_viu` | `open_vi` |
| `hi3516cv300_sensor` | `open_sensor_i2c` |
| `hi_acodec` | `open_acodec` |
| `hi_osal` | `open_osal` |
| `hi_mipi` | `open_mipi_rx` |
| `sys_config[.ko]` | `open_sys_config` |

Strategy B blob-wrapped modules left alone — verified present in real-hardware lsmod under their vendor names: `hi3516cv300_vou`, `hi_piris`. External / non-openhisilicon also kept: `cma_osal`.

## Verification

Real-hardware lsmod on `172.17.32.126` (the failing user's camera) confirms the loaded names:

```
open_wdt, open_mipi_rx, open_acodec, open_adec, open_aenc, open_ao, open_ai,
open_aio, hi_piris, open_pwm, open_ive, open_jpege, open_h265e, open_h264e,
open_vedu, open_chnl, open_venc, open_rc, hi3516cv300_vou, open_vpss, open_isp,
open_vi, open_vgs, open_rgn, open_sys, open_base, open_osal, open_sys_config
```

— with `open_sensor_i2c` notably *missing* because `insmod hi3516cv300_sensor.ko` failed on the unresolved symbols in `remove_ko`/insert_ko above. After the fix this module joins the set and `open_sensor_spi` joins it too.

## Test plan

- [ ] CI on this PR passes the cv300 build path.
- [ ] After merge + new `releases/latest` tarball: hi3516cv300 nightly produces `openipc.hi3516cv300-nor-lite.tgz` containing `hi_sensor_spi.ko` at `/lib/modules/3.18.20/hisilicon/`.
- [ ] On real hi3516cv300 camera (`172.17.32.126`, IMX323 i2c): after upgrade, `load_hisilicon -i` loads `open_sensor_spi`, `open_sensor_i2c` cleanly, no `Unknown symbol` lines in dmesg, `lsmod` shows both, `majestic` reaches `Sensor driver loaded` and serves frames.

## Refs

- `OpenIPC/openhisilicon#62` — root-cause investigation (umbrella for the rmmod-by-vendor-name issue across V1–V3.5).
- `OpenIPC/openhisilicon#66` — cv300 `Wrong chip-id: hiunknown` in QEMU (separate emulation gap; this PR fixes the real-hardware path).
- `OpenIPC/openhisilicon#59` (a416f9e) — added the `EXPORT_SYMBOL`s that this PR finally lets be consumed.
- Sibling fixes already merged: `#2026` (cv500), `#2027` (cv100), `#2028` (3519v101), `#2029` (cv200).