### PR TITLE
hi3516av300_neo / cv500 osdrv: switch to DT-defined CMA-default allocator

### DIFF
--- a/br-ext-chip-hisilicon/board/hi3516cv500/hi3516av300.neo.config
+++ b/br-ext-chip-hisilicon/board/hi3516cv500/hi3516av300.neo.config
@@ -63,8 +63,10 @@ CONFIG_PREEMPT_NONE=y
 # Memory
 CONFIG_CMA=y
 CONFIG_DMA_CMA=y
-# 4K capture (3840x2160 IMX415) needs ~150-200 MiB MMZ via CMA
-CONFIG_CMA_SIZE_MBYTES=192
+# CMA size & placement come from DT reserved-memory (mmz_cma node) —
+# linux,cma-default + reusable lets the kernel borrow CMA pages for
+# movable allocations when not pinned for DMA. Matches EV300 neo.
+CONFIG_CMA_SIZE_MBYTES=0
 CONFIG_CMA_AREAS=7
 CONFIG_PAGE_OFFSET=0xC0000000
 CONFIG_FLATMEM=y

--- a/general/package/hisilicon-osdrv-hi3516cv500/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516cv500/files/script/load_hisilicon
@@ -328,7 +328,16 @@ for arg in $@; do
     esac
 done
 #######################parse arg end########################
-if [ $os_mem_size -ge $mem_total ]; then
+# When CMA is configured as the base allocator (DT reserved-memory with
+# linux,cma-default + reusable), os_mem can equal total_mem because the
+# kernel maps all DDR; the MMZ pool comes from CMA, not from a carved-out
+# raw region. Skip the legacy "raw mmz fits in total - os" check in that
+# case. The check is still meaningful for the legacy hi_osal/raw mmz mode.
+if grep -q '\bcma\b' /proc/cmdline /sys/kernel/debug/cma 2>/dev/null \
+        || [ -d /sys/kernel/mm/cma ] \
+        || awk '/^CmaTotal:/{exit ($2>0)?0:1}' /proc/meminfo; then
+    : # CMA active — total_mem == os_mem is fine
+elif [ $os_mem_size -ge $mem_total ]; then
     echo "[err] os_mem[$os_mem_size], over total_mem[$mem_total]"
     exit
 fi


### PR DESCRIPTION
## Summary

Brings hi3516av300_neo / hi3516cv500 osdrv in line with the OpenIPC wiki's
[\"CMA as base allocator\"](https://github.com/OpenIPC/wiki/blob/master/en/memory-tuning.md)
recommendation and the EV300 neo working pattern.

### Changes

1. **\`hi3516av300.neo.config\`**: \`CONFIG_CMA_SIZE_MBYTES=0\` so the DT
   \`reserved-memory\` node from openipc/linux PR
   [#36](https://github.com/OpenIPC/linux/pull/36) drives CMA placement
   and size. The DT \`mmz_cma\` node has \`reusable\` +
   \`linux,cma-default\`, so the OS can borrow CMA pages for movable
   allocations when MMZ isn't pinning them.

   Net effect on a 1 GiB hi3516av300:
   \`\`\`
   MemTotal:   1031628 kB     (full 1 GiB visible)
   CmaTotal:    786432 kB     (768 MiB)
   CmaFree:     559216 kB     (after 4K H264 + MJPEG VB pools)
   \`\`\`

2. **\`load_hisilicon\`**: skip the legacy \`os_mem >= total_mem\`
   validity check when CMA is active. That check was correct only for
   the raw \"hisi\" mmz allocator that carved a fixed region out of DDR
   via \`mem=\`. With CMA-default, \`mem=\${osmem}\` maps the full DDR
   and MMZ comes from inside it — so equality (osmem=1024M ==
   totalmem=1024M) is normal, not an error.

### Why this matters

Before, on a 1 GiB board with \`osmem=1024M\` / \`totalmem=1024M\`,
S70vendor would print:

\`\`\`
[err] os_mem[1024], over total_mem[1024]
\`\`\`

…and exit without loading any vendor module → \`majestic\` had no
backend → no video.

After: full 32 OSDRV modules load, \`majestic\` starts the SDK, RTSP
listens on :554, HTTP returns a valid 3840×2160 4K JPEG snapshot.

### Test plan (verified on hi3516av300_imx415)

- [x] All 32 OSDRV modules load cleanly
- [x] \`majestic\`: \`HiSilicon SDK started\`,
  \`Free MMZ mem after allocation: 617352KB\` (was 5616KB before)
- [x] H264 4K + MJPEG 4K channels both succeed (no \`ERR_VENC_NOMEM\`)
- [x] RTSP server on :554, HTTP snapshot at 3840×2160

Companion kernel change: openipc/linux PR
[#36](https://github.com/OpenIPC/linux/pull/36) (1 GiB \`memory.reg\` +
DT \`mmz_cma\` reserved-memory node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)