### PR TITLE
hisilicon-opensdk: bump to 45b17cc (mipi_rx/hi3519v101 fix)

### DIFF
--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = e866011
+HISILICON_OPENSDK_VERSION = 45b17cc
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE


### PR DESCRIPTION
## Summary

Bumps `HISILICON_OPENSDK_VERSION` `e866011` → `45b17cc` to pick up [openipc/openhisilicon#74](https://github.com/OpenIPC/openhisilicon/pull/74) — `mipi_rx/hi3519v101: ioremap MIPI registers + wire up module_init`.

Before this bump, `BOARD=hi3519v101_lite` (and the `hi3516av200` sibling that uses the same opensdk pin) ships an **inert** `open_mipi_rx.ko`: `mipi_init` and `mipi_exit` exist but no `module_init` wires them up, so `/dev/hi_mipi` is never created. On a real camera this surfaces as:

```
warning: open hi_mipi dev failed
Cannot set VI Mipi attr
Cannot init sensor / Cannot start SDK
```

Same shape as the cv300 fix that landed in opensdk earlier — same fix, different platform.

## Verified end-to-end

On a live `hi3516av200` with `imx385` over MIPI (kernel 3.18.20), with the manually-deployed module from this commit + the `load_hisilicon` cmdline-mem fix from #2039:

```
$ ls /dev/ | grep mipi
hi_mipi
$ dmesg | grep mipi | tail -1
load hi_mipi driver successful!

$ SENSOR=imx385_i2c_1080p majestic
...
-------Sony IMX385 Sensor 1080p30 Initial OK!-------
h264 1920x1080@20fps 4096kbit 20gop
HiSilicon SDK started
RTSP server started on port 554
```

## Test plan
- [ ] CI: build `hi3519v101_lite` (no other board's opensdk objects change since the openhisilicon commit only touches `kernel/mipi_rx/hi3519v101/`).
- [ ] CI: QEMU smoke test for `hi3519v101` boots clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)