### PR TITLE
ci: regression-test that selected kernel modules ship in firmware

### DIFF
--- a/.github/scripts/check_target_modules.sh
+++ b/.github/scripts/check_target_modules.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Regression check: assert that every kernel-module package selected in
+# the build's .config produced its expected .ko under output/target/lib/modules/.
+#
+# Catches per-package merge regressions like #2032 where extra/wireguard.ko
+# silently disappeared from firmware on hi3516cv200/hi3518ev200 builds.
+#
+# CI-only — not part of the local make flow, so contributors experimenting
+# locally don't get blocked. Add new (config var, .ko) pairs to the list
+# below whenever a new kernel-module package lands.
+set -eu
+
+CONFIG="${1:-output/.config}"
+TARGET_DIR="${2:-output/target}"
+
+if [ ! -f "$CONFIG" ]; then
+	echo "check_target_modules: config file not found: $CONFIG" >&2
+	exit 1
+fi
+
+if [ ! -d "$TARGET_DIR/lib/modules" ]; then
+	echo "check_target_modules: no /lib/modules in $TARGET_DIR — nothing to verify"
+	exit 0
+fi
+
+fail=0
+
+# config-var → expected .ko filename
+# Add new pairs here when a kernel-module package is introduced.
+check_module() {
+	var="$1"
+	ko="$2"
+	grep -q "^${var}=y" "$CONFIG" || return 0
+	if find "$TARGET_DIR/lib/modules" -name "$ko" | grep -q .; then
+		echo "OK: $ko present (${var}=y)"
+	else
+		echo "MISSING: ${var}=y but $ko not found under $TARGET_DIR/lib/modules/" >&2
+		fail=1
+	fi
+}
+
+check_module BR2_PACKAGE_WIREGUARD_LINUX_COMPAT wireguard.ko
+
+if [ "$fail" -ne 0 ]; then
+	echo "check_target_modules: regression detected" >&2
+	exit 1
+fi
+echo "check_target_modules: all expected kernel modules present"

--- a/.github/workflows/build-one.yml
+++ b/.github/workflows/build-one.yml
@@ -53,6 +53,9 @@ jobs:
             echo NANDFW=${NANDFW} >> ${GITHUB_ENV}
           fi
 
+      - name: Verify kernel modules
+        run: sh .github/scripts/check_target_modules.sh
+
       - name: Upload firmware
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,6 +208,9 @@ jobs:
             echo NANDFW=${NANDFW} >> ${GITHUB_ENV}
           fi
 
+      - name: Verify kernel modules
+        run: sh .github/scripts/check_target_modules.sh
+
       - name: Upload firmware
         if: github.event_name != 'pull_request'
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

- Adds `.github/scripts/check_target_modules.sh`, run after every CI build (`build.yml`, `build-one.yml`)
- For each entry in a small explicit map it asserts the `.ko` exists under `output/target/lib/modules/` when the package is selected in `.config`
- Currently maps `BR2_PACKAGE_WIREGUARD_LINUX_COMPAT` → `wireguard.ko`; new kernel-module packages should add a one-line entry to the script
- CI-only — not wired into the local Makefile, so contributors can experiment locally without being blocked by the check

## Why

Catches the regression class just fixed in #2032: per-package merge interactions in `hisilicon-opensdk` silently dropped `extra/wireguard.ko` from hi3516cv200 / hi3518ev200 firmware. With this in place, any future regression that loses a selected kernel module would fail the PR build before merge.

## Test plan

- [x] Local smoke test: script returns OK on the post-#2032 hi3518ev200_lite build (`wireguard.ko` present)
- [ ] PR build (this run) confirms it passes for representative SoCs
- [ ] Manually verify it fails as expected: temporarily add a bogus entry like `BR2_PACKAGE_BUSYBOX nonexistent.ko` and confirm the step exits non-zero (don't merge that)

🤖 Generated with [Claude Code](https://claude.com/claude-code)