### PR TITLE
Revert "hisilicon-opensdk: bump 7fa06b2 → 28a30ca (#2126)"

### DIFF
--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = 28a30ca
+HISILICON_OPENSDK_VERSION = 7fa06b2
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Urgent revert — nightly with #2126 bricked majestic on at least one hi3518ev200 (V2A) board: kernel WARN at \`rtmutex.c:1545\` (rt_mutex_trylock from inside ISP_ISR via \`hi_sensor_i2c_write → i2c_transfer\`), camera reachable via SSH but \`curl http://localhost/image.jpg\` returns HTTP 000 / 10 s timeout.

The bump pulled in openhisilicon PR #178, which was hardware-validated only on hi3516ev300 (V4 / IMX335) and hi3516av300 (cv500 / IMX415). My changes inside \`kernel/isp/arch/hi3516cv200/firmware/drv/isp.c\` shift ISP_ISR timing enough to surface a latent i2c-from-hardirq race on V2A / hi3518ev200; backtrace is identical to a pre-existing issue, so the bug isn't strictly new, but my code is what tipped it past the threshold and that's enough to brick majestic on those boards.

Pin back to 7fa06b2 (prior known-good opensdk version) until PR #178 is re-scoped to explicitly exclude SoCs without a hardware-validation bench (V2A / hi3518e variants in particular).

Re-land plan tracked in openhisilicon, not here.