### PR TITLE
ci/manifest: publish on partial failure; fix built_at=; extend retry budget

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,7 +250,11 @@ jobs:
           mkdir -p /tmp/ccache
           ln -s /tmp/ccache ${HOME}/.ccache
 
-          backoffs="30 60 120 300"
+          # Backoffs give 7 attempts total. The longer tail (600, 1200) covers
+          # the GitHub releases CDN / toolchain mirror flakes that took down
+          # hi3516av100_ultimate on 2026-05-20 (run 26196546684) — 502s
+          # storming for >10 min outlasted the previous 30/60/120/300 budget.
+          backoffs="30 60 120 300 600 1200"
           attempt=1
           for sleep_for in $backoffs ""; do
             make BOARD=${{matrix.platform}} && break

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
       head_sha:     ${{ steps.gate.outputs.head_sha }}
       short_sha:    ${{ steps.gate.outputs.short_sha }}
       build_id:     ${{ steps.gate.outputs.build_id }}
+      built_at:     ${{ steps.gate.outputs.built_at }}
     steps:
       - uses: actions/checkout@v4
       - id: gate
@@ -25,6 +26,7 @@ jobs:
           HEAD=$(git rev-parse HEAD)
           SHORT=$(git rev-parse --short HEAD)
           BUILD_ID="nightly-$(date -u +%Y%m%d)-${SHORT}"
+          BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           PREV=$(gh release view nightly --json body -q .body 2>/dev/null \
                   | sed -n 's/^sha=//p' | head -1 || true)
           if [ "${{ github.event_name }}" = "schedule" ] && [ "$PREV" = "$HEAD" ]; then
@@ -37,6 +39,7 @@ jobs:
           echo "head_sha=$HEAD"   >> "$GITHUB_OUTPUT"
           echo "short_sha=$SHORT" >> "$GITHUB_OUTPUT"
           echo "build_id=$BUILD_ID" >> "$GITHUB_OUTPUT"
+          echo "built_at=$BUILT_AT" >> "$GITHUB_OUTPUT"
 
   buildroot:
     name: Firmware
@@ -285,7 +288,7 @@ jobs:
           body: |
             sha=${{ needs.preflight.outputs.head_sha }}
             short=${{ needs.preflight.outputs.short_sha }}
-            built_at=${{ github.run_started_at }}
+            built_at=${{ needs.preflight.outputs.built_at }}
           files: |
             ${{env.NORFW}}
             ${{env.NANDFW}}
@@ -298,7 +301,7 @@ jobs:
           body: |
             sha=${{ needs.preflight.outputs.head_sha }}
             short=${{ needs.preflight.outputs.short_sha }}
-            built_at=${{ github.run_started_at }}
+            built_at=${{ needs.preflight.outputs.built_at }}
           files: |
             ${{env.NORFW}}
             ${{env.NANDFW}}

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -15,7 +15,14 @@ concurrency:
 jobs:
   generate:
     name: Generate manifest
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    # Publish on success AND on partial-failure: one flaky board (e.g. a
+    # transient toolchain 502) should not deny manifest updates for the 90+
+    # platforms that did upload artifacts. enrich_manifest.py reads whatever
+    # assets actually exist on the release, so a partial release just shows
+    # up with fewer platforms in its `platforms` map.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master (for the script)


### PR DESCRIPTION
## Summary

Hotfix on top of #2111 + #2112. Three issues uncovered when the first real cron after the redesign hit a flaky board.

### Context: what happened on the 2026-05-20 cron

Run [26196546684](https://github.com/OpenIPC/firmware/actions/runs/26196546684) — one matrix job, `hi3516av100_ultimate`, exhausted its retry budget while the GitHub releases CDN / Hisilicon toolchain mirror was returning 502 Bad Gateway over a >10 min window. 91 of 92 jobs succeeded, the dated release `nightly-20260520-887328c` and the rolling `nightly` both ended up with **102 assets each**, the preflight gate worked correctly. (The user's GH email "9 assets" was a snapshot taken the moment the release was first created — assets continued piling on as the remaining matrix jobs finished.)

### Fix #1 — manifest.yml was skipped

Trigger condition was `workflow_run.conclusion == 'success'`. That's the whole workflow conclusion, which is `failure` if ANY matrix job fails. So the manifest workflow was skipped and gh-pages kept serving the empty-state placeholder while 102 valid artifacts existed on the release.

Loosened to publish on `success` OR `failure`, only skip `cancelled`. `enrich_manifest.py` reads whatever assets actually exist — a partial release just gets fewer entries in its `platforms` map.

### Fix #2 — `built_at=` empty in release body

`${{ github.run_started_at }}` rendered as empty in softprops/action-gh-release@v2's `body:` field (context-availability quirk). Moved the timestamp calculation into the preflight job (`date -u +%Y-%m-%dT%H:%M:%SZ`), exposed as a job output, referenced from both upload steps. Cosmetic-only — `enrich_manifest.py` already falls back to the release's `created_at` — but the body now has a real RFC3339 timestamp.

### Fix #3 — extend retry budget for upstream toolchain/CDN flakes

Backoffs `30 60 120 300` → `30 60 120 300 600 1200`. Total attempts: 5 → 7. Max idle sleep: ~8.5 min → ~40 min. The longer tail only fires on persistent upstream issues — happy-path builds still finish on the first attempt with zero added wait.

Without this, even a routine GH releases CDN hiccup is enough to fail a matrix entry and (pre-Fix #1) deny manifest updates for the other 91 platforms.

### Immediate remediation done

Manually dispatched `manifest.yml` (the `workflow_dispatch` path was already correct). gh-pages now serves the 102-entry index live at https://openipc.github.io/firmware/manifest.flat — lab cameras running PR #2114's sysupgrade can `--list-builds` and see real data.

## Test plan

- [ ] CI passes on this PR.
- [ ] Next scheduled cron triggers manifest.yml automatically — verify gh-pages updates without needing manual dispatch.
- [ ] Release body of next dated build shows `built_at=2026-MM-DDThh:mm:ssZ`.
- [ ] If a future toolchain/CDN flake recurs, the longer backoff tail (10/20 min) gives it room to recover before declaring matrix failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)