### PR TITLE
hisilicon-cv300: add IMX291 LVDS WDR sensor config

### DIFF
--- a/general/package/hisilicon-osdrv-hi3516cv300/files/sensor/config/WDR/imx291_i2c_lvds_1080p.ini
+++ b/general/package/hisilicon-osdrv-hi3516cv300/files/sensor/config/WDR/imx291_i2c_lvds_1080p.ini
@@ -1,0 +1,259 @@
+[sensor]
+Sensor_type   =imx291                   ;sensor name
+Mode          =2                        ;WDR_MODE_NONE = 0
+                                        ;WDR_MODE_BUILT_IN = 1
+                                        ;WDR_MODE_2To1_LINE = 2
+                                        ;WDR_MODE_2To1_LINE = 3
+                                        ;WDR_MODE_2To1_FRAME_FULL_RATE =4 ...etc
+DllFile = /usr/lib/sensors/libsns_imx291_i2c_lvds.so   ;sensor lib path
+
+
+[mode]
+input_mode =2                           ;INPUT_MODE_MIPI = 0
+                                        ;INPUT_MODE_SUBLVDS = 1
+                                        ;INPUT_MODE_LVDS = 2 ...etc
+
+dev_attr = 1                         	;mipi_dev_attr_t = 0
+                                        ;lvds_dev_attr_t = 1
+                                        ;NULL =2
+
+[lvds]
+;----------only for lvds_dev---------
+img_size_w = 1920                     	;oringnal sensor input image size W
+img_size_h = 1110                     	;oringnal sensor input image size H
+wdr_mode = 0                            ;HI_WDR_MODE_NONE =0
+                                        ;HI_WDR_MODE_2F = 1
+                                        ;HI_WDR_MODE_3F = 2
+                                        ;HI_WDR_MODE_4F =3
+raw_data_type = 2                    	;RAW_DATA_8BIT = 0
+                                        ;RAW_DATA_10BIT = 1
+                                        ;RAW_DATA_12BIT = 2
+                                        ;RAW_DATA_14BIT = 3
+lane_id = 0|1|2|3
+sync_code_0 = 0xab0|0xb60|0x800|0x9d0|0xab0|0xb60|0x800|0x9d0|0xab0|0xb60|0x800|0x9d0|0xab0|0xb60|0x800|0x9d0
+sync_code_1 = 0xab0|0xb60|0x800|0x9d0|0xab0|0xb60|0x800|0x9d0|0xab0|0xb60|0x800|0x9d0|0xab0|0xb60|0x800|0x9d0
+sync_code_2 = 0xab0|0xb60|0x800|0x9d0|0xab0|0xb60|0x800|0x9d0|0xab0|0xb60|0x800|0x9d0|0xab0|0xb60|0x800|0x9d0
+sync_code_3 = 0xab0|0xb60|0x800|0x9d0|0xab0|0xb60|0x800|0x9d0|0xab0|0xb60|0x800|0x9d0|0xab0|0xb60|0x800|0x9d0
+
+[isp_image]
+Isp_x      =0
+Isp_y      =0
+Isp_W      =1920
+Isp_H      =1080
+Isp_FrameRate=25
+Isp_Bayer  =2   ;BAYER_RGGB=0, BAYER_GRBG=1, BAYER_GBRG=2, BAYER_BGGR=3
+
+
+[vi_dev]
+Input_mod =6	;VI_MODE_BT656 = 0,              /* ITU-R BT.656 YUV4:2:2 */
+		;VI_MODE_BT601,                  /* ITU-R BT.601 YUV4:2:2 */
+		;VI_MODE_DIGITAL_CAMERA,         /* digital camera mode */
+		;VI_MODE_BT1120_STANDARD,        /* BT.1120 progressive mode */
+		;VI_MODE_BT1120_INTERLEAVED,     /* BT.1120 interstage mode */
+		;VI_MODE_MIPI,                   /* MIPI mode*/
+		;VI_MODE_LVDS,
+		;VI_MODE_HISPI 
+Work_mod =0     ;VI_WORK_MODE_1Multiplex = 0
+                ;VI_WORK_MODE_2Multiplex,
+                ;VI_WORK_MODE_4Multiplex
+Combine_mode =0 ;Y/C composite or separation mode
+                ;VI_COMBINE_COMPOSITE = 0 /*Composite mode */
+                ;VI_COMBINE_SEPARATE,     /*Separate mode */
+Comp_mode    =0 ;Component mode (single-component or dual-component)
+                ;VI_COMP_MODE_SINGLE = 0, /*single component mode */
+                ;VI_COMP_MODE_DOUBLE = 1, /*double component mode */
+Clock_edge   =1 ;Clock edge mode (sampling on the rising or falling edge)
+                ;VI_CLK_EDGE_SINGLE_UP=0, /*rising edge */
+                ;VI_CLK_EDGE_SINGLE_DOWN, /*falling edge */
+Mask_num     =2 ;Component mask
+Mask_0       =0xFFF00000
+Mask_1       =0x0
+Scan_mode    = 1;VI_SCAN_INTERLACED = 0
+                ;VI_SCAN_PROGRESSIVE,
+Data_seq     =2 ;data sequence (ONLY for YUV format)
+                ;----2th component U/V sequence in bt1120
+                ;    VI_INPUT_DATA_VUVU = 0,
+                ;    VI_INPUT_DATA_UVUV,
+                ;----input sequence for yuv
+                ;    VI_INPUT_DATA_UYVY = 0,
+                ;    VI_INPUT_DATA_VYUY,
+                ;    VI_INPUT_DATA_YUYV,
+                ;    VI_INPUT_DATA_YVYU
+
+Vsync   =1      ; vertical synchronization signal
+                ;VI_VSYNC_FIELD = 0,
+                ;VI_VSYNC_PULSE,
+VsyncNeg=1      ;Polarity of the vertical synchronization signal
+                ;VI_VSYNC_NEG_HIGH = 0,
+                ;VI_VSYNC_NEG_LOW /*if VIU_VSYNC_E
+Hsync  =0       ;Attribute of the horizontal synchronization signal
+                ;VI_HSYNC_VALID_SINGNAL = 0,
+                ;VI_HSYNC_PULSE,
+HsyncNeg =0     ;Polarity of the horizontal synchronization signal
+                ;VI_HSYNC_NEG_HIGH = 0,
+                ;VI_HSYNC_NEG_LOW
+VsyncValid =1   ;Attribute of the valid vertical synchronization signal
+                ;VI_VSYNC_NORM_PULSE = 0,
+                ;VI_VSYNC_VALID_SINGAL,
+VsyncValidNeg =0;Polarity of the valid vertical synchronization signal
+                ;VI_VSYNC_VALID_NEG_HIGH = 0,
+                ;VI_VSYNC_VALID_NEG_LOW
+Timingblank_HsyncHfb =0     ;Horizontal front blanking width
+Timingblank_HsyncAct =1920  ;Horizontal effetive width
+Timingblank_HsyncHbb =0     ;Horizontal back blanking width
+Timingblank_VsyncVfb =0     ;Vertical front blanking height
+Timingblank_VsyncVact =1080  ;Vertical effetive width
+Timingblank_VsyncVbb=0      ;Vertical back blanking height
+Timingblank_VsyncVbfb =0    ;Even-field vertical front blanking height(interlace, invalid progressive)
+Timingblank_VsyncVbact=0    ;Even-field vertical effetive width(interlace, invalid progressive)
+Timingblank_VsyncVbbb =0    ;Even-field vertical back blanking height(interlace, invalid progressive)
+
+;----- only for bt656 ----------
+FixCode   =0    ;BT656_FIXCODE_1 = 0,
+                ;BT656_FIXCODE_0
+FieldPolar=0    ;BT656_FIELD_POLAR_STD = 0
+                ;BT656_FIELD_POLAR_NSTD
+DataPath  =1    ;ISP enable or bypass
+                ;VI_PATH_BYPASS    = 0,/* ISP bypass */
+                ;VI_PATH_ISP       = 1,/* ISP enable */
+                ;VI_PATH_RAW       = 2,/* Capture raw data, for debug */
+InputDataType=1 ;VI_DATA_TYPE_YUV = 0,VI_DATA_TYPE_RGB = 1,
+DataRev      =FALSE ;Data reverse. FALSE = 0; TRUE = 1
+DevRect_x=0     ;
+DevRect_y=30    ;
+DevRect_w=1920  ;
+DevRect_h=1080  ;
+
+[vi_chn]
+CapRect_X    =0
+CapRect_Y    =0
+CapRect_Width=1920
+CapRect_Height=1080
+DestSize_Width=1920
+DestSize_Height=1080
+CapSel       =2 ;Frame/field select. ONLY used in interlaced mode
+                ;VI_CAPSEL_TOP = 0,                  /* top field */
+                ;VI_CAPSEL_BOTTOM,                   /* bottom field */
+                ;VI_CAPSEL_BOTH,                     /* top and bottom field */
+
+PixFormat    =23;PIXEL_FORMAT_YUV_SEMIPLANAR_422 = 22
+                ;PIXEL_FORMAT_YUV_SEMIPLANAR_420 = 23 ...etc
+CompressMode =0 ;COMPRESS_MODE_NONE = 0
+                ;COMPRESS_MODE_SEG =1 ...etc
+
+SrcFrameRate=-1 ;Source frame rate. -1: not controll
+FrameRate   =-1 ;Target frame rate. -1: not controll
+
+[vpss_group]
+Vpss_DciEn  =FALSE
+Vpss_IeEn   =FALSE
+Vpss_NrEn   =TRUE
+Vpss_HistEn =FALSE
+Vpss_DieMode=1  ;Define de-interlace mode
+                ;VPSS_DIE_MODE_AUTO  = 0,
+                ;VPSS_DIE_MODE_NODIE = 1,
+                ;VPSS_DIE_MODE_DIE   = 2,
+
+[vpss_corp]
+Crop_enable =FALSE
+Coordinate  =1  ;VPSS_CROP_RATIO_COOR = 0,   /*Ratio coordinate*/
+		        ;VPSS_CROP_ABS_COOR = 1      /*Absolute coordinate*/
+Crop_X      =128
+Crop_Y      =128
+Crop_W      =1158
+Crop_H      =562
+
+[vpss_chn]
+Vpss_W    =1920
+Vpss_H    =1080
+CompressMode=0  ;COMPRESS_MODE_NONE = 0
+		        ;COMPRESS_MODE_SEG =1 ...etc
+Mirror     =FALSE;Whether to mirror
+Flip       =FALSE;Whether to flip
+
+[vb_conf]
+VbCnt=10
+vbTimes=15     ;when raw=8bit  vbTimes = 10
+                ;when raw=10/12 bit  vbTimes = 15
+				;when raw=14/16 bit   vbTimes = 20
+[venc_comm]
+venc_chn =1     ;create venc chn number;(0,2]
+BufCnt = 1      ;network meida-trans bufcnt
+
+[venc_0]
+PicWidth  =1920
+PicHeight =1080
+Profile   =2
+RcMode   =VENC_RC_MODE_H264CBR
+
+Gop    =50
+StatTime =2
+ViFrmRate  =30
+TargetFrmRate=30
+;----- only for VENC_RC_MODE_H264CBR ----------
+BitRate=4096
+FluctuateLevel=0
+;----- only for VENC_RC_MODE_H264VBR ----------
+MaxBitRate =10000
+
+MaxQp=32
+MinQp=24
+;----- only for VENC_RC_MODE_H264FIXQP ----------
+IQp=45
+
+PQp=40
+;-------- for REF_EX IsliceEnable------
+IsliceEnable = FALSE  ;IsliceEnable and ViEnable  is mutual exclusion
+IsRefreshEnable = FALSE  ;IsliceEnable  and  bRefreshEnable  both TRUE is effective
+RefreshLineNum = 12  ;PicHeight/16/6  6 is empirical value,ask Fuyang
+ReqIQp = 30
+;-------- for REF_EX ViEnable------
+ViEnable = TRUE
+ViInterval = 50 ; 2s
+ViQpDelta = 2
+
+[venc_1]
+PicWidth  =1920
+PicHeight =1080
+Profile   =2
+RcMode   =VENC_RC_MODE_H264CBR
+
+Gop    =50
+StatTime =2
+ViFrmRate  =25
+TargetFrmRate=25
+;----- only for VENC_RC_MODE_H264CBR ----------
+BitRate=4096
+FluctuateLevel=0
+;----- only for VENC_RC_MODE_H264VBR ----------
+MaxBitRate =10000
+
+MaxQp=32
+
+MinQp=24
+;----- only for VENC_RC_MODE_H264FIXQP ----------
+IQp=40
+
+PQp=45
+;-------- for REF_EX IsliceEnable------
+IsliceEnable = FALSE  ;IsliceEnable and ViEnable  is mutual exclusion
+IsRefreshEnable = FALSE  ;IsliceEnable  and  bRefreshEnable  both TRUE is effective
+RefreshLineNum = 12  ;PicHeight/16/6  6 is empirical value,ask Fuyang
+ReqIQp = 30
+;-------- for REF_EX ViEnable------
+ViEnable = TRUE
+ViInterval = 50 ; 2s
+ViQpDelta = 2
+
+[bind]
+ViDev   =0
+ViChn   =0
+VpssGrp =0
+VpssChn = 0
+VoDev   =0
+VoChn   =0
+ViSnapChn =0
+VpssSnapGrp=0
+VpssSnapChn=1
+VencSnapGrp=1
+VencSnapChn=3


### PR DESCRIPTION
## Summary

Adds `WDR/imx291_i2c_lvds_1080p.ini` for hi3516cv300, mirroring the existing WDR pattern in `hisilicon-osdrv-hi3516ev200/files/sensor/config/WDR/`.

The WDR variant differs from the linear baseline only in:

- `[sensor] Mode = 2` (`WDR_MODE_2To1_LINE`)
- `[lvds] img_size_h = 1110` (matches a working DOL 2T1 capture from XM Sofia on the same SoC+sensor)

Sync codes, lane mapping, raw_data_type, vi_dev / vpss / venc settings — unchanged from the linear ini, because for IMX291 LVDS DOL the sensor outputs interleaved long/short exposure scan lines as a single tall frame and the ISP de-interleaves them downstream. The LVDS receiver stays in `HI_WDR_MODE_NONE`.

## Dependencies

This config alone is not sufficient. It needs both:

- widgetii/sony_imx291@8899282 — replaces the broken WDR register table in `sensor_wdr_1080p60_2to1_init` (was writing `0x3046=0x00` killing the LVDS bus output, plus wrong HMAX/VMAX/FRSEL) with the 60-write sequence captured via `ipctool trace` from a working camera.
- widgetii/majestic#74 — makes Majestic honour `[lvds] wdr_mode` from the `.ini` instead of auto-deriving `HI_WDR_MODE_DOL_2F` from `[sensor] Mode`.

Without #74, Majestic forces `wdr_mode = DOL_2F` on the LVDS receiver and `VI WDR Mode = 2L1`, and `VI PHYCHN` never sees a valid frame (`venc_read: Timeout from venc channel 0`).

## Test plan

- [x] hi3516cv300 + IMX291 LVDS, default linear ini → streams 1080p over RTSP (regression)
- [x] hi3516cv300 + IMX291 LVDS, swap `/etc/sensors/imx291_i2c_lvds_1080p_line.ini` ← `WDR/imx291_i2c_lvds_1080p.ini` → streams 1080p WDR over RTSP
- [x] `/proc/umap/vi` after WDR enable: `VI WDR ATTR Mode = NONE`, matches reference XM Sofia capture
- [x] hi3516ev300 + IMX335 MIPI VC WDR — unaffected (different code path, regression-clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)