### PR TITLE
sysupgrade: route 'neo' variant to OpenIPC/firmware repo

### DIFF
--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -84,7 +84,7 @@ download_firmware() {
 		[ ! -f "$archive" ] && die "File $archive not found"
 		gzip -d "$archive" -c | tar xf - -C /tmp && echo_c 32 "Local archive unpacked" || die "Cannot extract $archive"
 	else
-		[ "$osr" = "lite" ] || [ "$osr" = "ultimate" ] && repo=firmware
+		case "$osr" in lite|ultimate|neo) repo=firmware ;; esac
 		[ -z "$url" ] && url=$(fw_printenv -n upgrade || echo "https://github.com/OpenIPC/${repo:-builder}/releases/download/latest/openipc.$build.tgz")
 		echo "Download from $url"
 		[ "$(curl -o /dev/null -s -k -w '%{http_code}\n' "$url")" = "000" ] && die "Check your network!"


### PR DESCRIPTION
## Summary

The lite/ultimate/builder split landed in #1686 and \`neo\` didn't exist as a variant at the time. Neo artifacts (\`hi3516av300_neo\`, \`hi3516ev300_neo\`) are published to OpenIPC/firmware releases alongside lite and ultimate, but the script falls through to OpenIPC/builder for any non-lite/ultimate variant — so \`sysupgrade -k -r\` on a neo camera hits a 404-ish \"Check your network! Aborting.\" path because the neo \`.tgz\` doesn't exist under \`OpenIPC/builder\`.

## Change

Replace the trailing-\`&&\` chain with a \`case\`. Equivalent for lite/ultimate, adds neo, and future variants drop in as a single token.

\`\`\`diff
-		[ \"$osr\" = \"lite\" ] || [ \"$osr\" = \"ultimate\" ] && repo=firmware
+		case \"$osr\" in lite|ultimate|neo) repo=firmware ;; esac
\`\`\`

## Repro (before this PR)

On a hi3516av300_neo camera (\`BUILD_OPTION=neo\` in \`/etc/os-release\`):

\`\`\`
# sysupgrade -k -r -z
…
Firmware
Download from https://github.com/OpenIPC/builder/releases/download/latest/openipc.hi3516av300-nor-neo.tgz
Check your network! Aborting.
Unconditional reboot
\`\`\`

(The artifact lives at \`OpenIPC/firmware/releases/download/latest/openipc.hi3516av300-nor-neo.tgz\` — the script picked the wrong repo.)

## Test plan

- [ ] hi3516av300_neo or hi3516ev300_neo camera: \`sysupgrade -k -r -z\` resolves to \`OpenIPC/firmware\` URL and completes
- [ ] hi3516av300_lite / *_ultimate: no behaviour change (still routes to firmware)
- [ ] Other variants (e.g. fpv): still route to OpenIPC/builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)