### PR TITLE
ci: harden build workflows against transient download 404s

### DIFF
--- a/.github/workflows/build-one.yml
+++ b/.github/workflows/build-one.yml
@@ -29,6 +29,13 @@ jobs:
           path: /tmp/ccache
           key: ${{inputs.platform}}-${{env.CACHE_DATE}}
 
+      - name: Setup dl cache
+        uses: actions/cache@v4
+        with:
+          path: output/dl
+          key: dl-${{env.CACHE_DATE}}
+          restore-keys: dl-
+
       - name: Build firmware
         run: |
           export GIT_HASH=$(git rev-parse --short ${GITHUB_SHA})
@@ -38,7 +45,16 @@ jobs:
 
           mkdir -p /tmp/ccache
           ln -s /tmp/ccache ${HOME}/.ccache
-          make BOARD=${{inputs.platform}}
+
+          for attempt in 1 2 3; do
+            make BOARD=${{inputs.platform}} && break
+            if [ ${attempt} -eq 3 ]; then
+              echo "::error::build failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "::warning::attempt ${attempt} failed, retrying after $((attempt * 30))s"
+            sleep $((attempt * 30))
+          done
 
           TIME=$(date -d @${SECONDS} +%M:%S)
           echo TIME=${TIME} >> ${GITHUB_ENV}

--- a/.github/workflows/build-one.yml
+++ b/.github/workflows/build-one.yml
@@ -46,14 +46,17 @@ jobs:
           mkdir -p /tmp/ccache
           ln -s /tmp/ccache ${HOME}/.ccache
 
-          for attempt in 1 2 3; do
+          backoffs="30 60 120 300"
+          attempt=1
+          for sleep_for in $backoffs ""; do
             make BOARD=${{inputs.platform}} && break
-            if [ ${attempt} -eq 3 ]; then
+            if [ -z "$sleep_for" ]; then
               echo "::error::build failed after ${attempt} attempts"
               exit 1
             fi
-            echo "::warning::attempt ${attempt} failed, retrying after $((attempt * 30))s"
-            sleep $((attempt * 30))
+            echo "::warning::attempt ${attempt} failed, retrying after ${sleep_for}s"
+            sleep "$sleep_for"
+            attempt=$((attempt + 1))
           done
 
           TIME=$(date -d @${SECONDS} +%M:%S)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,14 +210,17 @@ jobs:
           mkdir -p /tmp/ccache
           ln -s /tmp/ccache ${HOME}/.ccache
 
-          for attempt in 1 2 3; do
+          backoffs="30 60 120 300"
+          attempt=1
+          for sleep_for in $backoffs ""; do
             make BOARD=${{matrix.platform}} && break
-            if [ ${attempt} -eq 3 ]; then
+            if [ -z "$sleep_for" ]; then
               echo "::error::build failed after ${attempt} attempts"
               exit 1
             fi
-            echo "::warning::attempt ${attempt} failed, retrying after $((attempt * 30))s"
-            sleep $((attempt * 30))
+            echo "::warning::attempt ${attempt} failed, retrying after ${sleep_for}s"
+            sleep "$sleep_for"
+            attempt=$((attempt + 1))
           done
 
           TIME=$(date -d @${SECONDS} +%M:%S)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,6 +184,22 @@ jobs:
           path: /tmp/ccache
           key: ${{matrix.platform}}-${{env.CACHE_DATE}}
 
+      - name: Setup dl cache
+        if: github.event_name != 'pull_request'
+        uses: actions/cache@v4
+        with:
+          path: output/dl
+          key: dl-${{env.CACHE_DATE}}
+          restore-keys: dl-
+
+      - name: Restore dl cache
+        if: github.event_name == 'pull_request'
+        uses: actions/cache/restore@v4
+        with:
+          path: output/dl
+          key: dl-${{env.CACHE_DATE}}
+          restore-keys: dl-
+
       - name: Build firmware
         run: |
           export GIT_HASH=$(git rev-parse --short ${GITHUB_SHA})
@@ -193,7 +209,16 @@ jobs:
 
           mkdir -p /tmp/ccache
           ln -s /tmp/ccache ${HOME}/.ccache
-          make BOARD=${{matrix.platform}}
+
+          for attempt in 1 2 3; do
+            make BOARD=${{matrix.platform}} && break
+            if [ ${attempt} -eq 3 ]; then
+              echo "::error::build failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "::warning::attempt ${attempt} failed, retrying after $((attempt * 30))s"
+            sleep $((attempt * 30))
+          done
 
           TIME=$(date -d @${SECONDS} +%M:%S)
           echo TIME=${TIME} >> ${GITHUB_ENV}

--- a/general/openipc.fragment
+++ b/general/openipc.fragment
@@ -7,6 +7,7 @@ BR2_GLOBAL_PATCH_DIR="$(BR2_EXTERNAL)/package/all-patches"
 # Cache
 BR2_CCACHE=y
 BR2_CCACHE_DIR="$(HOME)/.ccache"
+BR2_BACKUP_SITE="https://sources.buildroot.net"
 
 # Build
 BR2_PER_PACKAGE_DIRECTORIES=y


### PR DESCRIPTION
## Summary

- 3-attempt retry around \`make BOARD=...\` in \`build.yml\` and \`build-one.yml\` so a single transient 404 no longer fails the whole job.
- Shared (non-per-platform) cache of \`output/dl\` keyed by month, restored on every run; one successful download benefits the entire matrix and all subsequent nightlies.
- \`BR2_BACKUP_SITE=https://sources.buildroot.net\` in \`general/openipc.fragment\` for free fallback on upstream-Buildroot packages.

Refs #2036 — see the issue for the 30-day failure data and pattern analysis. ~80% of failures on master in the past month were transient single-attempt download 404s; this PR addresses that class.

Buildroot's \`support/download/wget\` script makes a single \`_plain_wget\` call with no \`--tries=\` flag, and \`set -e\` aborts the whole job on any failure. The retry loop wraps the entire \`make\`, but because Buildroot uses per-package \`.stamp_*\` files, retries only re-fetch what failed — they don't redo work.

## Test plan

- [ ] PR CI completes successfully (or with only pre-existing unrelated failures).
- [ ] Manually dispatch \`build-one.yml\` for one platform on this branch; confirm the new \`Setup dl cache\` step runs and the build succeeds.
- [ ] After merge, watch three consecutive nightly \`build.yml\` runs on master; expect zero failures attributable to download 404s.
- [ ] After three green nights, update #2036 with results and check off / close as appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)