### PR TITLE
ci/image: downstream of build via workflow_run; manifest-driven URLs

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,36 +1,95 @@
 name: image
 on:
-  schedule:
-    - cron: '30 23 * * *'
+  workflow_run:
+    workflows: [build]
+    types: [completed]
   workflow_dispatch:
+    inputs:
+      build_id:
+        description: 'Build ID to assemble (e.g. nightly-20260520-887328c). Default: channels.nightly from manifest.'
+        required: false
 
-env:
-  SIGMASTAR: ssc30kd ssc30kq ssc325 ssc333 ssc335 ssc335de ssc337 ssc337de ssc338q ssc377 ssc377d ssc377de ssc377qe ssc378de ssc378qe
-  INGENIC: t10 t10l t20 t20l t20x t21n t23n t30a t30a1 t30l t30n t30x t31a t31al t31l t31lc t31n t31x
-  ALLWINNER: v851s
-  TAG_NAME: image
+permissions:
+  contents: write
 
 jobs:
   toolchain:
     name: Image
     runs-on: ubuntu-latest
+    # Publish on success AND on partial-failure: see manifest.yml rationale.
+    # A flaky board doesn't deny image assembly for the platforms that did
+    # upload a firmware tgz — firmware_url returns empty for missing ones and
+    # create() skips them.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion)
+    env:
+      SIGMASTAR: ssc30kd ssc30kq ssc325 ssc333 ssc335 ssc335de ssc337 ssc337de ssc338q ssc377 ssc377d ssc377de ssc377qe ssc378de ssc378qe
+      INGENIC: t10 t10l t20 t20l t20x t21n t23n t30a t30a1 t30l t30n t30x t31a t31al t31l t31lc t31n t31x
+      ALLWINNER: v851s
+      MANIFEST_URL: https://openipc.github.io/firmware/manifest.json
+      UBOOT_URL: https://github.com/openipc/firmware/releases/download/latest
+
     steps:
-      - name: Prepare
+      - name: Resolve build_id from manifest
+        id: resolve
+        env:
+          INPUT_BUILD_ID: ${{ inputs.build_id }}
         run: |
-            link=https://github.com/openipc/firmware/releases/download/latest
+          set -eu
+          curl -fsSL "$MANIFEST_URL" -o /tmp/manifest.json
+          if [ -n "$INPUT_BUILD_ID" ]; then
+            BUILD_ID="$INPUT_BUILD_ID"
+          else
+            BUILD_ID=$(jq -r '.channels.nightly // ""' /tmp/manifest.json)
+          fi
+          if [ -z "$BUILD_ID" ] || [ "$BUILD_ID" = "null" ]; then
+            echo "::error::No build_id resolved (manifest channels.nightly empty? input not given?)"
+            exit 1
+          fi
+          # Sanity check: does the manifest actually know this build?
+          if ! jq -e --arg b "$BUILD_ID" '.builds[] | select(.id==$b)' /tmp/manifest.json >/dev/null; then
+            echo "::error::build_id $BUILD_ID is not present in manifest at $MANIFEST_URL"
+            exit 1
+          fi
+          echo "build_id=$BUILD_ID" >> "$GITHUB_OUTPUT"
+          echo "Assembling images for $BUILD_ID"
+
+      - name: Prepare
+        env:
+          BUILD_ID: ${{ steps.resolve.outputs.build_id }}
+        run: |
+            MANIFEST=/tmp/manifest.json
+
+            # firmware_url <firmware_soc> <variant>
+            #   -> echoes the .nor URL for ${firmware_soc}_${variant} in
+            #      $BUILD_ID, or nothing if the manifest has no such entry.
+            firmware_url() {
+                jq -r --arg b "$BUILD_ID" --arg p "${1}_${2}" \
+                    '.builds[] | select(.id==$b) | .platforms[$p].nor.url // empty' \
+                    "$MANIFEST"
+            }
+
+            # create <uboot_board> <firmware_soc> <variant>
+            #   The two SoC arguments differ for Ingenic: u-boot is per
+            #   board (t31al, t31lc, ...), firmware is per family (t31).
             create() {
               uboot=u-boot-$1-nor.bin
-              firmware=openipc.$2-nor-$3.tgz
               release=target/openipc-$1-nor-$3.bin
 
               mkdir -p output target
-              if ! wget -nv $link/$uboot -O output/$1.bin; then
-                echo -e "Download failed: $link/$uboot\n"
+              if ! wget -nv "$UBOOT_URL/$uboot" -O "output/$1.bin"; then
+                echo -e "Download failed: $UBOOT_URL/$uboot\n"
                 return 0
               fi
 
-              if ! wget -nv $link/$firmware -O output/$2.tgz; then
-                echo -e "Download failed: $link/$firmware\n"
+              url=$(firmware_url "$2" "$3")
+              if [ -z "$url" ]; then
+                echo -e "Skip: no firmware in $BUILD_ID for ${2}_${3}\n"
+                return 0
+              fi
+              if ! wget -nv "$url" -O "output/$2.tgz"; then
+                echo -e "Download failed: $url\n"
                 return 0
               fi
 
@@ -57,6 +116,6 @@ jobs:
       - name: Upload
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{env.TAG_NAME}}
+          tag_name: image
           make_latest: false
           files: target/*.bin


### PR DESCRIPTION
## Summary

PR-F (final) of six in the nightly-build redesign. `image.yml` flips from a standalone cron at 23:30 UTC to triggering on `build.yml`'s `workflow_run` completion, and resolves firmware URLs via the gh-pages manifest instead of hardcoding `releases/download/latest`.

### Changes

- **Trigger:** drop the independent 23:30 UTC cron; trigger via `workflow_run` on `build.yml` + `workflow_dispatch` as before.
- **Partial-failure tolerance** (matches #2115): run on `success` OR `failure`, only skip `cancelled`. Missing firmware tgzs for a particular platform become silent skips inside `create()`.
- **New optional input** `build_id` (default: `channels.nightly` from the gh-pages manifest). Lets `workflow_dispatch` assemble flash images for any historic dated nightly without code changes — useful for recovering an older known-good image after a bisect identifies a regression.
- **Manifest-driven URL resolution** for firmware tgzs via `jq` against `manifest.json`. Returns empty for missing platforms; the existing `create()` skip-on-empty path handles that cleanly (matches pre-PR behaviour for boards the build matrix doesn't cover, e.g. `ssc325_ultimate`, `t10_ultimate`).
- **U-Boot binaries unchanged** — still come from `releases/download/latest/u-boot-<board>-nor.bin` because `uboot.yml` uploads to the `latest` tag and U-Boot has its own (manual) build cadence, not coupled to the nightly firmware cycle.

### Verified locally

`jq` resolution against the live manifest:

```
  ssc335_lite: openipc.ssc335-nor-lite.tgz
  ssc335_ultimate: openipc.ssc335-nor-ultimate.tgz
  ssc325_ultimate: <not in manifest — skip>
  t31_lite: openipc.t31-nor-lite.tgz
  t31_ultimate: openipc.t31-nor-ultimate.tgz
  v851s_lite: openipc.v851s-nor-lite.tgz
  t10_ultimate: <not in manifest — skip>
```

### Test plan

- [ ] CI passes on this PR.
- [ ] After merge, dispatch `image.yml` manually with no inputs — assembles images for the current `channels.nightly`.
- [ ] Dispatch with `build_id=nightly-20260520-887328c` — assembles for that specific historic build.
- [ ] Tonight's cron: `build.yml` completes → `manifest.yml` and `image.yml` both fire via `workflow_run` and both produce fresh artifacts.

### What this completes

With this merge the original plan in `.claude/plans/let-s-think-about-how-fizzy-bubble.md` is fully implemented. The full PR chain across the redesign:

- #2111 — SHA-gate cron, dated `nightly-YYYYMMDD-<short>` releases, BUILD_ID in os-release
- #2112 — manifest aggregator + 90-build retention sweep
- #2113 — gh `--repo` flag (hotfix)
- #2114 — sysupgrade learns `--channel/--build/--list-builds` (1.0.50)
- #2115 — partial-failure publication; `built_at=` fix; retry budget
- #2116 — `build-one.yml` accepts arbitrary commit input
- #2117 — host-side `contrib/openipc-bisect`
- **#this** — image.yml downstream of build.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)