### PR TITLE
hisilicon-opensdk: bump e22d315 → b958db4 (V4 mipi_rx vsync IRQ fix)

### DIFF
--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = e22d315
+HISILICON_OPENSDK_VERSION = b958db4
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE


### PR DESCRIPTION
## Summary

Pulls in openhisilicon main HEAD with merged PR [OpenIPC/openhisilicon#195](https://github.com/OpenIPC/openhisilicon/pull/195) — the `openipc_frame_ts` vsync IRQ block in the generic `kernel/mipi_rx/mipi_rx_hal.{c,h}` is now gated to non-V4 only. cv500 keeps the feature through its own per-SoC source file.

Fixes the V4 (hi3516ev200, hi3516ev300, gk7205v200, gk7205v300) nightly regression that landed with `nightly-20260522-7d32f00`. Root-cause issue at OpenIPC/openhisilicon#194. User reports covered torn image (gk7205v300/sc223a, hi3516ev300/sp2305) and outright stream collapse with `Timeout from venc channel 0` in majestic (gk7205v200/os02g10).

## Verified on hardware

`gk7205v300` lab camera + IMX335 sensor + `lite` variant. Same scene (color checker) across three flashes:

| Build | opensdk | `open_mipi_rx.ko` srcversion | depends | Image |
|---|---|---|---|---|
| `nightly-20260521-932db82` (LKG) | `74d8a65` (pre-#155) | `9F6077B785E512DDED501D6` | `open_osal,open_sys_config` | clean |
| `nightly-20260522-7d32f00` (first-bad) | `28a30ca` (post-#155) | `8EF923DF907C1F7F3C6898E` | `+open_openipc_frame_ts` | heavy horizontal tearing, underexposure |
| this PR (`b958db4` = `e22d315` + #195 squash) | `b958db4` | `64D9F91D0C23EE5FB79F14A` | `open_osal,open_sys_config` | clean, matches LKG |

The patched module's `depends` line matches LKG — confirms the `#if defined(hi3516ev200) || defined(gk7205v200)` guard removes the `openipc_frame_ts_push` call site at compile time on V4. cv500 retains the feature via its own per-SoC file.

## Test plan

- [x] `make BOARD=gk7205v300_lite clean && make BOARD=gk7205v300_lite` against the bumped SHA pulls the github tarball, builds clean in 4:21 (uImage 1834/2048 KB, rootfs.squashfs 5060/5120 KB)
- [x] Flashed via `sysupgrade -k -r --archive=...`, post-reboot RTSP snapshot matches LKG quality
- [ ] CI matrix on this PR (V4 + non-V4) confirms no other family regresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)