### PR TITLE
glibc-compat: add static-link mmap shim (32-bit off_t for vendor V2 blobs)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,10 @@ define BUNDLE_SDK
 	OSDRV_DIR=$(PWD)/general/package/$(BR2_OPENIPC_SOC_VENDOR)-osdrv-$(BR2_OPENIPC_SOC_FAMILY)/files; \
 	MPP_HEADERS=$(PWD)/general/package/hisilicon-osdrv-hi3516cv100/files/include; \
 	SDK_TGZ=$$(find $(TARGET)/images -name '*_sdk-buildroot.tar.gz' | head -1); \
-	COMPAT_SRC=$(PWD)/general/package/uclibc-compat/src/uclibc-compat.c; \
+	UCLIBC_COMPAT_SRC=$(PWD)/general/package/uclibc-compat/src/uclibc-compat.c; \
+	UCLIBC_COMPAT_STATIC=$(PWD)/general/package/uclibc-compat/src/uclibc-compat-static.c; \
+	GLIBC_COMPAT_SRC=$(PWD)/general/package/glibc-compat/src/glibc-compat.c; \
+	GLIBC_COMPAT_STATIC=$(PWD)/general/package/glibc-compat/src/glibc-compat-static.c; \
 	SDK_CC=$$(ls $(TARGET)/host/bin/*-gcc 2>/dev/null | head -1); \
 	if [ -d "$$OSDRV_DIR" ] && [ -n "$$SDK_TGZ" ]; then \
 		SDK_TOP=$$(tar tzf $$SDK_TGZ | head -1 | cut -d/ -f1); \
@@ -129,19 +132,33 @@ define BUNDLE_SDK
 			mkdir -p /tmp/sdk-overlay/$$SDK_TOP/sdk/include; \
 			cp -a $$MPP_HEADERS/. /tmp/sdk-overlay/$$SDK_TOP/sdk/include/; \
 		fi; \
-		if [ -f "$$COMPAT_SRC" ] && [ -n "$$SDK_CC" ]; then \
-			$$SDK_CC -shared -Wall -O2 -fPIC \
-				-o /tmp/sdk-overlay/$$SDK_TOP/sdk/lib/libuclibc-compat.so \
-				$$COMPAT_SRC; \
-			COMPAT_STATIC=$(PWD)/general/package/uclibc-compat/src/uclibc-compat-static.c; \
-			if [ -f "$$COMPAT_STATIC" ]; then \
-				SDK_AR=$$(echo $$SDK_CC | sed 's/-gcc$$/-ar/'); \
+		if [ -n "$$SDK_CC" ]; then \
+			SDK_AR=$$(echo $$SDK_CC | sed 's/-gcc$$/-ar/'); \
+			if [ -f "$$UCLIBC_COMPAT_SRC" ]; then \
+				$$SDK_CC -shared -Wall -O2 -fPIC \
+					-o /tmp/sdk-overlay/$$SDK_TOP/sdk/lib/libuclibc-compat.so \
+					$$UCLIBC_COMPAT_SRC; \
+			fi; \
+			if [ -f "$$UCLIBC_COMPAT_STATIC" ]; then \
 				$$SDK_CC -Wall -O2 -fPIC -c \
 					-o /tmp/sdk-overlay/$$SDK_TOP/sdk/lib/uclibc-compat-static.o \
-					$$COMPAT_STATIC; \
+					$$UCLIBC_COMPAT_STATIC; \
 				$$SDK_AR rcs /tmp/sdk-overlay/$$SDK_TOP/sdk/lib/libuclibc-compat-static.a \
 					/tmp/sdk-overlay/$$SDK_TOP/sdk/lib/uclibc-compat-static.o; \
 				rm -f /tmp/sdk-overlay/$$SDK_TOP/sdk/lib/uclibc-compat-static.o; \
+			fi; \
+			if [ -f "$$GLIBC_COMPAT_SRC" ]; then \
+				$$SDK_CC -shared -Wall -O2 -fPIC \
+					-o /tmp/sdk-overlay/$$SDK_TOP/sdk/lib/libglibc-compat.so \
+					$$GLIBC_COMPAT_SRC; \
+			fi; \
+			if [ -f "$$GLIBC_COMPAT_STATIC" ]; then \
+				$$SDK_CC -Wall -O2 -fPIC -c \
+					-o /tmp/sdk-overlay/$$SDK_TOP/sdk/lib/glibc-compat-static.o \
+					$$GLIBC_COMPAT_STATIC; \
+				$$SDK_AR rcs /tmp/sdk-overlay/$$SDK_TOP/sdk/lib/libglibc-compat-static.a \
+					/tmp/sdk-overlay/$$SDK_TOP/sdk/lib/glibc-compat-static.o; \
+				rm -f /tmp/sdk-overlay/$$SDK_TOP/sdk/lib/glibc-compat-static.o; \
 			fi; \
 		fi; \
 		gunzip $$SDK_TGZ && \

--- a/general/package/glibc-compat/glibc-compat.mk
+++ b/general/package/glibc-compat/glibc-compat.mk
@@ -7,6 +7,7 @@
 GLIBC_COMPAT_VERSION =
 GLIBC_COMPAT_SITE =
 GLIBC_COMPAT_LICENSE = MIT
+GLIBC_COMPAT_INSTALL_STAGING = YES
 
 define GLIBC_COMPAT_BUILD_CMDS
 	$(MAKE) $(TARGET_CONFIGURE_OPTS) -C $(GLIBC_COMPAT_PKGDIR)/src all
@@ -17,6 +18,11 @@ endef
 # pointing all four names at it is enough for the loader to satisfy NEEDED
 # entries; the libglibc-compat.so providing missing symbols is pulled in by
 # the LD_PRELOAD-equivalent NEEDED added to vendor wrapper scripts.
+define GLIBC_COMPAT_INSTALL_STAGING_CMDS
+	$(INSTALL) -D -m 0644 $(GLIBC_COMPAT_PKGDIR)/src/libglibc-compat-static.a \
+		$(STAGING_DIR)/usr/lib/libglibc-compat-static.a
+endef
+
 define GLIBC_COMPAT_INSTALL_TARGET_CMDS
 	$(INSTALL) -D -m 0755 $(GLIBC_COMPAT_PKGDIR)/src/libglibc-compat.so \
 		$(TARGET_DIR)/usr/lib/libglibc-compat.so

--- a/general/package/glibc-compat/src/Makefile
+++ b/general/package/glibc-compat/src/Makefile
@@ -1,10 +1,16 @@
 CFLAGS ?= -O2
 CFLAGS += -Wall -fPIC
 
-all: libglibc-compat.so
+all: libglibc-compat.so libglibc-compat-static.a
 
 libglibc-compat.so: glibc-compat.c
 	$(CC) $(CFLAGS) -shared -o $@ $^
 
+libglibc-compat-static.a: glibc-compat-static.o
+	$(AR) rcs $@ $^
+
+glibc-compat-static.o: glibc-compat-static.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
 clean:
-	rm -f *.o *.so
+	rm -f *.o *.so *.a

--- a/general/package/glibc-compat/src/glibc-compat-static.c
+++ b/general/package/glibc-compat/src/glibc-compat-static.c
@@ -1,0 +1,41 @@
+/*
+ * glibc-compat-static.c -- ABI wrappers that MUST be statically linked
+ *
+ * Vendor glibc binaries built against 32-bit off_t (no _FILE_OFFSET_BITS=64,
+ * typical of 2014-era SDKs like Hi3520DV200's MPP) call mmap() with a
+ * single-register 32-bit offset arg. musl's mmap() expects 64-bit off_t —
+ * when the vendor .so binds against musl, the kernel sees uninitialised
+ * stack as the high half of pgoff and rejects with EINVAL. Symptom on
+ * hi3520dv200: VENC CreateChn returns 0xa007800c (EN_ERR_VENC_NOMEM)
+ * because libmpi can't mmap the model_buf via /dev/venc.
+ *
+ * This function MUST be linked statically into the EXECUTABLE
+ * (-lglibc-compat-static) so it appears in the executable's symbol
+ * table. The dynamic linker then resolves vendor .so imports from the
+ * executable BEFORE musl. Putting it in a shared library would override
+ * musl's mmap process-wide, breaking musl's own internal mmap callers
+ * (malloc, dlopen, ...).
+ *
+ * Pattern mirrors OpenIPC/firmware#2000 (uclibc-compat-static for the
+ * hi3516cv100 vendor blobs).
+ */
+
+#define _GNU_SOURCE
+#include <stdint.h>
+#include <stddef.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+
+#ifndef SYS_mmap2
+#define SYS_mmap2 192
+#endif
+
+void *mmap(void *addr, size_t len, int prot, int flags, int fd, uint32_t offset)
+{
+	return (void *)syscall(SYS_mmap2, addr, len, prot, flags, fd, offset >> 12);
+}
+
+void *mmap64(void *addr, size_t len, int prot, int flags, int fd, uint32_t offset)
+{
+	return (void *)syscall(SYS_mmap2, addr, len, prot, flags, fd, offset >> 12);
+}


### PR DESCRIPTION
## Summary

Mirror of [#2000](https://github.com/OpenIPC/firmware/pull/2000) but for **glibc** vendor binaries (V2 SoCs like hi3520dv200).

Vendor glibc binaries from the V2 era (\`libmpi.so\` etc.) were built without \`_FILE_OFFSET_BITS=64\` — their \`mmap()\` import takes a 32-bit \`off_t\`. musl's \`mmap()\` exports 64-bit \`off_t\`. When libmpi dynamic-links against musl, the high 32 bits of the offset come from uninitialised stack; the kernel sees a garbage pgoff and rejects with \`EINVAL\`.

**Symptom on hi3520dv200**: every \`HI_MPI_VENC_CreateChn\` returns \`0xa007800c\` (\`EN_ERR_VENC_NOMEM\`) because libmpi can't mmap the model_buf via \`/dev/venc\`. Confirmed via an \`LD_PRELOAD\` trace shim that wraps \`mmap()\`:

\`\`\`
mmap(fd=28[/dev/venc], off=0x402b65d8, len=229376) = -1  errno=22 EINVAL
mmap err,page addr:-1896943616 u32PagePhy size:114688
VENC: CreateChn(0) 0xa007800c
\`\`\`

\`0x402b65d8\` is a userspace VA (lower 12 bits constant \`0x5d8\`, upper bits vary between runs with ASLR) — pure stack garbage. The vendor's printed \"page addr / u32PagePhy size\" values are libmpi-internal state, not the real mmap args, so the message is misleading.

## Fix

Mirror PR #2000's pattern, scoped to glibc vendor blobs:

- **\`glibc-compat/src/glibc-compat-static.c\`**: new file, \`mmap()\` / \`mmap64()\` wrappers that take \`uint32_t offset\` and go straight to \`SYS_mmap2\` with \`offset >> 12\` as pgoff, bypassing musl's libc wrapper entirely.
- **\`glibc-compat/src/Makefile\`**: build both \`libglibc-compat.so\` (the existing \`__xstat\`/\`__isoc99_sscanf\` shim) and the new \`libglibc-compat-static.a\`.
- **\`glibc-compat/glibc-compat.mk\`**: \`GLIBC_COMPAT_INSTALL_STAGING = YES\` + \`INSTALL_STAGING_CMDS\` so dependent packages can link \`-lglibc-compat-static\`.
- **\`Makefile\` (\`BUNDLE_SDK\`)**: produce \`libglibc-compat.so\` and \`libglibc-compat-static.a\` in the published toolchain SDK tarball next to the existing uclibc-compat ones.

The wrapper **must** be statically linked into the consumer executable. Putting it in a shared library would override musl's mmap process-wide and break musl's own internal callers (malloc, dlopen, …) — that's exactly the bug PR #2000 fixed for uclibc-compat.

## Why static linking works

The dynamic linker resolves an undefined import like \`mmap\` from libmpi.so by walking the global symbol scope: the executable first, then \`DT_NEEDED\` libraries in order. With \`-Wl,--export-dynamic-symbol=mmap\` on the executable (or just having the symbol from a static lib that gets pulled in via reference), the executable's \`mmap\` enters its \`.dynsym\` and libmpi binds against it instead of musl. musl's own internal mmap calls still bind locally because musl uses internal versions / direct syscalls and isn't subject to symbol interposition for its own callers.

## Test plan

- [x] \`make BOARD=hi3520dv200_lite\` builds clean.
- [x] \`output-hi3520dv200/per-package/glibc-compat/host/<triplet>/sysroot/usr/lib/libglibc-compat-static.a\` exists (staging install works).
- [x] Local test: consumer app (the dvr_home demo at \`~/hifb-demo\`) with the mmap shim statically linked + \`-Wl,--export-dynamic-symbol=mmap\` makes \`HI_MPI_VENC_CreateChn\` succeed on all 4 channels. Trace shim now shows the syscall reaching the kernel with a valid pgoff and returning a valid mapping.
- [ ] CI: SDK build matrix for hi3520dv200_lite (will be wired in a follow-up — currently absent because hi3520dv200 had no opensdk wiring until #2109).
- [ ] Cross-platform regression check: cv100/ev200/cv500 unaffected (BUNDLE_SDK now also writes libglibc-compat.{so,a} but those families don't link against it).

Refs: #1992 (toolchain ABI audit), #1993 (cv100 stat shim), #2000 (cv100 static-link split), #2109 (hi3520dv200 opensdk wiring that built on top of glibc-compat).