### PR TITLE
hisilicon-cv200: install + load open_openipc_frame_ts.ko so ISP loads

### DIFF
--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -406,6 +406,13 @@ define HISILICON_OPENSDK_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 644 $(@D)/kernel/open_acodec.ko  $(HISILICON_OPENSDK_KMOD_DST)/acodec.ko
 	# HWRNG: install verbatim — load_hisilicon insmods it pre-sensor-probe.
 	$(INSTALL) -m 644 $(@D)/kernel/open_hwrng.ko   $(HISILICON_OPENSDK_KMOD_DST)/open_hwrng.ko
+	# Frame-timestamp chrdev — open_isp.ko (renamed to hi3518e_isp.ko above)
+	# imports openipc_frame_ts_push from this module since the openhisilicon
+	# bump that wired cv200 ISP_ISR into the openipc_frame_ts chrdev path
+	# (kernel/isp/arch/hi3516cv200/firmware/drv/isp.c). Without it,
+	# `insmod hi3518e_isp.ko` fails with "unknown symbol" and the dependent
+	# sensor_i2c / sensor_spi insmods cascade.
+	$(INSTALL) -m 644 $(@D)/kernel/open_openipc_frame_ts.ko $(HISILICON_OPENSDK_KMOD_DST)/open_openipc_frame_ts.ko
 	# V2 OSAL shim — only meaningful on neo (kernel 7.0). On lite (4.9)
 	# the module compiles as a no-op so it could ship there too, but
 	# load_hisilicon would still try to insmod it; gate to neo only.

--- a/general/package/hisilicon-osdrv-hi3516cv200/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516cv200/files/script/load_hisilicon
@@ -43,6 +43,7 @@ insert_detect() {
         insmod hi_media.ko
         insmod hi3518e_base.ko
         insmod hi3518e_sys.ko vi_vpss_online=$b_arg_online sensor=unknown mem_total=$mem_total
+        insmod open_openipc_frame_ts.ko
         insert_isp
         insmod sensor_i2c.ko
         insmod sensor_spi.ko
@@ -53,6 +54,7 @@ remove_detect() {
         rmmod -w open_sensor_spi
         rmmod -w open_sensor_i2c
         rmmod -w open_isp
+        rmmod -w open_openipc_frame_ts
         rmmod -w hi3518e_sys
         rmmod -w hi3518e_base
         rmmod -w open_himedia
@@ -232,6 +234,7 @@ insert_ko() {
         insmod hi3518e_region.ko
         insmod hi3518e_vgs.ko
 
+        insmod open_openipc_frame_ts.ko
         insert_isp
         insmod hi3518e_viu.ko detect_err_frame=10
         insmod hi3518e_vpss.ko rfr_frame_comp=1
@@ -285,6 +288,7 @@ remove_ko() {
 
         #rmmod -w piris
         rmmod -w open_isp
+        rmmod -w open_openipc_frame_ts
         rmmod -w hi3518e_sys
         rmmod -w hi3518e_base
         rmmod -w open_himedia


### PR DESCRIPTION
## Summary

Fix cv200 lite firmware so `hi3518e_isp.ko` actually loads. Currently it doesn't, which cascades into broken sensor detection and trips the openhisilicon QEMU-boot gate (openhisilicon#62, hit by openhisilicon#188).

## Root cause

The recent opensdk bump (#2121, 55b72ec → 74d8a65) wired cv200's `ISP_ISR` into the `openipc_frame_ts` chrdev path (`kernel/isp/arch/hi3516cv200/firmware/drv/isp.c`). cv200's `open_isp.ko` (renamed to `hi3518e_isp.ko` at install time) now declares:

```
$ strings .../hi3518e_isp.ko | grep ^depends=
depends=open_base,open_himedia,open_openipc_frame_ts,open_mmz
```

But the cv200 block of `general/package/hisilicon-opensdk/hisilicon-opensdk.mk` (which uses an explicit per-file install list rather than the cv500-style `for ko in $(@D)/kernel/open_*.ko` glob) never shipped `open_openipc_frame_ts.ko`. depmod silently drops the unresolvable dep:

```
$ grep hi3518e_isp .../modules.dep  # before
hisilicon/hi3518e_isp.ko: hisilicon/hi3518e_base.ko hisilicon/mmz.ko hisilicon/hi_media.ko
```

`insmod hi3518e_isp.ko` fails on the unresolvable symbols imported from the missing module. `sensor_i2c.ko` / `sensor_spi.ko` (`depends: open_isp`) cascade, and `remove_detect` rmmods modules that were never loaded — those `rmmod: can't unload` lines are what the openhisilicon CI gate greps for.

cv500 escapes the bug because its install block uses a glob and ships all 44 `open_*.ko` files including `open_openipc_frame_ts.ko`.

## Fix

- **`general/package/hisilicon-opensdk/hisilicon-opensdk.mk`** — cv200 install block: install `open_openipc_frame_ts.ko` (keep `open_` prefix, no vendor counterpart — same pattern as `open_hwrng.ko`).
- **`general/package/hisilicon-osdrv-hi3516cv200/files/script/load_hisilicon`** — `insert_detect()` / `insert_ko()`: `insmod open_openipc_frame_ts.ko` before `insert_isp`. `remove_detect()` / `remove_ko()`: `rmmod -w open_openipc_frame_ts` immediately after `rmmod -w open_isp` (reverse order — loaded before, removed after).

## Test plan

- [x] `make BOARD=hi3516cv200_lite` builds clean, rootfs 4924KB / 5120KB cap.
- [x] `output/target/lib/modules/4.9.37/hisilicon/open_openipc_frame_ts.ko` is present.
- [x] `modules.dep` now reads `hi3518e_isp.ko: open_openipc_frame_ts.ko hi3518e_base.ko mmz.ko hi_media.ko` (was missing the frame_ts entry).
- [x] Boot under `qemu-system-arm -M hi3516cv200 -m 64 -append "console=ttyAMA0,115200 mem=32M root=/dev/ram0 rootfstype=squashfs"`: reaches `openipc-hi3516cv200 login:` cleanly. Serial log has **0** `insmod: can't insert` lines and **0** `rmmod: can't unload` lines. `SENSOR as unknown` (no sensor on QEMU is expected; the modules loaded cleanly).
- [ ] End-to-end: once this merges and the firmware nightly re-tags, re-run `QEMU boot (hi3516cv200)` on openhisilicon#188 — expected green.

## Related

- openhisilicon#144 introduced the `openipc_frame_ts` chrdev.
- openhisilicon#188 (V3A bring-up) surfaced this as the first PR to run against the new nightly.
- The same per-SoC explicit install pattern (cv300, av100, cv100, 3519v101) may need an audit when their ISP source path is wired into frame_ts too — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)