### PR TITLE
load_hisilicon: skip cmdline mem= when it equals total RAM (V4+CMA)

### DIFF
--- a/.github/scripts/test_load_hisilicon.sh
+++ b/.github/scripts/test_load_hisilicon.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# Regression test for load_hisilicon's os_mem_size derivation.
+#
+# Catches #2059: kernel cmdline mem=NM was unconditionally accepted as the
+# OS/MMZ split, which broke V4+CMA boards where bootargs pass mem=<totalmem>
+# (with the MMZ chunk CMA-reserved within it). Result: os_mem_size=mem_total,
+# the existing "[ os_mem >= total ]" guard tripped, script exited before any
+# insmod, every camera came up with empty lsmod.
+#
+# Two-part check:
+#   Part 1 — logic test: synthetic harness reproducing the post-fix code.
+#            Exercises the parsing rules directly; independent of script files.
+#   Part 2 — drift test: every general/package/hisilicon-osdrv-*/.../load_hisilicon
+#            must contain the validation block. If someone reverts the fix in any
+#            family the drift test fails immediately.
+#
+# Lightweight: pure shell, no QEMU, runs in a few seconds.
+
+set -eu
+
+fail=0
+ok()   { echo "ok   $*"; }
+bad()  { echo "FAIL $*"; fail=$((fail + 1)); }
+T()    { local exp="$1" act="$2" desc="$3"
+         if [ "$exp" = "$act" ]; then ok "$desc"; else bad "$desc -- want '$exp', got '$act'"; fi; }
+
+# ----- Part 1: parsing logic -----
+# Mirrors the post-fix block in every load_hisilicon. Any divergence here
+# (vs the scripts) is caught by Part 2.
+parse_os_mem() {
+    cmdline="$1"; mem_total="$2"; osmem_env="$3"
+    os_mem_size=$(printf '%s' "$cmdline" | awk 'BEGIN{RS=" "} /^mem=[0-9]+M/{gsub(/^mem=|M.*$/,""); print; exit}')
+    if [ -n "$os_mem_size" ] && [ "$os_mem_size" -ge "$mem_total" ]; then
+        os_mem_size=""
+    fi
+    if [ -z "$os_mem_size" ]; then
+        os_mem_size="$osmem_env"
+    fi
+    : "${os_mem_size:=32}"
+    printf '%s\n' "$os_mem_size"
+}
+
+echo "=== Part 1: os_mem_size derivation logic ==="
+# The bug case: V4+CMA cmdline passes mem=<totalmem>. Pre-fix this set
+# os_mem_size=128, mem_total=128, then the load_hisilicon guard "[ os_mem
+# >= total ]" exited the whole script. Post-fix the validation block
+# discards the cmdline value and falls through to the osmem env (32).
+T 32 "$(parse_os_mem 'mem=128M mmz_allocator=cma mmz=anonymous,0,0x42000000,96M' 128 32)" \
+   "V4+CMA mem=128M, totalmem=128M → fall through to osmem env (#2059)"
+
+# Legacy split: cmdline mem= is strictly less than totalmem, signaling
+# a real OS/MMZ split. Use the cmdline value as authoritative.
+T 96 "$(parse_os_mem 'mem=96M mmz_allocator=hisi mmz=anonymous,0,0x46000000,32M' 128 32)" \
+   "legacy mem=96M, totalmem=128M → use cmdline 96 (PR #2039 intent)"
+
+# No mem= at all — fall back to env.
+T 32 "$(parse_os_mem 'console=ttyAMA0,115200 root=/dev/mtdblock3' 64 32)" \
+   "no cmdline mem= → fall back to osmem env"
+
+# Neither cmdline nor env — script default of 32.
+T 32 "$(parse_os_mem '' 64 '')" \
+   "no cmdline mem=, no env → default 32"
+
+# Misconfigured cmdline (mem= over total). Still fall through to env to
+# avoid the >= guard later in the script killing the boot.
+T 64 "$(parse_os_mem 'mem=256M' 128 64)" \
+   "mem=256M > totalmem=128 → fall through (avoid guard)"
+
+# Edge: mem= equals totalmem-1 (legitimate split with 1M for MMZ — silly
+# but valid). Should still use cmdline.
+T 127 "$(parse_os_mem 'mem=127M' 128 32)" \
+   "mem=127M, totalmem=128M → use cmdline 127"
+
+# ----- Part 2: every hisilicon-osdrv-* script contains the validation -----
+echo
+echo "=== Part 2: validation block present in every load_hisilicon ==="
+needle='if \[ -n "\$os_mem_size" \] && \[ "\$os_mem_size" -ge "\$mem_total" \]; then'
+scripts=$(find general/package -name 'load_hisilicon' -path '*hisilicon-osdrv-*' | sort)
+
+if [ -z "$scripts" ]; then
+    bad "no hisilicon-osdrv-*/files/script/load_hisilicon found — repo layout changed?"
+else
+    count=$(printf '%s\n' "$scripts" | wc -l)
+    echo "scanning $count load_hisilicon copies"
+    for s in $scripts; do
+        family=$(printf '%s\n' "$s" | sed 's|.*hisilicon-osdrv-||; s|/.*||')
+        if grep -qE "$needle" "$s"; then
+            ok "$family: validation block present"
+        else
+            bad "$family: validation block MISSING — fix from #2060 was reverted or not applied"
+        fi
+    done
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+    echo "All load_hisilicon regression checks passed."
+    exit 0
+else
+    echo "$fail check(s) failed. See https://github.com/OpenIPC/firmware/issues/2059"
+    exit 1
+fi

--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -1,0 +1,17 @@
+name: shell-tests
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  load-hisilicon-parsing:
+    name: load_hisilicon os_mem_size derivation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash .github/scripts/test_load_hisilicon.sh

--- a/general/package/hisilicon-osdrv-hi3516av100/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516av100/files/script/load_hisilicon
@@ -12,9 +12,15 @@ mem_start=0x80000000 # phy mem start
 mem_total=$(fw_printenv -n totalmem | tr -d 'M')
 mem_total=${mem_total:=128}
 
-# Prefer kernel cmdline mem=NM -- that's the authoritative kernel/MMZ split.
-# Fall back to U-Boot osmem env only when the kernel was booted without mem=.
+# Prefer kernel cmdline mem=NM -- that's the authoritative kernel/MMZ split,
+# but only when it's a strict subset of total RAM. With mmz_allocator=cma
+# (V4 CMA layouts), bootargs typically pass mem=<totalmem> with the MMZ
+# chunk CMA-reserved within that range; in that case mem= is no longer an
+# OS/MMZ split and we must fall through to the U-Boot osmem env.
 os_mem_size=$(awk 'BEGIN{RS=" "} /^mem=[0-9]+M/{gsub(/^mem=|M.*$/,""); print; exit}' /proc/cmdline)
+if [ -n "$os_mem_size" ] && [ "$os_mem_size" -ge "$mem_total" ]; then
+	os_mem_size=""
+fi
 if [ -z "$os_mem_size" ]; then
 	os_mem_size=$(fw_printenv -n osmem | tr -d 'M')
 fi

--- a/general/package/hisilicon-osdrv-hi3516cv100/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516cv100/files/script/load_hisilicon
@@ -9,9 +9,15 @@ mem_start=0x80000000 # phy mem start
 mem_total=$(fw_printenv -n totalmem | tr -d 'M')
 mem_total=${mem_total:=64}
 
-# Prefer kernel cmdline mem=NM -- that's the authoritative kernel/MMZ split.
-# Fall back to U-Boot osmem env only when the kernel was booted without mem=.
+# Prefer kernel cmdline mem=NM -- that's the authoritative kernel/MMZ split,
+# but only when it's a strict subset of total RAM. With mmz_allocator=cma
+# (V4 CMA layouts), bootargs typically pass mem=<totalmem> with the MMZ
+# chunk CMA-reserved within that range; in that case mem= is no longer an
+# OS/MMZ split and we must fall through to the U-Boot osmem env.
 os_mem_size=$(awk 'BEGIN{RS=" "} /^mem=[0-9]+M/{gsub(/^mem=|M.*$/,""); print; exit}' /proc/cmdline)
+if [ -n "$os_mem_size" ] && [ "$os_mem_size" -ge "$mem_total" ]; then
+	os_mem_size=""
+fi
 if [ -z "$os_mem_size" ]; then
 	os_mem_size=$(fw_printenv -n osmem | tr -d 'M')
 fi

--- a/general/package/hisilicon-osdrv-hi3516cv200/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516cv200/files/script/load_hisilicon
@@ -13,9 +13,15 @@ mem_start=0x80000000 # phy mem start
 mem_total=$(fw_printenv -n totalmem | tr -d 'M')
 mem_total=${mem_total:=64}
 
-# Prefer kernel cmdline mem=NM -- that's the authoritative kernel/MMZ split.
-# Fall back to U-Boot osmem env only when the kernel was booted without mem=.
+# Prefer kernel cmdline mem=NM -- that's the authoritative kernel/MMZ split,
+# but only when it's a strict subset of total RAM. With mmz_allocator=cma
+# (V4 CMA layouts), bootargs typically pass mem=<totalmem> with the MMZ
+# chunk CMA-reserved within that range; in that case mem= is no longer an
+# OS/MMZ split and we must fall through to the U-Boot osmem env.
 os_mem_size=$(awk 'BEGIN{RS=" "} /^mem=[0-9]+M/{gsub(/^mem=|M.*$/,""); print; exit}' /proc/cmdline)
+if [ -n "$os_mem_size" ] && [ "$os_mem_size" -ge "$mem_total" ]; then
+	os_mem_size=""
+fi
 if [ -z "$os_mem_size" ]; then
 	os_mem_size=$(fw_printenv -n osmem | tr -d 'M')
 fi

--- a/general/package/hisilicon-osdrv-hi3516cv300/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516cv300/files/script/load_hisilicon
@@ -13,9 +13,15 @@ mem_start=0x80000000;                             # phy mem start
 mem_total=$(fw_printenv -n totalmem | tr -d 'M')
 mem_total=${mem_total:=64}
 
-# Prefer kernel cmdline mem=NM -- that's the authoritative kernel/MMZ split.
-# Fall back to U-Boot osmem env only when the kernel was booted without mem=.
+# Prefer kernel cmdline mem=NM -- that's the authoritative kernel/MMZ split,
+# but only when it's a strict subset of total RAM. With mmz_allocator=cma
+# (V4 CMA layouts), bootargs typically pass mem=<totalmem> with the MMZ
+# chunk CMA-reserved within that range; in that case mem= is no longer an
+# OS/MMZ split and we must fall through to the U-Boot osmem env.
 os_mem_size=$(awk 'BEGIN{RS=" "} /^mem=[0-9]+M/{gsub(/^mem=|M.*$/,""); print; exit}' /proc/cmdline)
+if [ -n "$os_mem_size" ] && [ "$os_mem_size" -ge "$mem_total" ]; then
+	os_mem_size=""
+fi
 if [ -z "$os_mem_size" ]; then
 	os_mem_size=$(fw_printenv -n osmem | tr -d 'M')
 fi

--- a/general/package/hisilicon-osdrv-hi3516cv500/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516cv500/files/script/load_hisilicon
@@ -15,9 +15,15 @@ mem_start=0x80000000 # phy mem start
 mem_total=$(fw_printenv -n totalmem | tr -d 'M')
 mem_total=${mem_total:=64}
 
-# Prefer kernel cmdline mem=NM -- that's the authoritative kernel/MMZ split.
-# Fall back to U-Boot osmem env only when the kernel was booted without mem=.
+# Prefer kernel cmdline mem=NM -- that's the authoritative kernel/MMZ split,
+# but only when it's a strict subset of total RAM. With mmz_allocator=cma
+# (V4 CMA layouts), bootargs typically pass mem=<totalmem> with the MMZ
+# chunk CMA-reserved within that range; in that case mem= is no longer an
+# OS/MMZ split and we must fall through to the U-Boot osmem env.
 os_mem_size=$(awk 'BEGIN{RS=" "} /^mem=[0-9]+M/{gsub(/^mem=|M.*$/,""); print; exit}' /proc/cmdline)
+if [ -n "$os_mem_size" ] && [ "$os_mem_size" -ge "$mem_total" ]; then
+	os_mem_size=""
+fi
 if [ -z "$os_mem_size" ]; then
 	os_mem_size=$(fw_printenv -n osmem | tr -d 'M')
 fi

--- a/general/package/hisilicon-osdrv-hi3516ev200/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516ev200/files/script/load_hisilicon
@@ -15,9 +15,15 @@ mem_start=0x40000000 # phy mem start
 mem_total=$(fw_printenv -n totalmem | tr -d 'M')
 mem_total=${mem_total:=64}
 
-# Prefer kernel cmdline mem=NM -- that's the authoritative kernel/MMZ split.
-# Fall back to U-Boot osmem env only when the kernel was booted without mem=.
+# Prefer kernel cmdline mem=NM -- that's the authoritative kernel/MMZ split,
+# but only when it's a strict subset of total RAM. With mmz_allocator=cma
+# (V4 CMA layouts), bootargs typically pass mem=<totalmem> with the MMZ
+# chunk CMA-reserved within that range; in that case mem= is no longer an
+# OS/MMZ split and we must fall through to the U-Boot osmem env.
 os_mem_size=$(awk 'BEGIN{RS=" "} /^mem=[0-9]+M/{gsub(/^mem=|M.*$/,""); print; exit}' /proc/cmdline)
+if [ -n "$os_mem_size" ] && [ "$os_mem_size" -ge "$mem_total" ]; then
+	os_mem_size=""
+fi
 if [ -z "$os_mem_size" ]; then
 	os_mem_size=$(fw_printenv -n osmem | tr -d 'M')
 fi

--- a/general/package/hisilicon-osdrv-hi3519v101/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3519v101/files/script/load_hisilicon
@@ -12,9 +12,15 @@ mem_start=0x80000000 # phy mem start
 mem_total=$(fw_printenv -n totalmem | tr -d 'M')
 mem_total=${mem_total:=64}
 
-# Prefer kernel cmdline mem=NM -- that's the authoritative kernel/MMZ split.
-# Fall back to U-Boot osmem env only when the kernel was booted without mem=.
+# Prefer kernel cmdline mem=NM -- that's the authoritative kernel/MMZ split,
+# but only when it's a strict subset of total RAM. With mmz_allocator=cma
+# (V4 CMA layouts), bootargs typically pass mem=<totalmem> with the MMZ
+# chunk CMA-reserved within that range; in that case mem= is no longer an
+# OS/MMZ split and we must fall through to the U-Boot osmem env.
 os_mem_size=$(awk 'BEGIN{RS=" "} /^mem=[0-9]+M/{gsub(/^mem=|M.*$/,""); print; exit}' /proc/cmdline)
+if [ -n "$os_mem_size" ] && [ "$os_mem_size" -ge "$mem_total" ]; then
+	os_mem_size=""
+fi
 if [ -z "$os_mem_size" ]; then
 	os_mem_size=$(fw_printenv -n osmem | tr -d 'M')
 fi

--- a/general/package/hisilicon-osdrv-hi3536dv100/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3536dv100/files/script/load_hisilicon
@@ -8,9 +8,15 @@ mem_start=0x80000000
 mem_total=$(fw_printenv -n totalmem | tr -d 'M')
 mem_total=${mem_total:=64}
 
-# Prefer kernel cmdline mem=NM -- that's the authoritative kernel/MMZ split.
-# Fall back to U-Boot osmem env only when the kernel was booted without mem=.
+# Prefer kernel cmdline mem=NM -- that's the authoritative kernel/MMZ split,
+# but only when it's a strict subset of total RAM. With mmz_allocator=cma
+# (V4 CMA layouts), bootargs typically pass mem=<totalmem> with the MMZ
+# chunk CMA-reserved within that range; in that case mem= is no longer an
+# OS/MMZ split and we must fall through to the U-Boot osmem env.
 os_mem_size=$(awk 'BEGIN{RS=" "} /^mem=[0-9]+M/{gsub(/^mem=|M.*$/,""); print; exit}' /proc/cmdline)
+if [ -n "$os_mem_size" ] && [ "$os_mem_size" -ge "$mem_total" ]; then
+	os_mem_size=""
+fi
 if [ -z "$os_mem_size" ]; then
 	os_mem_size=$(fw_printenv -n osmem | tr -d 'M')
 fi


### PR DESCRIPTION
## Summary

Fixes #2059. PR #2039's "prefer cmdline `mem=` over `osmem` env" change broke V4+CMA boards (hi3516ev300_neo etc.), where `mem=` is total physical RAM (with the MMZ chunk CMA-reserved within it) rather than the OS-only slice. The script computed `os_mem_size == mem_total`, tripped the existing `[ os_mem >= total ]` guard, and `exit`ed before any `insmod` — leaving every camera with empty `lsmod` after `sysupgrade`.

This PR contains **two paired commits**, fix + regression test, so any future change to `load_hisilicon`'s mem= parsing fails CI before release rather than after a user reports their camera is bricked.

## Commits

### `load_hisilicon: skip cmdline mem= when it equals total RAM (V4+CMA)`

Validate that `mem=` is a strict subset of `mem_total` before accepting it. If `mem= >= mem_total`, it's the whole RAM (CMA layout), not an OS/MMZ split — fall through to `fw_printenv -n osmem`. Same patch applied identically across all 8 `hisilicon-osdrv-*` families (matches PR #2039's lockstep approach).

### `ci: add shell unit-test for load_hisilicon os_mem_size derivation`

Two-part lightweight regression test (no QEMU, runs in seconds on every PR via the new `shell-tests` workflow):

- **Part 1 — logic test.** Synthetic harness reproducing the post-fix `parse_os_mem` block, exercised against six cmdline / totalmem / osmem combinations: the V4+CMA bug case from #2059, the legacy split #2039 wanted to honor, missing-cmdline fallback, default-32, `mem>totalmem` misconfig, and edge case `mem=N-1`.
- **Part 2 — drift test.** greps every `general/package/hisilicon-osdrv-*` `load_hisilicon` for the totalmem-validation block. If anyone reverts the fix in any family, or adds a new `hisilicon-osdrv-*` package without the validation, Part 2 fails immediately.

## TDD verification

Running the test against the **unfixed** scripts on master (i.e. the world before this PR) — Part 2 catches the absent validation block in every script, every platform:

```
=== Part 2: validation block present in every load_hisilicon ===
scanning 8 load_hisilicon copies
FAIL hi3516av100: validation block MISSING — fix from #2060 was reverted or not applied
FAIL hi3516cv100: validation block MISSING — fix from #2060 was reverted or not applied
FAIL hi3516cv200: validation block MISSING — fix from #2060 was reverted or not applied
FAIL hi3516cv300: validation block MISSING — fix from #2060 was reverted or not applied
FAIL hi3516cv500: validation block MISSING — fix from #2060 was reverted or not applied
FAIL hi3516ev200: validation block MISSING — fix from #2060 was reverted or not applied
FAIL hi3519v101: validation block MISSING — fix from #2060 was reverted or not applied
FAIL hi3536dv100: validation block MISSING — fix from #2060 was reverted or not applied

8 check(s) failed. See https://github.com/OpenIPC/firmware/issues/2059
exit=1
```

After the fix, all 14 checks pass (6 logic + 8 drift). Reviewers can verify by reverting the first commit and re-running CI.

## Reproducer (before fix)

```
$ load_hisilicon -i
[err] os_mem[128], over total_mem[128]
$ lsmod | grep -c '^open_'
0
```

## Verified on real hardware (with fix)

hi3516ev300_neo + IMX335 running `master+2ac854e, 2026-05-05`, fix copied to `/usr/bin/load_hisilicon`, rebooted:

```
$ load_hisilicon -i
mmz_start: 0x42000000, mmz_size: 96M
hisilicon: Get data from environment and set SENSOR as imx335
insert audio
$ lsmod | awk '/^open_/' | wc -l
28
$ head -1 /proc/media-mem
+---ZONE: PHYS(0x42000000, 0x47FFFFFF), GFP=0, nBYTES=98304KB,    NAME="anonymous"
$ logread | grep majestic | tail -2
... HiSilicon SDK started
... RTSP server started on port 554
$ curl -sI http://camera/ | head -1
HTTP/1.1 200 OK
```

After reboot the fix persists, `S70vendor`'s `load_hisilicon -i` populates all 28 `open_*` modules, majestic streams h264 + MJPEG at 2592×1520, web UI returns 200.

## Why patch all 8 scripts

PR #2039 added the same "prefer cmdline `mem=`" block to all 8 `hisilicon-osdrv-*/files/script/load_hisilicon` files. The bug exists in all 8; it currently *manifests* only on V4+CMA layouts because that's the only family whose production bootargs satisfy `mem= >= totalmem`. Patching all 8 keeps the scripts in lockstep (same intent as #2039) and pre-empts the same misuse pattern landing on any platform that later adopts CMA-style bootargs.

## Coverage architecture

This PR is the **pre-release gate**: shell test runs on every firmware PR, fails fast if `load_hisilicon` regresses on any family.

OpenIPC/openhisilicon#86 is the **post-release safety net**: a stronger qemu-boot assertion plus a missing `hi3516ev300_neo` matrix row, validated against the actual `latest` firmware tarball after release. Catches anything that slips past the unit test (e.g. a kernel-side regression, a new bug in load_hisilicon's downstream `insert_*` blocks, a sensor driver that fails to load).

## Refs

- regression introduced by: PR #2039 / d36dfd6 ("load_hisilicon: derive os_mem_size from kernel cmdline mem=")
- pairs with: OpenIPC/openhisilicon#86 (post-release defence-in-depth)
- closes: #2059