### PR TITLE
hisilicon-opensdk: drop soi_h63 from hi3516ev200 family to fit 5120 KB

### DIFF
--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -96,7 +96,6 @@ HISILICON_OPENSDK_SENSORS_hi3516ev200 = \
 	smart_sc4236/libsns_sc4236 \
 	smart_sc500ai/libsns_sc500ai \
 	soi_f37/libsns_f37 \
-	soi_h63/libsns_h63 \
 	sony_imx290/libsns_imx290 \
 	sony_imx307/libsns_imx307 \
 	sony_imx307_2L/libsns_imx307_2l \


### PR DESCRIPTION
## Summary

- gk7205v300_lite started failing on master last night with `rootfs.squashfs: [5124KB/5120KB]` — 4 KB over the NOR cap. The hi3516ev200 family sensor list (inherited verbatim by gk7205v200) now ships 30 source-built sensor .so files. Removing **`soi_h63/libsns_h63`** (46 KB raw → ~17 KB squashed) recovers ~13 KB net headroom — the smallest viable trim.
- H63 is a budget Chinese 2 MP sensor with the narrowest installed base of the three candidates safe to drop here; Sony IMX307 and IMX335 stay (popular low-light + 5 MP).
- Once green, this also unblocks #2133 (cleanup workflow permissions fix).

## Test plan

- [ ] `Firmware (gk7205v300_lite)` check turns green in this PR's CI.
- [ ] `Firmware (hi3516ev200_lite)`, `Firmware (hi3516ev200_ultimate)`, `Firmware (hi3516ev300_*)`, `Firmware (gk7205v200_*)`, `Firmware (gk7205v300_ultimate)` all stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)