### PR TITLE
gk7205v200: modprobe open_hwrng in load_goke (PR #2058 follow-up)

### DIFF
--- a/general/package/goke-osdrv-gk7205v200/files/script/load_goke
+++ b/general/package/goke-osdrv-gk7205v200/files/script/load_goke
@@ -329,6 +329,14 @@ for arg in $@; do
 	esac
 done
 #######################parse arg end########################
+
+# HWRNG: load before any conditional exit (os_mem mismatch, sensor
+# probe failure, etc.) so entropy is always available to userspace
+# daemons (majestic, dropbear, openssl) that block on getrandom().
+if [ "$b_arg_insmod" = "1" ]; then
+    modprobe open_hwrng 2>/dev/null
+fi
+
 if [ $os_mem_size -ge $mem_total ]; then
 	echo "[err] os_mem[$os_mem_size], over total_mem[$mem_total]"
 	exit


### PR DESCRIPTION
## Summary

- PR #2058 added an early `modprobe open_hwrng` to all five `load_hisilicon` variants (cv200/cv300/cv500/3519v101/ev200) so userspace daemons (majestic, dropbear, openssl) that block on `getrandom()` always have entropy at boot.
- The `.mk` side of that PR already ships `open_hwrng.ko` to `/lib/modules/<kver>/extra/` on the V4 Goke build — see `general/package/hisilicon-opensdk/hisilicon-opensdk.mk:445-451`. But `load_goke` was never updated, so the module is installed and not loaded.
- Symptom: `ssh root@openipc-gk7205v200.dlab.doty.ru` hangs after cold reboot. `/proc/sys/kernel/random/entropy_avail` stays at 0 until enough boot-time noise accrues; dropbear's RSA host-key generation / session-key derivation block on `getrandom()` in the meantime.
- This PR adds the same block PR #2058 placed in the ev200 script, in the same position (right after `#parse arg end#`, before the `os_mem_size >= mem_total` exit gate), to `general/package/goke-osdrv-gk7205v200/files/script/load_goke`. No `.mk` changes needed — `modprobe` finds `open_hwrng.ko` in `extra/` via `modules.dep`.

Scope: gk7205v200 only. `goke-osdrv-gk7205v500` and `goke-osdrv-gk710x` don't depend on `hisilicon-opensdk` and don't ship `open_hwrng.ko`, so the same edit would be a no-op there and requires separate upstream work.

## Test plan

- [ ] `make BOARD=gk7205v200_lite` succeeds
- [ ] After flash + cold reboot on a gk7205v200 device:
  - `lsmod | grep open_hwrng` shows the module loaded
  - `dmesg | grep -i hwrng` shows TRNG registration
  - `cat /proc/sys/kernel/random/entropy_avail` is non-zero immediately at login
  - `dd if=/dev/random bs=32 count=1 | xxd` returns instantly
- [ ] `ssh root@openipc-gk7205v200.dlab.doty.ru` connects without the post-cold-boot hang

## Pairs with

- #2058 — the original entropy fix for HiSilicon platforms; this PR completes the V4 fall-through it referenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)