### PR TITLE
hisilicon-ev200 / goke-gk7205v200: IMX335 boost-1944p latency framing

### DIFF
--- a/general/package/goke-osdrv-gk7205v200/files/sensor/config/high-fps/imx335_2592x1944_45fps.ini
+++ b/general/package/goke-osdrv-gk7205v200/files/sensor/config/high-fps/imx335_2592x1944_45fps.ini
@@ -1,10 +1,31 @@
-; IMX335 boost full-frame mode, 2592x1944 @ 45 fps — full 5M readout
-; at 1.5x the stock 30 fps rate. Dispatched by Isp_SnsMode=6.
-; Useful when full sensor resolution is required at higher motion rate.
+; IMX335 boost full-frame mode, 2592x1944 — full 5M readout at the
+; sensor's boost rate (~40 fps internally vs the stock 30 fps).
+; Dispatched by Isp_FrameRate > 30 at 5M (auto-promoted inside
+; cmos_fps_set).
+;
+; This preset's value is **latency**, not wire fps. The encoder
+; pipeline caps wire-rate at ~21 fps for full-5M h.264 4 Mbps
+; regardless of video0.size (downscale doesn't help at 4:3 output).
+; But every delivered frame is fresher than stock 5M because:
+;   - sensor readout per frame is ~25 ms (vs ~33 ms stock 5M)
+;   - encoder picks a more recent frame from a 40 fps stream
+;     instead of a 30 fps stream
+; Combined: ~16 ms shorter glass-to-glass latency than stock 5M.
+; Useful for FPV / machine-vision where freshness > fps count.
+;
 ; clock=37.125MHz overrides gk's vendor blob default of 27 MHz —
 ; without it the sensor INCK is wrong and the rate is ~73% of ev's.
+;
+; To enable (output at full 4:3 native, max FoV):
+;   cli -s .isp.sensorConfig /etc/sensors/high-fps/imx335_2592x1944_45fps.ini
+;   cli -s .video0.size 2592x1944
+;   cli -s .video0.fps 45
+; killall -HUP majestic   # or reboot
+;
 ; Full per-mode notes:
 ;   openhisilicon/docs/imx335-v4-high-fps.md
+; How to measure the latency win (this claim is analytical, unverified):
+;   openhisilicon/docs/sensor-pipeline-latency-metering.md
 [sensor]
 Sensor_type=stSnsImx335Obj
 Mode=WDR_MODE_NONE

--- a/general/package/hisilicon-osdrv-hi3516ev200/files/sensor/config/high-fps/imx335_2592x1944_45fps.ini
+++ b/general/package/hisilicon-osdrv-hi3516ev200/files/sensor/config/high-fps/imx335_2592x1944_45fps.ini
@@ -1,8 +1,28 @@
-; IMX335 boost full-frame mode, 2592x1944 @ 45 fps — full 5M readout
-; at 1.5x the stock 30 fps rate. Dispatched by Isp_SnsMode=6.
-; Useful when full sensor resolution is required at higher motion rate.
+; IMX335 boost full-frame mode, 2592x1944 — full 5M readout at the
+; sensor's boost rate (~40 fps internally vs the stock 30 fps).
+; Dispatched by Isp_FrameRate > 30 at 5M (auto-promoted inside
+; cmos_fps_set).
+;
+; This preset's value is **latency**, not wire fps. The encoder
+; pipeline caps wire-rate at ~21 fps for full-5M h.264 4 Mbps
+; regardless of video0.size (downscale doesn't help at 4:3 output).
+; But every delivered frame is fresher than stock 5M because:
+;   - sensor readout per frame is ~25 ms (vs ~33 ms stock 5M)
+;   - encoder picks a more recent frame from a 40 fps stream
+;     instead of a 30 fps stream
+; Combined: ~16 ms shorter glass-to-glass latency than stock 5M.
+; Useful for FPV / machine-vision where freshness > fps count.
+;
+; To enable (output at full 4:3 native, max FoV):
+;   cli -s .isp.sensorConfig /etc/sensors/high-fps/imx335_2592x1944_45fps.ini
+;   cli -s .video0.size 2592x1944
+;   cli -s .video0.fps 45
+; killall -HUP majestic   # or reboot
+;
 ; Full per-mode notes:
 ;   openhisilicon/docs/imx335-v4-high-fps.md
+; How to measure the latency win (this claim is analytical, unverified):
+;   openhisilicon/docs/sensor-pipeline-latency-metering.md
 [sensor]
 Sensor_type=stSnsImx335Obj
 Mode=WDR_MODE_NONE


### PR DESCRIPTION
## Summary

Rewrites the IMX335 boost-1944p INI header comment to describe what the mode is actually for.

The encoder caps wire-rate at ~21 fps for full-5M h.264 4 Mbps regardless of `video0.size`, so the wire-fps number alone makes this preset look pointless next to stock 5M. The real benefit is **glass-to-glass latency**:
- sensor readout per frame: 25 ms (vs 33 ms stock 5M)
- encoder picks from a 40 fps stream instead of 30 fps (~4 ms fresher on average)
- combined: ~16 ms shorter glass-to-glass latency at identical wire fps

That 16 ms claim is **analytical, not measured**. Adds a link from the INI header to the new methodology spec for verifying it (in flight at OpenIPC/openhisilicon#103) so the next person can run actual numbers.

Also expands the header with the three-line enable recipe (`sensorConfig` + `video0.size=2592x1944` + `video0.fps=45`) so users don't accidentally downscale to 1920×1080 and get a 4:3-cropped image.

Companion to OpenIPC/openhisilicon#103. Independent of it — INI just adds a comment-only link.

No register/INI value changes. Header text only.

## Test plan

- [ ] Files install at `/etc/sensors/high-fps/imx335_2592x1944_45fps.ini` on both ev200 and gk7205v200 firmware images (no install-rule changes; pure file edit)
- [ ] cli/majestic parses the INI unchanged (header is `;`-comment-only; no register/section edits)
- [ ] Boost preset still delivers identical sensor + encoder behavior as PR #2090

🤖 Generated with [Claude Code](https://claude.com/claude-code)