### PR TITLE
hisilicon-opensdk: bump 55b72ec → 74d8a65 (cv200 + av100 V2/V2A neo, issue #51)

### DIFF
--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = 55b72ec
+HISILICON_OPENSDK_VERSION = 74d8a65
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE


### PR DESCRIPTION
## Summary

Bumps `HISILICON_OPENSDK_VERSION` from `55b72ec` → `74d8a65`, pulling in V2 (hi3516cv200) + V2A (hi3516av100) modern-kernel bring-up from openhisilicon [#162](https://github.com/OpenIPC/openhisilicon/pull/162) and [#165](https://github.com/OpenIPC/openhisilicon/pull/165) — both squash-merged today (issue [#51](https://github.com/OpenIPC/openhisilicon/issues/51)).

## Why this is safe for existing lite cameras

cv200 and av100 *_lite firmware variants (kernel 4.9) were rebuilt against the new openhisilicon tip via `HISILICON_OPENSDK_OVERRIDE_SRCDIR` and **byte-equivalence-tested** against nightly:

| Variant | Rootfs files | Hisilicon `.ko` count | Module set | QEMU `lsmod` |
|---|---|---|---|---|
| `hi3516cv200_lite` (4.9) | 697 / 697 | 34 / 34 | identical | identical |
| `hi3516av100_lite` (4.9) | 290 / 290 | 61 / 61 | identical | identical |

`dmesg` diffs were ≤ 20 benign lines (BogoMIPS jitter, random MAC, ramdisk rounding). Neither shim module (`open_v2_shim.ko`, `open_v2a_shim.ko`) ships on 4.9 — they're gated to no-op and the av100/cv200 firmware install blocks don't reference them.

## What's in the range

```
74d8a65  kernel/hi3516av100: bring up V2A generation against Linux 7.0 (#165)
abadb7cf kernel/hi3516cv200: bring up V2 generation against Linux 7.0 (#162)
91cada81 ci: drop hi3516av300 row from QEMU NNIE forward regression (#167)
824ed48f nnie_neo: multi-segment .wk parser + ForwardWithBbox harness (#166)
```

Only #162 and #165 affect firmware-built binaries; #166 is cv500-only NNIE host-side work, #167 is openhisilicon-CI cleanup.

## What's NOT in this PR (follow-ups)

- **`hi3516cv200_neo` defconfig + neo kernel config + post-image script** — needed to actually consume `open_v2_shim.ko` under a 7.0 kernel. Separate firmware PR.
- **`hi3516av100_neo` ditto** — separate firmware PR.
- Both neo bring-ups carry the same `struct timer_list.data` drift caveat as cv300_neo (chnl/viu/vpss blobs) — broken video pipeline expected until either a kernel-side `.data` restore patch lands or the blobs are recompiled. Documented inside both shim sources.

## Test plan

- [x] `hi3516cv200_lite` byte-equivalence vs nightly (no regression)
- [x] `hi3516av100_lite` byte-equivalence vs nightly (no regression)
- [x] Full openhisilicon CI green on both squash-merged PRs (#162, #165): all 8 SDK rows + 4 neo rows + 8 QEMU smoke tests + libraries checks
- [ ] Real-hardware sysupgrade smoke (cv200 + av100 boards) — recommended before tagging a release

🤖 Generated with [Claude Code](https://claude.com/claude-code)