### PR TITLE
ci/build-one: accept arbitrary commit input; publish to nightly-bisect-* tag

### DIFF
--- a/.github/workflows/build-one.yml
+++ b/.github/workflows/build-one.yml
@@ -5,18 +5,44 @@ on:
       platform:
         description: 'Platform to build (e.g. hi3516cv100_lite)'
         required: true
-
-env:
-  TAG_NAME: latest
+      commit:
+        description: 'Commit SHA to build (optional; defaults to current branch HEAD). Use this from `git bisect run` or for one-off historic rebuilds.'
+        required: false
 
 jobs:
+  resolve:
+    name: Resolve commit
+    runs-on: ubuntu-latest
+    outputs:
+      ref:       ${{ steps.r.outputs.ref }}
+      short_sha: ${{ steps.r.outputs.short_sha }}
+      tag_name:  ${{ steps.r.outputs.tag_name }}
+    steps:
+      - id: r
+        run: |
+          REF="${{ inputs.commit }}"
+          [ -z "$REF" ] && REF="${{ github.sha }}"
+          SHORT="$(printf '%s' "$REF" | cut -c1-7)"
+          if [ -n "${{ inputs.commit }}" ]; then
+            TAG="nightly-bisect-${SHORT}"
+          else
+            TAG="nightly-bisect-${SHORT}-$(date -u +%Y%m%d%H%M%S)"
+          fi
+          echo "ref=$REF"               >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT"       >> "$GITHUB_OUTPUT"
+          echo "tag_name=$TAG"          >> "$GITHUB_OUTPUT"
+          echo "Building ${{ inputs.platform }} at $REF -> release tag $TAG"
+
   buildroot:
     name: Firmware (${{inputs.platform}})
+    needs: resolve
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.ref }}
 
       - name: Prepare firmware
         run: |
@@ -37,6 +63,9 @@ jobs:
           restore-keys: dl-
 
       - name: Build firmware
+        env:
+          BUILD_ID:  ${{ needs.resolve.outputs.tag_name }}
+          BUILD_SHA: ${{ needs.resolve.outputs.ref }}
         run: |
           export GIT_HASH=$(git rev-parse --short ${GITHUB_SHA})
           export GIT_BRANCH=${GITHUB_REF_NAME}
@@ -46,7 +75,7 @@ jobs:
           mkdir -p /tmp/ccache
           ln -s /tmp/ccache ${HOME}/.ccache
 
-          backoffs="30 60 120 300"
+          backoffs="30 60 120 300 600 1200"
           attempt=1
           for sleep_for in $backoffs ""; do
             make BOARD=${{inputs.platform}} && break
@@ -78,7 +107,13 @@ jobs:
       - name: Upload firmware
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{env.TAG_NAME}}
+          tag_name: ${{ needs.resolve.outputs.tag_name }}
+          prerelease: true
+          body: |
+            sha=${{ needs.resolve.outputs.ref }}
+            short=${{ needs.resolve.outputs.short_sha }}
+            platform=${{ inputs.platform }}
+            one_off=true
           files: |
             ${{env.NORFW}}
             ${{env.NANDFW}}


### PR DESCRIPTION
## Summary

PR-E of six. Tiny CI-only change: `build-one.yml` gains an optional `commit` workflow_dispatch input. With it, `git bisect run` can drive sub-nightly granularity rebuilds when daily resolution isn't enough.

### What changes

- New optional input `commit:` (SHA). When set, checkout pulls that ref.
- New `resolve` job computes the upload tag once and threads it via job outputs:
  - With `commit`: `nightly-bisect-<short>` (deterministic per commit, prerelease)
  - Without `commit`: `nightly-bisect-<short>-<UTC ts>` (so repeated one-offs of the same HEAD don't collide)
- Upload becomes prerelease with a structured body (`sha=`, `short=`, `platform=`, `one_off=true`).
- Retry budget bumped to match #2115 (`30 60 120 300 600 1200`).

### Tag namespace separation

`nightly-bisect-*` is deliberately distinct from `nightly-YYYYMMDD-<short>` (the dated nightlies produced by `build.yml`):

- `enrich_manifest.py` (#2112) filters strictly on `^nightly-[0-9]{8}-[0-9a-f]{7}$`, so `nightly-bisect-*` releases **never enter `manifest.{json,flat}`**.
- `cleanup.yml` (#2112) uses the same regex, so the 90-build retention sweep **leaves them alone**. One-off bisect builds persist until you delete them manually.

This means `sysupgrade --build=nightly-bisect-<short>` won't resolve via the manifest path (correct — these aren't channel-published builds), but `sysupgrade --url=<github asset url>` works as always.

### Use it

```sh
# Single platform, single commit
gh workflow run build-one.yml -f platform=hi3520dv200_lite -f commit=<sha>

# git bisect run example (will be wrapped by upcoming PR-D's openipc-bisect)
git bisect start <bad-sha> <good-sha>
git bisect run sh -c '
  gh workflow run build-one.yml -f platform=hi3520dv200_lite -f commit=$(git rev-parse HEAD) &&
  gh run watch $(gh run list -L1 -w build-one.yml --json databaseId -q .[0].databaseId)
'
```

### Test plan

- [ ] CI passes on this PR.
- [ ] After merge, dispatch with `platform=hi3520dv200_lite` and no commit → builds HEAD, publishes to `nightly-bisect-<short>-<ts>`.
- [ ] Dispatch with `platform=hi3520dv200_lite -f commit=<earlier sha>` → builds that ref, publishes to `nightly-bisect-<short>` (deterministic).
- [ ] Verify the dated nightly index on gh-pages is unchanged (no `nightly-bisect-*` entries in `manifest.flat`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)