### PR TITLE
hisilicon: load open_hwrng early in load_hisilicon (entropy)

### DIFF
--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -140,6 +140,8 @@ define HISILICON_OPENSDK_INSTALL_TARGET_CMDS
 	done
 	$(INSTALL) -m 644 $(@D)/kernel/open_vi.ko      $(HISILICON_OPENSDK_KMOD_DST)/hi3516cv300_viu.ko
 	$(INSTALL) -m 644 $(@D)/kernel/open_rgn.ko     $(HISILICON_OPENSDK_KMOD_DST)/hi3516cv300_region.ko
+	# HWRNG: install verbatim — load_hisilicon insmods it pre-sensor-probe.
+	$(INSTALL) -m 644 $(@D)/kernel/open_hwrng.ko   $(HISILICON_OPENSDK_KMOD_DST)/open_hwrng.ko
 endef
 
 # For hi3519v101: install opensdk .ko to hisilicon/ with vendor names.
@@ -169,6 +171,8 @@ define HISILICON_OPENSDK_INSTALL_TARGET_CMDS
 	done
 	$(INSTALL) -m 644 $(@D)/kernel/open_vi.ko      $(HISILICON_OPENSDK_KMOD_DST)/hi3519v101_viu.ko
 	$(INSTALL) -m 644 $(@D)/kernel/open_rgn.ko     $(HISILICON_OPENSDK_KMOD_DST)/hi3519v101_region.ko
+	# HWRNG: install verbatim — load_hisilicon insmods it pre-sensor-probe.
+	$(INSTALL) -m 644 $(@D)/kernel/open_hwrng.ko   $(HISILICON_OPENSDK_KMOD_DST)/open_hwrng.ko
 endef
 
 # For hi3516av100: install opensdk .ko to hisilicon/ with vendor names.
@@ -261,6 +265,8 @@ define HISILICON_OPENSDK_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 644 $(@D)/kernel/open_vi.ko      $(HISILICON_OPENSDK_KMOD_DST)/hi3518e_viu.ko
 	$(INSTALL) -m 644 $(@D)/kernel/open_rgn.ko     $(HISILICON_OPENSDK_KMOD_DST)/hi3518e_region.ko
 	$(INSTALL) -m 644 $(@D)/kernel/open_acodec.ko  $(HISILICON_OPENSDK_KMOD_DST)/acodec.ko
+	# HWRNG: install verbatim — load_hisilicon insmods it pre-sensor-probe.
+	$(INSTALL) -m 644 $(@D)/kernel/open_hwrng.ko   $(HISILICON_OPENSDK_KMOD_DST)/open_hwrng.ko
 endef
 
 # For hi3516cv500: install opensdk .ko directly to hisilicon/ with vendor names,
@@ -290,6 +296,8 @@ define HISILICON_OPENSDK_INSTALL_TARGET_CMDS
 			$(INSTALL) -m 644 $(@D)/kernel/open_$${mod}.ko \
 				$(HISILICON_OPENSDK_KMOD_DST)/$(HISILICON_OPENSDK_CHIP)_$${mod}.ko || true; \
 	done
+	# HWRNG: install verbatim — load_hisilicon insmods it pre-sensor-probe.
+	$(INSTALL) -m 644 $(@D)/kernel/open_hwrng.ko   $(HISILICON_OPENSDK_KMOD_DST)/open_hwrng.ko
 endef
 
 else

--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = 680085e
+HISILICON_OPENSDK_VERSION = a6586f4
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE

--- a/general/package/hisilicon-osdrv-hi3516cv200/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516cv200/files/script/load_hisilicon
@@ -378,6 +378,17 @@ for arg in $@; do
 done
 #######################parse arg end########################
 
+# HWRNG: load before any conditional exit (os_mem mismatch, sensor
+# probe failure, etc.) so entropy is always available to userspace
+# daemons (majestic, dropbear, openssl) that block on getrandom().
+if [ "$b_arg_insmod" = "1" ]; then
+    modprobe open_hwrng 2>/dev/null
+fi
+
+
+
+
+
 if [ $os_mem_size -ge $mem_total ]; then
         echo "[err] os_mem[$os_mem_size], over total_mem[$mem_total]"
         exit

--- a/general/package/hisilicon-osdrv-hi3516cv300/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516cv300/files/script/load_hisilicon
@@ -547,6 +547,17 @@ do
 done
 #######################parse arg end########################
 
+# HWRNG: load before any conditional exit (os_mem mismatch, sensor
+# probe failure, etc.) so entropy is always available to userspace
+# daemons (majestic, dropbear, openssl) that block on getrandom().
+if [ "$b_arg_insmod" = "1" ]; then
+    modprobe open_hwrng 2>/dev/null
+fi
+
+
+
+
+
 if [ $os_mem_size -ge $mem_total ] ; then
 	echo "[err] os_mem[$os_mem_size], over total_mem[$mem_total]"
 	exit;

--- a/general/package/hisilicon-osdrv-hi3516cv500/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516cv500/files/script/load_hisilicon
@@ -328,6 +328,17 @@ for arg in $@; do
     esac
 done
 #######################parse arg end########################
+
+# HWRNG: load before any conditional exit (os_mem mismatch, sensor
+# probe failure, etc.) so entropy is always available to userspace
+# daemons (majestic, dropbear, openssl) that block on getrandom().
+if [ "$b_arg_insmod" = "1" ]; then
+    modprobe open_hwrng 2>/dev/null
+fi
+
+
+
+
 # When CMA is configured as the base allocator (DT reserved-memory with
 # linux,cma-default + reusable), os_mem can equal total_mem because the
 # kernel maps all DDR; the MMZ pool comes from CMA, not from a carved-out

--- a/general/package/hisilicon-osdrv-hi3516ev200/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516ev200/files/script/load_hisilicon
@@ -334,6 +334,18 @@ for arg in $@; do
 	esac
 done
 #######################parse arg end########################
+
+# HWRNG: load before any conditional exit (os_mem mismatch, sensor
+# probe failure, etc.) so entropy is always available to userspace
+# daemons (majestic, dropbear, openssl) that block on getrandom().
+if [ "$b_arg_insmod" = "1" ]; then
+    modprobe open_hwrng 2>/dev/null
+fi
+
+
+
+
+
 if [ $os_mem_size -ge $mem_total ]; then
 	echo "[err] os_mem[$os_mem_size], over total_mem[$mem_total]"
 	exit

--- a/general/package/hisilicon-osdrv-hi3519v101/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3519v101/files/script/load_hisilicon
@@ -860,6 +860,17 @@ for arg in $@; do
 done
 #######################parse arg end########################
 
+# HWRNG: load before any conditional exit (os_mem mismatch, sensor
+# probe failure, etc.) so entropy is always available to userspace
+# daemons (majestic, dropbear, openssl) that block on getrandom().
+if [ "$b_arg_insmod" = "1" ]; then
+    modprobe open_hwrng 2>/dev/null
+fi
+
+
+
+
+
 if [ $os_mem_size -ge $mem_total ]; then
 	echo "[err] os_mem[$os_mem_size], over total_mem[$mem_total]"
 	exit


### PR DESCRIPTION
## Summary

- Loads the redesigned `open_hwrng.ko` (from OpenIPC/openhisilicon#85) **before** any conditional exit in `load_hisilicon`. Previously the module wasn't loaded at all; once it lands as part of the openhisilicon PR it would get skipped by every existing `os_mem >= total_mem` exit and `SENSOR=unknown` gate. Entropy is platform-essential, not sensor-dependent.
- Single canonical block placed right after `#parse arg end#` in all 5 scripts (cv200/cv300/cv500/3519v101/ev200):
  ```sh
  if [ "$b_arg_insmod" = "1" ]; then
      modprobe open_hwrng 2>/dev/null
  fi
  ```
- For cv500/cv300/cv200/3519v101 the post-finalize wipe in `hisilicon-opensdk.mk` removes `lib/modules/*/extra/open_*.ko`. Add an explicit verbatim install of `open_hwrng.ko` into the per-platform `hisilicon/` dir so `modprobe` finds it via `modules.dep`. ev200/gk7205v200 (V4 fall-through) keep modules in `extra/` — no `.mk` change needed for those.
- cv100/av100 left out — no documented TRNG block (PR #54 leaves their `hwrng_base = 0`).

## Test plan

End-to-end QEMU runs under widgetii/qemu-hisilicon (HWRNG block emulation from its PR #54) for every supported platform. Each boots its released firmware tarball, loads `open_hwrng` automatically via `S70vendor` → `load_hisilicon -i`, and reaches login with the entropy pool primed:

| Platform | Family | Kernel | HW_RANDOM | Driver mode | TRNG addr | entropy_avail | /dev/hwrng |
|---|---|---|---|---|---|---|---|
| hi3516cv200 | V2  | 4.9.37  | y | `hwrng-core`        | 0x20280000+0x4   | 922→923  | yes |
| hi3516cv300 | V3  | 3.18.20 | y | `hwrng-core + pump` | 0x120c0000+0x204 | 1536     | yes |
| hi3519v101  | V3A | 3.18.20 | n | `pump`              | 0x120c0000+0x204 | 1536     | n/a |
| hi3516cv500 | V3.5| 4.9.37  | n | `pump`              | 0x10090000+0x204 | 0→1280   | n/a |
| hi3516ev200 | V4  | 4.9.37  | n | `pump`              | 0x10080000+0x204 | 1024     | n/a |

`/dev/random` returns immediately on every platform — Majestic / dropbear / openssl no longer block on `getrandom()`.

- [x] All 5 enabled platforms boot to login under QEMU
- [x] `dmesg` shows `hisi-hwrng: TRNG at <per-SoC base> registered (<mode>)` on each
- [x] `/proc/sys/kernel/random/entropy_avail` non-zero immediately
- [x] `dd if=/dev/random bs=32 count=1` returns instantly with random bytes
- [x] No new `rmmod can't unload` regressions (existing CI assertion)

## Pairs with

- OpenIPC/openhisilicon#85 — provides the `open_hwrng.ko` module this PR loads.
- Emulation: widgetii/qemu-hisilicon#54 (already merged) — needed for QEMU CI to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)