### PR TITLE
hisilicon-opensdk: skip openipc_frame_ts vsync IRQ block on V4 (fix torn frames)

### DIFF
--- a/general/package/hisilicon-opensdk/0001-mipi_rx-skip-v4-vsync-irq-frame-ts-dispatch.patch
+++ b/general/package/hisilicon-opensdk/0001-mipi_rx-skip-v4-vsync-irq-frame-ts-dispatch.patch
@@ -1,0 +1,73 @@
+From: OpenIPC firmware <maintainers@openipc.org>
+Subject: [PATCH] mipi_rx: skip the openipc_frame_ts vsync-IRQ dispatch on V4
+
+openhisilicon#155 (commits 89e5b6b4 + 28a30ca3) added a vsync→openipc_frame_ts
+dispatch to the generic kernel/mipi_rx/mipi_rx_hal.{c,h}. That file is only
+built by SoCs that take the default `else` branch of kernel/Kbuild — in
+practice V4 (hi3516ev200, gk7205v200). cv500 has its own copy under
+kernel/mipi_rx/hi3516cv500/ which received the parallel change; V2/V2A/V3
+use per-family .kbuild and don't touch this file.
+
+On V4 hardware the new IRQ block (vsync-bit W1C inside the ISR) breaks MIPI
+row sync — verified on gk7205v300 + IMX335: nightly-20260521-932db82 (LKG,
+opensdk 74d8a65) shows a clean picture; nightly-20260522-7d32f00 (first-bad,
+opensdk 28a30ca) shows heavy horizontal stripe tearing and underexposure on
+the same sensor + scene. Reported user-side as torn image or
+"Timeout from venc channel 0" depending on sensor.
+
+Fix until upstream (OpenIPC/openhisilicon#194) lands a guard: gate the new
+vsync block and the mask widening to non-V4 only. cv500 keeps the feature
+through its own per-SoC copy.
+
+Forwarded: https://github.com/OpenIPC/openhisilicon/issues/194
+---
+ kernel/mipi_rx/mipi_rx_hal.c | 4 ++++
+ kernel/mipi_rx/mipi_rx_hal.h | 6 ++++++
+ 2 files changed, 10 insertions(+)
+
+diff --git a/kernel/mipi_rx/mipi_rx_hal.c b/kernel/mipi_rx/mipi_rx_hal.c
+--- a/kernel/mipi_rx/mipi_rx_hal.c
++++ b/kernel/mipi_rx/mipi_rx_hal.c
+@@ -1979,7 +1979,9 @@ static int mipi_rx_interrupt_route(int irq, void *dev_id)
+ {
+ 	volatile mipi_rx_sys_regs_t *mipi_rx_sys_regs = get_mipi_rx_sys_regs();
+ 	volatile lvds_ctrl_regs_t *lvds_ctrl_regs;
++#if !defined(hi3516ev200) && !defined(gk7205v200)
+ 	volatile mipi_ctrl_regs_t *mipi_ctrl_regs;
++#endif
+ 	int i = 0;
+
+ 	for (i = 0; i < MIPI_RX_MAX_PHY_NUM; i++) {
+@@ -1999,6 +2001,7 @@ static int mipi_rx_interrupt_route(int irq, void *dev_id)
+ 	 * the 0→1 transition; the per-event-type 1 ms dedupe in
+ 	 * openipc_frame_ts still backstops cv500's double-vsync quirk.
+ 	 */
++#if !defined(hi3516ev200) && !defined(gk7205v200)
+ 	for (i = 0; i < MIPI_RX_MAX_DEV_NUM; i++) {
+ 		static bool s_vsync_was_set[MIPI_RX_MAX_DEV_NUM];
+ 		unsigned int mipi_int, lvds_int;
+@@ -2021,6 +2024,7 @@ static int mipi_rx_interrupt_route(int irq, void *dev_id)
+ 			openipc_frame_ts_push(i, OPENIPC_FT_EVT_MIPI_FS);
+ 		s_vsync_was_set[i] = vsync_now;
+ 	}
++#endif
+
+ 	for (i = 0; i < MIPI_RX_MAX_DEV_NUM; i++) {
+ 		lvds_ctrl_regs = get_lvds_ctrl_regs(i);
+diff --git a/kernel/mipi_rx/mipi_rx_hal.h b/kernel/mipi_rx/mipi_rx_hal.h
+--- a/kernel/mipi_rx/mipi_rx_hal.h
++++ b/kernel/mipi_rx/mipi_rx_hal.h
+@@ -17,8 +17,13 @@
+  * where openipc_frame_ts dispatches it. Error-stat bits unchanged. */
+ #define MIPI_INT_VSYNC     (1u << 4)   /* MIPI_CTRL_INT.int_vsync */
+ #define LVDS_INT_VSYNC     (1u << 28)  /* LVDS_CTRL_INT.lvds_vsync */
++#if defined(hi3516ev200) || defined(gk7205v200)
++#define MIPI_CTRL_INT_MASK (0x00030003)
++#define LVDS_CTRL_INT_MASK (0x0f110000)
++#else
+ #define MIPI_CTRL_INT_MASK (0x00030013)
+ #define LVDS_CTRL_INT_MASK (0x1f110000)
++#endif
+ #define MIPI_FRAME_INT_MASK (0x000f0000)
+ #define MIPI_PKT_INT1_MASK (0x0001000f)
+ #define MIPI_PKT_INT2_MASK (0x000f000f)


### PR DESCRIPTION
## Summary

V4-family cameras (hi3516ev200 / hi3516ev300 / gk7205v200 / gk7205v300) on nightly builds since `nightly-20260522-7d32f00` ship broken video — torn frames on some sensors, `Timeout from venc channel 0` on others.

Root cause: upstream openhisilicon PR [OpenIPC/openhisilicon#155](https://github.com/OpenIPC/openhisilicon/pull/155) (commits `89e5b6b4` + `28a30ca3`) added a vsync→`openipc_frame_ts` dispatch into the **generic** top-level `kernel/mipi_rx/mipi_rx_hal.{c,h}`. That file is built only by SoCs taking the default `else` branch of `openhisilicon/kernel/Kbuild` — in practice V4. cv500 has its own per-SoC copy under `kernel/mipi_rx/hi3516cv500/` that received the parallel change correctly; V2/V2A/V3 take per-family `.kbuild` and don't touch this file.

The new IRQ body W1C-clears the MIPI/LVDS vsync bit inside the ISR. On V4 hardware that desyncs MIPI row reception and the frame falls apart.

This is a downstream workaround until [OpenIPC/openhisilicon#194](https://github.com/OpenIPC/openhisilicon/issues/194) lands a proper guard upstream. The patch gates the new vsync block and the mask widening to non-V4 only. cv500 keeps the feature through its own per-SoC source file.

## Verified on hardware

`gk7205v300` lab camera + IMX335 sensor + `lite` variant. Same scene (color checker) across three flashes:

| Build | opensdk | open_mipi_rx srcversion | depends | Image |
|---|---|---|---|---|
| nightly-20260521-932db82 (LKG) | `74d8a65` | `9F6077B785E512DDED501D6` | `open_osal,open_sys_config` | clean |
| nightly-20260522-7d32f00 (first-bad) | `28a30ca` | `8EF923DF907C1F7F3C6898E` | `+open_openipc_frame_ts` | torn |
| this PR (28a30ca + patch) | `28a30ca` | `64D9F91D0C23EE5FB79F14A` | `open_osal,open_sys_config` | clean |

The patched module's `depends` line matches LKG (no `openipc_frame_ts` dep on V4), confirming the `#if defined(hi3516ev200) || defined(gk7205v200)` guard removed the call site at compile time.

## Test plan

- [x] Patch applies cleanly on opensdk `28a30ca` and current head `e22d315`
- [x] `make BOARD=gk7205v300_lite` builds clean (uImage 1834/2048 KB, rootfs.squashfs 5104/5120 KB)
- [x] Flashed to lab camera via `sysupgrade -k -r --archive=...`, post-reboot RTSP snapshot matches LKG quality
- [ ] Worth re-running CI matrix to make sure no other SoC family regresses (cv500 ships its own copy of the IRQ block so should be unaffected, but extra verification is cheap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)