### PR TITLE
hisilicon-opensdk: bump 7fa06b2 → 28a30ca (frame-ts FEND extension)

### DIFF
--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = 7fa06b2
+HISILICON_OPENSDK_VERSION = 28a30ca
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE


### PR DESCRIPTION
## Summary

Picks up [OpenIPC/openhisilicon#178](https://github.com/OpenIPC/openhisilicon/pull/178) (closes openhisilicon#176, openhisilicon#177):

- **ISP_FEND** second event source on `/dev/openipc-frame-ts` alongside `MIPI_FS`. Pairing both events frame-by-frame gives sensor readout duration directly (`wall_ns[FEND] − wall_ns[FS]`).
- ABI extended additively: `event_type` field in `struct openipc_frame_ts_event`, new `OPENIPC_FT_IOC_SET_EVENT_MASK` and `OPENIPC_FT_IOC_GET_COALESCED` ioctls.
- Edge-detect on the level-held raw vsync / FEND bits in `ISP_ISR` and `mipi_rx_interrupt_route` (V4 + cv500) — fixes a previously-shipped cherry-pick that fired zero FEND events on real silicon.
- Per-channel ring depth 64 → 256 (≈ 0.5 s of buffer at 480 Hz of FS+FEND combined).
- Split the previous single `dropped` counter into `dropped` (ring overflow → data loss) and `coalesced` (dedupe rejects → expected at high IRQ rates). New `GET_COALESCED` ioctl.

## End-user impact

With this bump, [widgetii/majestic#83](https://github.com/widgetii/majestic/pull/83) (already merged) can correctly anchor RTCP Sender Reports to wall-clock time across the HiSilicon V4 + cv500 lineup — RTSP clients see NTP-anchored timestamps instead of pipeline-relative ones (correct multi-camera sync, correct seek in recordings).

FEND consumers (ROS 2 multi-sensor fusion, PixelPilot-style per-segment latency telemetry, evidence chains) can also compute per-frame sensor readout duration without an external probe.

## Test plan

- [x] openhisilicon CI green on the underlying PR (22/22 jobs).
- [x] Validated empirically on ev300 (V4, IMX335) + av300 (cv500, IMX415) across the full sensor mode lineup:
  - Zero drops in every tested mode (21 fps → 240 fps configured).
  - Sensor readout times scale linearly with active row count: IMX335 4.4 ms @ 480 rows up to 28.4 ms @ 1944 rows; IMX415 31.5 ms @ 4M.
- [ ] Firmware CI on this PR.
- [ ] Smoke-test a built ev300 / av300 firmware image against the test program in `samples/openipc_frame_ts/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)