### PR TITLE
ci/manifest: pass --repo to gh so script doesn't need cwd .git

### DIFF
--- a/.github/scripts/enrich_manifest.py
+++ b/.github/scripts/enrich_manifest.py
@@ -31,7 +31,11 @@ ASSET_RE = re.compile(r"^openipc\.([^.]+)-(nor|nand)-(lite|ultimate|neo)\.tgz$")
 
 
 def gh(*args: str) -> str:
-    return subprocess.check_output(["gh", *args], text=True)
+    # Always pass --repo so we don't depend on a .git in cwd
+    # (the workflow runs the script from a path without .git).
+    return subprocess.check_output(
+        ["gh", *args, "--repo", REPO], text=True
+    )
 
 
 def list_dated_releases() -> list[dict]:


### PR DESCRIPTION
## Summary

Hotfix on top of #2112. The manifest workflow checks out master into `./master/` and gh-pages into `./pages/` — neither is the workflow's cwd, so \`gh release list\` fails with \"fatal: not a git repository\" because it tries to infer the repo from \`.git\` in cwd.

Fix: thread \`--repo \$GITHUB_REPOSITORY\` into every \`gh\` invocation. The script is now cwd-independent.

## Repro / verification

Failed run before fix: https://github.com/OpenIPC/firmware/actions/runs/26180862470

Local repro (from /tmp, no .git in cwd) produced the exact same trace. After the fix the same command emits the expected empty manifest with \`# No nightly-YYYYMMDD-<short> releases yet\`.

## Test plan

- [ ] CI passes on this PR.
- [ ] After merge, manually dispatch \`manifest.yml\`; expect green run and empty \`manifest.json\` / \`manifest.flat\` committed to gh-pages.
- [ ] Tonight's first cron after merge: full pipeline lights up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)