### PR TITLE
hi3516cv300: load_hisilicon — insmod hi_osal.ko in CMA branch too (closes #2061)

### DIFF
--- a/general/package/hisilicon-osdrv-hi3516cv300/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516cv300/files/script/load_hisilicon
@@ -57,7 +57,7 @@ insert_osal()
 	if [ -z "$MMZ" ]; then
 		insmod hi_osal.ko anony=1 mmz_allocator=hisi mmz=anonymous,0,$mmz_start,$mmz_size || report_error
 	else
-		insmod cma_osal.ko anony=1 mmz_allocator=cma mmz=$MMZ || report_error
+		insmod hi_osal.ko anony=1 mmz_allocator=cma mmz=$MMZ || report_error
 	fi
 }
 


### PR DESCRIPTION
## Summary

\`insert_osal()\` picks between the hisi-allocator and the cma-allocator init paths based on whether the kernel cmdline passes \`mmz=\`. Both paths are served by the same cv300 OSAL module (\`open_osal.ko\` renamed to \`hi_osal.ko\` on install by hisilicon-opensdk; \`mmz_allocator=\` is a module parameter, not a separate module). The script tried to insmod a \`cma_osal.ko\` that no recipe builds:

\`\`\`
insmod: can't insert 'cma_osal.ko': No such file or directory
******* Error: There's something wrong, please check! *****
\`\`\`

Hidden until #2059 / #2060 because \`load_hisilicon\` used to bail at the \`os_mem=\` guard before ever reaching \`insert_osal\`. Post-#2060 the guard is correct and the cma branch runs whenever the bootloader passes \`mmz=…\` (qemu-hisilicon, modern U-Boot setups) — zero modules load, majestic comes up with no \`/dev/mmz\`.

This PR is the 1-line "Option 1" fix from the issue. Mirrors how cv500's \`load_hisilicon\` already calls the same module on both branches with just the \`mmz_allocator=\` arg differing.

Closes #2061.

## Test plan

- [x] cv300 OSAL module accepts \`mmz_allocator=cma\` runtime — already exercised by OpenIPC/openhisilicon#73 init path
- [ ] qemu-boot \`-M hi3516cv300\` passes lsmod assertion (need a nightly rebuild to pull this fix); the cv300 row in openhisilicon CI is currently \`allow-failure: true\` for exactly this bug
- [ ] Follow-up openhisilicon PR to drop the \`allow-failure: true\` marker on cv300 (and verify cv500 row can lose its marker too)