### PR TITLE
hisilicon-opensdk: restrict fpv variant to IMX307 + IMX335 sensors

### DIFF
--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -203,6 +203,32 @@ HISILICON_OPENSDK_SENSORS_hi3516cv200 = \
 
 HISILICON_OPENSDK_SENSORS = $(HISILICON_OPENSDK_SENSORS_$(OPENIPC_SOC_FAMILY))
 
+# fpv variant on V4 (hi3516ev200 + gk7205v200): restrict to the high-fps
+# Sony sensors only. FPV cameras are permanently paired with one sensor;
+# the other 26 entries in HISILICON_OPENSDK_SENSORS_$(family) are dead
+# weight on the tight 5120 KB NOR rootfs that fpv variants ship on.
+#
+# PR #2054 (2026-05-08) switched 30 sensor .so files from pre-built
+# vendor blobs to source-built, adding ~+160 KB compressed to the rootfs
+# squashfs and pushing hi3516ev200_fpv + hi3516ev300_fpv past the 5120
+# KB cap. Bisect via OpenIPC/builder#94's firmware_ref input isolated
+# #2054 as the cause — see kaeru
+# hi3516ev200-ev300-fpv-rootfs-size-overflow-2026-05-24.
+#
+# Sony IMX307 and IMX335 are the only sensors with high-fps presets
+# validated for fpv so far (PRs #2090, #2091, #2093, #2094). Other
+# sensors can be re-enabled per user request once their high-fps modes
+# are checked and the rootfs has room.
+ifeq ($(OPENIPC_VARIANT),fpv)
+ifneq ($(filter $(OPENIPC_SOC_FAMILY),hi3516ev200 gk7205v200),)
+HISILICON_OPENSDK_SENSORS = \
+	sony_imx307/libsns_imx307 \
+	sony_imx307_2L/libsns_imx307_2l \
+	sony_imx335/libsns_imx335 \
+	sony_imx335_2L/libsns_imx335_2l
+endif
+endif
+
 # Kernel version from the actual build — no hardcoded fallback.
 # The kernel is always built before opensdk (dependency), so kernel.release exists.
 HISILICON_OPENSDK_KVER = $(shell cat $(BUILD_DIR)/linux-custom/include/config/kernel.release 2>/dev/null)


### PR DESCRIPTION
## Summary

Restricts `HISILICON_OPENSDK_SENSORS` to the four high-fps-validated Sony entries (IMX307 + IMX307_2L + IMX335 + IMX335_2L) when `OPENIPC_VARIANT=fpv` AND `OPENIPC_SOC_FAMILY ∈ {hi3516ev200, gk7205v200}`. Restores `hi3516ev200_fpv` / `hi3516ev300_fpv` (and any future device-specific `*_fpv_*` matrix entry under these families) to a buildable state.

## Why

PR #2054 (2026-05-08, "build 30 sensor drivers from source") moved hi3516ev200 + gk7205v200 sensor `.so` files from pre-built vendor blobs to source-built. The source builds are ~+160 KB compressed in the squashfs vs the vendor's stripped pre-built ones, pushing every `_fpv` variant past the 5120 KB NOR rootfs cap:

```
hi3516ev200_fpv : 5196 KB / 5120 KB (76 KB over)
hi3516ev300_fpv : 5196 KB / 5120 KB (76 KB over)
```

### Bisect proof

Using OpenIPC/builder#94's `firmware_ref` input on `build-one.yml`:

| firmware_ref | Date | Includes #2054? | rootfs.squashfs |
|---|---|---|---|
| `4d88e9d` | 2026-05-08 13:45 UTC | **No** (parent of #2054) | **5028 KB ✅** (92 KB headroom) |
| `1be1b6c9` | 2026-05-10 | Yes | 5188 KB ❌ |
| `7fc6cda4` | 2026-05-18 | Yes | 5196 KB ❌ |
| master HEAD | 2026-05-24 | Yes | 5204 KB ❌ |

Same builder.sh, same `hisilicon-opensdk` SHA, same majestic — only #2054's source-built switch differs. (Earlier attribution to majestic growth was a methodology error caught by widgetii/majestic#88 — variant-conflation in the comparison. See kaeru `hi3516ev200-ev300-fpv-rootfs-size-overflow-2026-05-24` for the full trace.)

### Why pruning, not compile-flag tweaks

Per-binary section anatomy explains it:

```
libsns_imx307.so (153 KB total)
  .text:   37,208 B (24%)
  .data:  114,648 B (75%)  ← calibration + register init tables
```

Sensor `.so` files are data-dominated 3:1 over text. `-ffunction-sections + -Wl,--gc-sections` and `-flto` mostly help `.text` — limited leverage when the `.data` is what bloats and is reachable through the exported dlopen API. Realistic flag-tweak saving: ~30 KB compressed across all sensors. Clears the current 76 KB overflow with zero margin for next drift.

Per-variant sensor pruning has dramatically higher leverage:

```
30 sensors × ~30-50 KB each ≈ 1 MB uncompressed in /usr/lib/sensors
fpv camera permanently paired with one sensor → 26 unused
→ ~870 KB uncompressed dead weight (~320 KB compressed in xz squashfs)
```

That's 4x the overflow, leaving comfortable headroom for normal package growth.

## Why IMX307 + IMX335 specifically

These two sensors have fpv-validated high-fps presets shipped by recent PRs:
- #2090 — IMX335 companion to openhisilicon #99
- #2091 — IMX335 boost-1944p latency framing
- #2093 — IMX307 high-fps presets
- #2094 — IMX335 5M Isp_FrameRate 20 → 30

The 2-lane variants (`_2L`) are included because some board layouts use 2-lane MIPI wiring rather than 4-lane. Other sensors can be re-enabled per user request once their fpv high-fps modes are characterized.

## Precedent in this file

Same shape as the existing `HISILICON_OPENSDK_TRIM_SP2308` finalize hook for `hi3518ev300/lite` (added when a previous majestic bump exceeded that variant's cap). This is the cleaner version — restricts at install enumeration rather than removing after install.

## Test plan

- [ ] CI passes on this PR.
- [ ] After merge, OpenIPC/builder dispatch of `hi3516ev200_fpv` against master HEAD produces rootfs.squashfs ≪ 5120 KB.
- [ ] Same for `hi3516ev300_fpv`, `gk7205v200_fpv`, and the device-specific `*_fpv_*` matrix entries under these families.
- [ ] `/usr/lib/sensors/` on a flashed fpv camera contains only `libsns_imx307{,_2l}.so` + `libsns_imx335{,_2l}.so`.
- [ ] FPV camera with IMX307 or IMX335 sensor still boots + streams correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)