### PR TITLE
cleanup: grant actions:write and skip no-op manifest refresh

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: gh-pages-manifest
@@ -19,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Delete releases beyond the 90 newest
+        id: prune
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -29,6 +31,7 @@ jobs:
 
           if [ -z "$to_delete" ]; then
             echo "Nothing to delete; <=90 dated nightlies present."
+            echo "pruned=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -37,8 +40,10 @@ jobs:
             echo "Deleting $tag"
             gh release delete "$tag" --cleanup-tag --yes
           done
+          echo "pruned=true" >> "$GITHUB_OUTPUT"
 
       - name: Refresh manifest
+        if: steps.prune.outputs.pruned == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh workflow run manifest.yml


### PR DESCRIPTION
## Summary

- Today's scheduled `cleanup` run [failed](https://github.com/OpenIPC/firmware/actions/runs/26392118729) with `HTTP 403: Resource not accessible by integration` when dispatching `manifest.yml`. The `prune` job only declared `contents: write`, so `gh workflow run` couldn't fire. Adds `actions: write`.
- The refresh step was also reached on the empty-prune path (the `exit 0` after `Nothing to delete; <=90 dated nightlies present.` only exits the step, not the job). Gate it on a new `pruned` output so it runs only when something was actually deleted — `manifest.yml` already self-refreshes via `workflow_run` after every `build.yml`.

## Test plan

- [ ] Manually dispatch `cleanup.yml` with <90 dated nightlies present → only the prune step runs, job exits success.
- [ ] Next Monday's scheduled run (or a forced one after seeding >90 dated nightlies on a fork) → prune deletes the surplus AND dispatches `manifest.yml` successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)