### PR TITLE
hisilicon-osdrv-hi3516cv500: ship set_allocator helper script

### DIFF
--- a/general/package/hisilicon-osdrv-hi3516cv500/files/script/set_allocator
+++ b/general/package/hisilicon-osdrv-hi3516cv500/files/script/set_allocator
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+
+get_env() {
+  bootargs=$(fw_printenv -n bootargs)
+  mem=$(echo ${bootargs} | awk -F '=' '$1=="mem"{print $2}' RS=' ')
+  console=$(echo ${bootargs} | awk -F '=' '$1=="console"{print $2}' RS=' ')
+  panic=$(echo ${bootargs} | awk -F '=' '$1=="panic"{print $2}' RS=' ')
+  rootfstype=$(echo ${bootargs} | awk -F '=' '$1=="rootfstype"{print $2}' RS=' ')
+  root=$(echo ${bootargs} | awk -F '=' '$1=="root"{print $2}' RS=' ')
+  init=$(echo ${bootargs} | awk -F '=' '$1=="init"{print $2}' RS=' ')
+  mtdparts=$(echo ${bootargs} | awk -F '=' '$1=="mtdparts"{print $2}' RS=' ')
+  osmem=$(fw_printenv -n osmem)
+  totalmem=$(fw_printenv -n totalmem)
+}
+
+calc_mmz() {
+  mem_start=0x80000000
+  mem_total=$(fw_printenv -n totalmem | tr -d 'M')
+  mem_total=${mem_total:=64}
+  os_mem_size=$(fw_printenv -n osmem | tr -d 'M')
+  os_mem_size=${os_mem_size:=32}
+  mmz_start=$(echo "$mem_start $os_mem_size" | awk 'BEGIN { temp = 0; } { temp = $1/1024/1024 + $2; } END { printf("0x%x00000\n", temp); }')
+  mmz_size=$(echo "$mem_total $os_mem_size" | awk 'BEGIN { temp = 0; } { temp = $1 - $2; } END { printf("%dM\n", temp); }')
+  mmz=anonymous,0,$mmz_start,$mmz_size
+}
+
+
+if [[ "$1" == 'hisi' ]]; then
+  echo "Allocator selected as hisi..."
+  get_env
+  mem=${osmem:=32M}
+  newbootargs="mem=${mem} console=${console} panic=${panic} rootfstype=${rootfstype} root=${root} init=${init} mtdparts=${mtdparts} mmz_allocator=hisi"
+  echo ${newbootargs}
+  fw_setenv bootargs ${newbootargs}
+  #
+elif [[ "$1" == 'cma'  ]]; then
+  echo "Allocator selected as cma..."
+  get_env
+  calc_mmz
+  mem=${totalmem:=64M}
+  newbootargs="mem=${mem} console=${console} panic=${panic} rootfstype=${rootfstype} root=${root} init=${init} mtdparts=${mtdparts} mmz_allocator=cma mmz=${mmz}"
+  fw_setenv bootargs ${newbootargs}
+  echo ${newbootargs}
+else
+  echo "NO or WRONG allocator, please select hisi or cma."
+  exit 1
+fi

--- a/general/package/hisilicon-osdrv-hi3516cv500/hisilicon-osdrv-hi3516cv500.mk
+++ b/general/package/hisilicon-osdrv-hi3516cv500/hisilicon-osdrv-hi3516cv500.mk
@@ -26,6 +26,7 @@ define HISILICON_OSDRV_HI3516CV500_INSTALL_COMMON
 
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/usr/bin
 	$(INSTALL) -m 755 -t $(TARGET_DIR)/usr/bin $(HISILICON_OSDRV_HI3516CV500_PKGDIR)/files/script/load*
+	$(INSTALL) -m 755 -t $(TARGET_DIR)/usr/bin $(HISILICON_OSDRV_HI3516CV500_PKGDIR)/files/script/set_allocator
 
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/usr/lib
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib $(HISILICON_OSDRV_HI3516CV500_PKGDIR)/files/lib/libaaccomm.so


### PR DESCRIPTION
## Background — the regression

openhisilicon's \`cma_allocator.c\` (kernel < 5.16 path, used by 4.9 lite
on cv500) looks up CMA zones via \`hisi_get_cma_zone(name)\`. That
function is populated by the **vendor 4.9 kernel's \`hi_cma.c\`** from
the kernel cmdline \`mmz=\` parameter via \`early_param\`. Without
\`mmz=\` in cmdline, no zones get registered, and every subsequent
\`hil_mmz_register\` call fails — and after openhisilicon
[#73](https://github.com/OpenIPC/openhisilicon/pull/73), \`__allocator_init\`
correctly returns \`-ENODEV\` when no zones survive registration, which
fails the OSAL \`insmod\`. The downstream blob modules (open_base,
open_sys, open_isp, open_dis, open_tde …) then either get \"Unknown
symbol\" cascades or hang waiting on init that will never complete.

EV200's osdrv has shipped a \`set_allocator\` helper for years that
rewrites U-Boot bootargs to include the right \`mmz=\` for either
\"hisi\" (raw legacy carve-out) or \"cma\" (V4+ shared pool) mode.
**CV500 osdrv was missing this helper** — fresh hi3516av300/cv500/dv300
installs on real 1 GiB hardware (e.g. hi3516av300_imx415) had no
mechanism to populate the cmdline that openhisilicon's allocator needs.

## What this PR does

Port the script from EV200, only changing \`mem_start\` from
\`0x40000000\` (V4 RAM base, EV200/EV300) to \`0x80000000\` (V3.5 RAM
base for CV500/DV300/AV300).

Wires it into the install rule alongside \`load_hisilicon\` so it lands
in \`/usr/bin/set_allocator\` on the camera.

## Usage on a fresh install

\`\`\`
set_allocator cma   # rewrites bootargs with mmz= and mmz_allocator=cma
reboot
\`\`\`

Same one-shot workflow EV300 owners have been using; with this on
cv500 too, \`load_hisilicon -i\` succeeds and the full vendor module
stack (32 modules: open_osal → ... → open_acodec) loads cleanly.

## Notes

- This is the minimum unblocking fix. A follow-up could auto-run it on
  first boot if it detects \"4.9 kernel + no mmz= in cmdline\".
- It does **not** fix every config combination automatically — boards
  with non-default \`osmem\`/\`totalmem\` still need that env to be
  correct. But it makes the standard cv500 setup recipe possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)