### PR TITLE
hi3520dv200: cd into modules dir before insmod in load_hisilicon

### DIFF
--- a/general/package/hisilicon-osdrv-hi3520dv200/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3520dv200/files/script/load_hisilicon
@@ -232,6 +232,8 @@ remove_ko() {
 	rmmod mmz
 }
 
+cd /lib/modules/3.0.8/hisilicon || exit 1
+
 case "$1" in
 -i) insert_ko ;;
 -r) remove_ko ;;


### PR DESCRIPTION
## Summary

\`/etc/init.d/S70vendor\` invokes \`load_hisilicon -i\` with \`PWD=/\`, but the script issues \`insmod mmz.ko\` relative to CWD — first \`insmod\` fails with \"can't insert 'mmz.ko': No such file or directory\". Mirror hi3536dv100's load_hisilicon which does \`cd /lib/modules/<kver>/hisilicon\` before \`insert_ko\`.

Caught in QEMU after PR #2082 made the rootfs mount: vendor module load aborted at the first \`mmz.ko\`.

## Test plan
- [ ] QEMU \`-M hi3520dv200\`: \`load_hisilicon -i\` loads all 30 vendor modules without errors, \`/dev/mmz_userdev\` and \`/dev/hi_*\` device nodes appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)