### PR TITLE
ci: register hi3516cv200_neo + hi3516av100_neo in build.yml matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,7 @@ jobs:
 
           # Hisilicon [HI3516AV100]
           - hi3516av100_lite
+          - hi3516av100_neo
           - hi3516dv100_lite
 
           # Hisilicon [HI3516CV100]
@@ -104,6 +105,7 @@ jobs:
 
           # Hisilicon [HI3516CV200]
           - hi3516cv200_lite
+          - hi3516cv200_neo
           - hi3518ev200_lite
 
           # Hisilicon [HI3516CV300]


### PR DESCRIPTION
## Summary

Fixes a miss in #2122. The defconfigs, board files, and post-image scripts landed, but the two new boards were not added to `.github/workflows/build.yml`'s `platform:` matrix list. That list is hand-maintained — entries control which firmware variants the nightly cron builds and which tarballs end up in the `latest` release. Without the entries, the nightly never produced `openipc.hi3516cv200-nor-neo.tgz` or `openipc.hi3516av100-nor-neo.tgz`, even though the build does work locally (verified end-to-end in #2122).

Adds two entries:
- `hi3516cv200_neo` under `# Hisilicon [HI3516CV200]`
- `hi3516av100_neo` under `# Hisilicon [HI3516AV100]`

After this lands, the next scheduled nightly will publish the neo tarballs alongside the lite ones, unblocking the follow-up openhisilicon CI-row addition (this issue #2123 → openhisilicon matrix rows that depend on these tarballs existing).

## Test plan

- [x] YAML parses cleanly
- [ ] PR CI exercises the two new matrix rows — must reach `success` for cv200_neo and av100_neo before merge
- [ ] Next nightly publishes both tarballs to `latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)