### PR TITLE
toolchain: add hi3520dv200_lite to matrix

### DIFF
--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -28,6 +28,7 @@ jobs:
           - hi3516cv500_lite
           - hi3516ev200_lite
           - hi3519v101_lite
+          - hi3520dv200_lite
           - hi3536cv100_lite
           - hi3536dv100_lite
 


### PR DESCRIPTION
## Summary

- Adds `hi3520dv200_lite` to the `.github/workflows/toolchain.yml` platform matrix.
- Hi3520DV200 needs a unique toolchain (Cortex-A9 + VFPv3 + glibc + headers-4.9, prefix `arm-openipc-linux-gnueabi`); no other board produces the same `toolname`.
- Follow-up to #2075. Once this lands, dispatching the `toolchain` workflow will build and upload `toolchain.hisilicon-hi3520dv200.tgz`, unblocking the regular `build` workflow for this board.

## Test plan
- [ ] Manually dispatch the `toolchain` workflow on master after merge.
- [ ] Confirm `toolchain.hisilicon-hi3520dv200.tgz` shows up under the `toolchain` release.
- [ ] Re-run `build-one` for `hi3520dv200_lite` and verify it can pull the toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)