### PR TITLE
hi3516av300_neo: disable THUMB2_KERNEL, add to CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,7 @@ jobs:
 
           # Hisilicon [HI3516CV500]
           - hi3516av300_lite
+          - hi3516av300_neo
           - hi3516cv500_lite
           - hi3516dv300_lite
 

--- a/br-ext-chip-hisilicon/board/hi3516cv500/hi3516av300.neo.config
+++ b/br-ext-chip-hisilicon/board/hi3516cv500/hi3516av300.neo.config
@@ -8,7 +8,9 @@ CONFIG_ARM=y
 CONFIG_ARCH_MULTI_V7=y
 CONFIG_SMP=y
 CONFIG_NR_CPUS=2
-CONFIG_THUMB2_KERNEL=y
+# CONFIG_THUMB2_KERNEL is not set
+# Vendor blob (hi_base.o etc.) is ARM-mode; Thumb-2 kernel breaks interworking
+# at insmod (R_ARM_CALL relocations to Thumb OSAL symbols)
 CONFIG_VMSPLIT_2G=y
 CONFIG_NEON=y
 CONFIG_VFP=y


### PR DESCRIPTION
## Summary

Follow-up to #2023. Two related fixes for the modern-kernel CV500 variant
on real hardware (hi3516av300_imx415):

### 1. Disable \`CONFIG_THUMB2_KERNEL\` (matches hi3516ev300_neo)

HiSilicon vendor blobs (\`obj/hi3516cv500/hi_*.o\` in openhisilicon) were
built for the legacy 4.9 kernel in **ARM mode**. Their relocations to
OSAL symbols are \`R_ARM_CALL\`, which assume an ARM target.

With a Thumb-2 kernel, our \`open_osal.ko\` ends up Thumb-2 and OSAL
symbols get the Thumb low-bit set. The module loader then rejects
\`open_base.ko\` insmod with:

\`\`\`
open_base: section 6 reloc 101 sym 'osal_destroydev':
  unsupported interworking call (ARM -> Thumb)
\`\`\`

That cascades into \"Unknown symbol HI_LOG / cmpi_register_module / ...\"
for every downstream module — adec, acodec, sys, tde, rgn, gdc, vi, etc.

Disabling Thumb-2 keeps the kernel in ARM mode so the blobs' \`R_ARM_CALL\`
relocations resolve cleanly. Verified on real HW: **all 19 OSDRV modules
now load** (open_osal, open_base, open_sys, open_isp, open_vi, open_vpss,
open_vo, open_chnl, open_venc, open_h264e, open_h265e, open_jpege,
open_vedu, open_rc, open_ive, open_dis, open_gdc, open_rgn, open_tde) —
none of the prior symbol-resolution errors remain.

uImage size: 2025 KB → 2011 KB.

### 2. Add \`hi3516av300_neo\` to CI build matrix

Under \`# Hisilicon [HI3516CV500]\` section in \`.github/workflows/build.yml\`.

## Test plan

- [x] uImage builds within 2048 KB NOR limit
- [x] All 19 OSDRV modules load on real hi3516av300_imx415 with no
      \"Unknown symbol\" or \"interworking call\" errors
- [x] eth0 still UP @ 100 Mbps
- [x] Boot to login console works

🤖 Generated with [Claude Code](https://claude.com/claude-code)