### PR TITLE
hisilicon-ev200 / goke-gk7205v200: IMX307 high-fps presets

### DIFF
--- a/general/package/goke-osdrv-gk7205v200/files/sensor/config/high-fps/imx307_1920x1080_60fps.ini
+++ b/general/package/goke-osdrv-gk7205v200/files/sensor/config/high-fps/imx307_1920x1080_60fps.ini
@@ -1,0 +1,43 @@
+; IMX307 boost-rate full-frame 1080p mode at 60 fps internally.
+; Auto-promoted by Isp_FrameRate > 30 (cmos_set_image_mode dispatch
+; in sony_imx307_2L driver). Wire fps is encoder-bound at ~44 fps
+; for h.265 4 Mbps 1080p; the value of this preset is **latency**,
+; not wire fps — sensor readout drops from ~33 ms to ~16.7 ms,
+; and the encoder picks frames from a 60 fps stream instead of 30.
+;
+; To enable:
+;   cli -s .isp.sensorConfig /etc/sensors/high-fps/imx307_1920x1080_60fps.ini
+;   cli -s .video0.size 1920x1080
+;   cli -s .video0.fps 60
+;   cli -s .video0.codec h265   ; h264 regresses to ~20 fps wire at 1080p60
+;   killall -HUP majestic
+;
+; Requires majestic with widgetii/majestic#77 merged (V200 chip_id fps
+; clamp removed) and openhisilicon with the IMX307 high-fps modes.
+[sensor]
+Sensor_type=stSnsImx307_2l_Obj
+Mode=WDR_MODE_NONE
+DllFile=libsns_imx307_2l.so
+
+[mode]
+input_mode=INPUT_MODE_MIPI
+raw_bitness=10
+clock=37.125MHz
+
+[mipi]
+data_type=DATA_TYPE_RAW_10BIT
+lane_id=0|2|-1|-1|-1|-1|-1|-1|
+
+[isp_image]
+Isp_FrameRate=60
+Isp_Bayer=BAYER_RGGB
+Isp_W=1920
+Isp_H=1080
+
+[vi_dev]
+Input_mod=VI_MODE_MIPI
+DevRect_w=1920
+DevRect_h=1080
+DevRect_x=0
+DevRect_y=0
+FullLinesStd=1125

--- a/general/package/goke-osdrv-gk7205v200/files/sensor/config/high-fps/imx307_368x304_200fps.ini
+++ b/general/package/goke-osdrv-gk7205v200/files/sensor/config/high-fps/imx307_368x304_200fps.ini
@@ -1,0 +1,39 @@
+; IMX307 flex window-crop @ 368x304 (smallest crop dimensions allowed
+; by datasheet — WINWH >= 368 mult-of-4, WINWV >= 304). Sensor and
+; encoder deliver 200 fps wire at h.265 4 Mbps; encoder ceiling
+; band is ~200-219 fps (sweep saturated at 200 in our test).
+; Selected by Isp_SnsMode=4 (sony_imx307_2L driver).
+;
+; To enable:
+;   cli -s .isp.sensorConfig /etc/sensors/high-fps/imx307_368x304_200fps.ini
+;   cli -s .video0.size 368x304
+;   cli -s .video0.fps 200
+;   killall -HUP majestic
+[sensor]
+Sensor_type=stSnsImx307_2l_Obj
+Mode=WDR_MODE_NONE
+DllFile=libsns_imx307_2l.so
+
+[mode]
+input_mode=INPUT_MODE_MIPI
+raw_bitness=10
+clock=37.125MHz
+
+[mipi]
+data_type=DATA_TYPE_RAW_10BIT
+lane_id=0|2|-1|-1|-1|-1|-1|-1|
+
+[isp_image]
+Isp_FrameRate=200
+Isp_Bayer=BAYER_RGGB
+Isp_SnsMode=4
+Isp_W=368
+Isp_H=304
+
+[vi_dev]
+Input_mod=VI_MODE_MIPI
+DevRect_w=368
+DevRect_h=304
+DevRect_x=0
+DevRect_y=0
+FullLinesStd=340

--- a/general/package/goke-osdrv-gk7205v200/files/sensor/config/high-fps/imx307_640x480_130fps.ini
+++ b/general/package/goke-osdrv-gk7205v200/files/sensor/config/high-fps/imx307_640x480_130fps.ini
@@ -1,0 +1,39 @@
+; IMX307 flex window-crop @ VGA 640x480 (WINMODE=4h). Sensor and
+; encoder both deliver 130 fps wire at h.265 4 Mbps. The crop window
+; is centred in the 1944x1097 active area, programmed via WINPH/WINPV/
+; WINWH/WINWV from Isp_W/Isp_H. Selected by Isp_SnsMode=4
+; (sony_imx307_2L driver).
+;
+; To enable:
+;   cli -s .isp.sensorConfig /etc/sensors/high-fps/imx307_640x480_130fps.ini
+;   cli -s .video0.size 640x480
+;   cli -s .video0.fps 130
+;   killall -HUP majestic
+[sensor]
+Sensor_type=stSnsImx307_2l_Obj
+Mode=WDR_MODE_NONE
+DllFile=libsns_imx307_2l.so
+
+[mode]
+input_mode=INPUT_MODE_MIPI
+raw_bitness=10
+clock=37.125MHz
+
+[mipi]
+data_type=DATA_TYPE_RAW_10BIT
+lane_id=0|2|-1|-1|-1|-1|-1|-1|
+
+[isp_image]
+Isp_FrameRate=130
+Isp_Bayer=BAYER_RGGB
+Isp_SnsMode=4
+Isp_W=640
+Isp_H=480
+
+[vi_dev]
+Input_mod=VI_MODE_MIPI
+DevRect_w=640
+DevRect_h=480
+DevRect_x=0
+DevRect_y=0
+FullLinesStd=520

--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = 8b5e47f
+HISILICON_OPENSDK_VERSION = 5b1aa42
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE

--- a/general/package/hisilicon-osdrv-hi3516ev200/files/sensor/config/high-fps/imx307_1280x720_60fps.ini
+++ b/general/package/hisilicon-osdrv-hi3516ev200/files/sensor/config/high-fps/imx307_1280x720_60fps.ini
@@ -16,7 +16,6 @@ DllFile=libsns_imx307_2l.so
 [mode]
 input_mode=INPUT_MODE_MIPI
 raw_bitness=10
-clock=37.125MHz
 
 [mipi]
 data_type=DATA_TYPE_RAW_10BIT

--- a/general/package/hisilicon-osdrv-hi3516ev200/files/sensor/config/high-fps/imx307_1920x1080_60fps.ini
+++ b/general/package/hisilicon-osdrv-hi3516ev200/files/sensor/config/high-fps/imx307_1920x1080_60fps.ini
@@ -1,0 +1,42 @@
+; IMX307 boost-rate full-frame 1080p mode at 60 fps internally.
+; Auto-promoted by Isp_FrameRate > 30 (cmos_set_image_mode dispatch
+; in sony_imx307_2L driver). Wire fps is encoder-bound at ~44 fps
+; for h.265 4 Mbps 1080p; the value of this preset is **latency**,
+; not wire fps — sensor readout drops from ~33 ms to ~16.7 ms,
+; and the encoder picks frames from a 60 fps stream instead of 30.
+;
+; To enable:
+;   cli -s .isp.sensorConfig /etc/sensors/high-fps/imx307_1920x1080_60fps.ini
+;   cli -s .video0.size 1920x1080
+;   cli -s .video0.fps 60
+;   cli -s .video0.codec h265   ; h264 regresses to ~20 fps wire at 1080p60
+;   killall -HUP majestic
+;
+; Requires majestic with widgetii/majestic#77 merged (V200 chip_id fps
+; clamp removed) and openhisilicon with the IMX307 high-fps modes.
+[sensor]
+Sensor_type=stSnsImx307_2l_Obj
+Mode=WDR_MODE_NONE
+DllFile=libsns_imx307_2l.so
+
+[mode]
+input_mode=INPUT_MODE_MIPI
+raw_bitness=10
+
+[mipi]
+data_type=DATA_TYPE_RAW_10BIT
+lane_id=0|2|-1|-1|-1|-1|-1|-1|
+
+[isp_image]
+Isp_FrameRate=60
+Isp_Bayer=BAYER_RGGB
+Isp_W=1920
+Isp_H=1080
+
+[vi_dev]
+Input_mod=VI_MODE_MIPI
+DevRect_w=1920
+DevRect_h=1080
+DevRect_x=0
+DevRect_y=0
+FullLinesStd=1125

--- a/general/package/hisilicon-osdrv-hi3516ev200/files/sensor/config/high-fps/imx307_368x304_200fps.ini
+++ b/general/package/hisilicon-osdrv-hi3516ev200/files/sensor/config/high-fps/imx307_368x304_200fps.ini
@@ -1,0 +1,38 @@
+; IMX307 flex window-crop @ 368x304 (smallest crop dimensions allowed
+; by datasheet — WINWH >= 368 mult-of-4, WINWV >= 304). Sensor and
+; encoder deliver 200 fps wire at h.265 4 Mbps; encoder ceiling
+; band is ~200-219 fps (sweep saturated at 200 in our test).
+; Selected by Isp_SnsMode=4 (sony_imx307_2L driver).
+;
+; To enable:
+;   cli -s .isp.sensorConfig /etc/sensors/high-fps/imx307_368x304_200fps.ini
+;   cli -s .video0.size 368x304
+;   cli -s .video0.fps 200
+;   killall -HUP majestic
+[sensor]
+Sensor_type=stSnsImx307_2l_Obj
+Mode=WDR_MODE_NONE
+DllFile=libsns_imx307_2l.so
+
+[mode]
+input_mode=INPUT_MODE_MIPI
+raw_bitness=10
+
+[mipi]
+data_type=DATA_TYPE_RAW_10BIT
+lane_id=0|2|-1|-1|-1|-1|-1|-1|
+
+[isp_image]
+Isp_FrameRate=200
+Isp_Bayer=BAYER_RGGB
+Isp_SnsMode=4
+Isp_W=368
+Isp_H=304
+
+[vi_dev]
+Input_mod=VI_MODE_MIPI
+DevRect_w=368
+DevRect_h=304
+DevRect_x=0
+DevRect_y=0
+FullLinesStd=340

--- a/general/package/hisilicon-osdrv-hi3516ev200/files/sensor/config/high-fps/imx307_640x480_130fps.ini
+++ b/general/package/hisilicon-osdrv-hi3516ev200/files/sensor/config/high-fps/imx307_640x480_130fps.ini
@@ -1,0 +1,38 @@
+; IMX307 flex window-crop @ VGA 640x480 (WINMODE=4h). Sensor and
+; encoder both deliver 130 fps wire at h.265 4 Mbps. The crop window
+; is centred in the 1944x1097 active area, programmed via WINPH/WINPV/
+; WINWH/WINWV from Isp_W/Isp_H. Selected by Isp_SnsMode=4
+; (sony_imx307_2L driver).
+;
+; To enable:
+;   cli -s .isp.sensorConfig /etc/sensors/high-fps/imx307_640x480_130fps.ini
+;   cli -s .video0.size 640x480
+;   cli -s .video0.fps 130
+;   killall -HUP majestic
+[sensor]
+Sensor_type=stSnsImx307_2l_Obj
+Mode=WDR_MODE_NONE
+DllFile=libsns_imx307_2l.so
+
+[mode]
+input_mode=INPUT_MODE_MIPI
+raw_bitness=10
+
+[mipi]
+data_type=DATA_TYPE_RAW_10BIT
+lane_id=0|2|-1|-1|-1|-1|-1|-1|
+
+[isp_image]
+Isp_FrameRate=130
+Isp_Bayer=BAYER_RGGB
+Isp_SnsMode=4
+Isp_W=640
+Isp_H=480
+
+[vi_dev]
+Input_mod=VI_MODE_MIPI
+DevRect_w=640
+DevRect_h=480
+DevRect_x=0
+DevRect_y=0
+FullLinesStd=520


### PR DESCRIPTION
## Summary

Companion to [OpenIPC/openhisilicon#104](https://github.com/OpenIPC/openhisilicon/pull/104) (merged as `5b1aa42`). Ships four IMX307 high-fps INI presets under `/etc/sensors/high-fps/` for both V4 osdrv packages — `hisilicon-osdrv-hi3516ev200` and `goke-osdrv-gk7205v200` — mirroring the existing IMX335 high-fps preset layout.

Bumps `HISILICON_OPENSDK_VERSION` from `8b5e47f` to `5b1aa42` to pull in the IMX307 `Isp_SnsMode` flex-mode dispatch added by openhisilicon#104.

## Presets

| Preset | Sensor mode | Selected by | Tested wire fps (h.265 @ 4 Mbps) |
|---|---|---|---|
| `imx307_1920x1080_60fps.ini` | 1080p60 boost (FRSEL=1h auto-promotion) | `Isp_FrameRate=60` | **44 fps** — encoder-bound at 1080p; real benefit is **latency** (sensor readout 33→16.7 ms) |
| `imx307_1280x720_60fps.ini` | 720p sub-readout (WINMODE=1h) | `Isp_SnsMode=1` | **60 fps** — sensor matches wire |
| `imx307_640x480_130fps.ini` | VGA flex window-crop (WINMODE=4h) | `Isp_SnsMode=4 + Isp_W/Isp_H` | **130 fps** — encoder ceiling |
| `imx307_368x304_200fps.ini` | smallest datasheet-allowed flex crop | `Isp_SnsMode=4 + Isp_W/Isp_H` | **200 fps** — encoder ceiling band 200-219 |

All four follow the existing IMX335 high-fps INI structure: minimal `[sensor]` / `[mode]` / `[mipi]` / `[isp_image]` / `[vi_dev]` sections, no vendor boilerplate.

## Verified on real hardware

`openipc-gk7205v200.dlab.doty.ru` board, `sony_imx307_2L` driver loaded with openhisilicon master after #104. Wire fps measured from `/proc/umap/venc` SEND counter delta over a 5 s window after a 6 s warm-up. ISP `IntRat` confirms sensor delivers exactly the requested rate at each measurement; encoder is the wire-fps ceiling above sub-1080p modes.

ev200 (Hisilicon-side, same silicon family) expected to behave identically — not separately verified on the Hisi board (re-uses the shared sensor driver source). 4-lane variant (`sony_imx307`) not exposed by these presets (only `sony_imx307_2L` is shipped today); upstream driver carries the matching dispatch but is untested.

## gk7205v200 specifics

The gk-side INIs carry the `clock=37.125MHz` override in `[mode]` — same as the IMX335 high-fps gk presets. Without it the gk vendor blob defaults to 27 MHz INCK and the delivered rate is ~73% of nominal.

## Notable INI update

`imx307_1280x720_60fps.ini` on the gk-side is **replaced** (not merely modified). The prior file was a bloated stock-style INI with vendor boilerplate that never engaged the WINMODE=1h hardware path; majestic capped it at 45 fps via the V200 clamp and the sensor ran at 30 fps internally with VPSS downscale-from-1080p. The new file uses `Isp_SnsMode=1` to dispatch to the dedicated 720p sub-readout path landed in openhisilicon#104.

## Dependency on majestic

Requires majestic >= [widgetii/majestic#77](https://github.com/widgetii/majestic/pull/77) (V200 chip_id 45 fps clamp removed, already merged on master). Without that, 1080p60 + any preset with `Isp_FrameRate > 45` silently caps at 45 fps on V200 silicon — same gotcha as the existing IMX335 high-fps presets had before #77.

## Test plan

- [ ] CI build green (firmware builds for hi3516ev200_lite, gk7205v200_lite, hi3516ev300_neo, gk7205v300_lite)
- [x] Verified IMX307 720p60 / VGA130 / CIF200 / 1080p60 wire fps on gk7205v200 (sweep results in commit message)
- [ ] Smoke-test on ev200 dev board (same silicon, expected identical)
- [ ] Backwards-compat: existing stock IMX307 1080p30 path remains the default; users explicitly opt in to high-fps via `cli -s .isp.sensorConfig /etc/sensors/high-fps/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)