### PR TITLE
sysupgrade: read manifest, learn --channel/--build/--list-builds (1.0.50)

### DIFF
--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -1,9 +1,11 @@
 #!/bin/sh
 # OpenIPC.org | 2025
-scr_version=1.0.49
+scr_version=1.0.50
 
 args="$@"
 LOCK_FILE=/tmp/sysupgrade.lock
+MANIFEST_URL=${MANIFEST_URL:-https://openipc.github.io/firmware/manifest.flat}
+MANIFEST_CACHE=/tmp/manifest.flat
 
 echo_c() {
 	# 31 red, 32 green, 33 yellow, 34 blue, 35 magenta, 36 cyan, 37 white, 38 grey
@@ -75,6 +77,24 @@ do_wipe_overlay() {
 	set_progress flash_eraseall $jffs2 "$(get_device "rootfs_data")"
 }
 
+fetch_manifest() {
+	[ "$(curl -o /dev/null -s -k -w '%{http_code}\n' "$MANIFEST_URL")" = "000" ] \
+		&& die "Check your network!"
+	curl --connect-timeout 30 -s -k -m 60 -L "$MANIFEST_URL" -o "$MANIFEST_CACHE" \
+		|| die "Cannot fetch manifest $MANIFEST_URL"
+}
+
+# resolve_channel <nightly|latest>  -> echoes a build_id
+resolve_channel() {
+	awk -v c="$1" '$1=="@channel" && $2==c { print $3; exit }' "$MANIFEST_CACHE"
+}
+
+# resolve_url <build_id> <platform> <flash>  -> echoes a URL
+resolve_url() {
+	awk -v b="$1" -v p="$2" -v f="$3" \
+		'$1==b && $2==p && $3==f { print $NF; exit }' "$MANIFEST_CACHE"
+}
+
 download_firmware() {
 	[ "$flash_type" = "nand" ] && echo_c 31 "\nNote: the updater uses the NOR package for updating NAND"
 	echo_c 33 "\nFirmware"
@@ -85,6 +105,15 @@ download_firmware() {
 		gzip -d "$archive" -c | tar xf - -C /tmp && echo_c 32 "Local archive unpacked" || die "Cannot extract $archive"
 	else
 		case "$osr" in lite|ultimate|neo) repo=firmware ;; esac
+		if [ -n "$channel" ] || [ -n "$build_id" ]; then
+			fetch_manifest
+			[ -n "$channel" ] && build_id=$(resolve_channel "$channel")
+			[ -z "$build_id" ] && die "Unknown channel/build"
+			platform="${soc}_${osr}"
+			url=$(resolve_url "$build_id" "$platform" "nor")
+			[ -z "$url" ] && die "No artifact for $platform in $build_id"
+			echo "Resolved $build_id for $platform"
+		fi
 		[ -z "$url" ] && url=$(fw_printenv -n upgrade || echo "https://github.com/OpenIPC/${repo:-builder}/releases/download/latest/openipc.$build.tgz")
 		echo "Download from $url"
 		[ "$(curl -o /dev/null -s -k -w '%{http_code}\n' "$url")" = "000" ] && die "Check your network!"
@@ -131,7 +160,7 @@ sync_time() {
 }
 
 self_update() {
-	if echo "$args" | grep -E "\-(k|r|w|url)" >/dev/null 2>&1; then
+	if echo "$args" | grep -E "\-(k|r|w|url|channel|build)" >/dev/null 2>&1; then
 		sync_time
 		echo -e "\nChecking for sysupgrade update..."
 		curl -s -k -L -o /tmp/sysupgrade "https://raw.githubusercontent.com/OpenIPC/firmware/master/general/overlay/usr/sbin/sysupgrade"
@@ -222,11 +251,20 @@ Where:
       --archive=[FILE]  Custom archive to update from (.tgz format).
       --kernel=[FILE]   Update kernel from file (uImage format).
       --rootfs=[FILE]   Update rootfs from file (squashfs format).
+      --channel=[NAME]  Update from a named channel via the manifest
+                        (nightly | latest). Default URL would be used
+                        otherwise.
+      --build=[ID]      Update to a specific dated build via the manifest,
+                        e.g. nightly-20260520-b9d5883.
+      --list-builds[=N] List the last N (default 20) builds available for
+                        this platform; mark the running build with '*'.
   -f, --force_all       Do not validate anything.
   -n, --wipe_overlay    Wipe overlay partition.
   -x, --no_reboot       Do not reboot after updating.
   -z, --no_update       Do not update self.
   -h, --help            Display this help and exit.
+
+Manifest URL: \$MANIFEST_URL (default: $MANIFEST_URL)
 "
 }
 
@@ -285,6 +323,29 @@ for i in "$@"; do
 			shift
 			;;
 
+		--channel=*)
+			update_kernel=1
+			update_rootfs=1
+			remote_update=1
+			channel="${i#*=}"
+			shift
+			;;
+
+		--build=*)
+			update_kernel=1
+			update_rootfs=1
+			remote_update=1
+			build_id="${i#*=}"
+			shift
+			;;
+
+		--list-builds*)
+			list_n="${i#--list-builds=}"
+			[ "$list_n" = "--list-builds" ] && list_n=20
+			list_only=1
+			shift
+			;;
+
 		--archive=*)
 			update_kernel=1
 			update_rootfs=1
@@ -331,6 +392,23 @@ for i in "$@"; do
 done
 
 print_sysinfo
+
+if [ "1" = "$list_only" ]; then
+	fetch_manifest
+	osr=$(get_system_build)
+	platform="${soc}_${osr}"
+	here=$(grep '^BUILD_ID=' /etc/os-release | cut -d= -f2)
+	builds=$(awk -v p="$platform" '$2==p && $3=="nor" { print $1 }' "$MANIFEST_CACHE" \
+		| head -n "${list_n:-20}")
+	if [ -z "$builds" ]; then
+		echo_c 33 "\nNo builds available for $platform yet."
+		echo "Manifest: $MANIFEST_URL"
+		exit 0
+	fi
+	echo_c 33 "\nAvailable builds for $platform (newest first):"
+	echo "$builds" | awk -v h="$here" '{ printf "  %s %s\n", ($1==h?"*":" "), $1 }'
+	exit 0
+fi
 
 [ "1" != "$clear_overlay" ] &&
 [ "1" != "$update_kernel" ] &&


### PR DESCRIPTION
## Summary

PR-C of six. Teaches on-device `sysupgrade` to read the busybox-friendly `manifest.flat` published by #2112 at `https://openipc.github.io/firmware/manifest.flat`. **No new rootfs dependency** — parsing is pure busybox `awk`/`grep`.

### New flags

| Flag | Behaviour |
|---|---|
| `--channel=<nightly\|latest>` | Resolve via `@channel` records in the manifest; pin to the rolling channel target. |
| `--build=<nightly-YYYYMMDD-xxxxxxx>` | Pin to a specific dated build (downgrade / bisect). |
| `--list-builds[=N]` | Print the last N (default 20) builds for this camera's `${soc}_${osr}` platform; mark the running build with `*` using `BUILD_ID` from `/etc/os-release` (#2111). |

`scr_version` bumped `1.0.49 → 1.0.50` and `self_update()`'s regex now fires on `--channel`/`--build` so users on a stale script get the manifest-aware version pulled before flashing.

### Backward compatibility

`download_firmware()` resolves the manifest into a `url` **before** the legacy `fw_printenv`/`releases/download/latest/` fallback, so unmodified invocations (`-k` / `-r` / `--url` / `--archive`) keep their exact prior behaviour. No flag day.

### Local verification

Tested against a hand-crafted `manifest.flat` covering three dated builds across two platforms (`hi3520dv200_lite`, `gk7205v200_lite`):

```
=== resolve_channel nightly ===
nightly-20260520-b9d5883

=== resolve_url nightly-20260519-aabbccd hi3520dv200_lite nor ===
https://github.com/.../openipc.hi3520dv200-nor-lite.tgz

=== list builds for hi3520dv200_lite, running == nightly-20260519-aabbccd ===
    nightly-20260520-b9d5883
  * nightly-20260519-aabbccd
    nightly-20260518-1111111
```

Empty/unknown-id error paths die with explicit messages.

### Test plan (on physical hardware after merge)

- [ ] `ssh root@openipc-hi3520dv200.dlab.torturelabs.com sysupgrade --list-builds=5` returns the friendly empty-state message right now (no dated nightly-* releases exist yet).
- [ ] After tonight's first cron, same command lists ≥1 entry with `*` on the running build (gates BUILD_ID/manifest end-to-end).
- [ ] `ssh root@openipc-gk7205v200.dlab.torturelabs.com sysupgrade --list-builds` — same, on a board whose defconfig does NOT enable BR2_PACKAGE_JSONFILTER, proving zero JSON-parser dependency (per kaeru `lab-gk7205v200-now-online`).
- [ ] `sysupgrade --channel=nightly` flashes the rolling channel target.
- [ ] `sysupgrade --build=<historic-id>` flashes the named build.
- [ ] `sysupgrade --url=…` legacy path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)