### PR TITLE
aws-webrtc: bump SDK to upstream awslabs v1.18.1

### DIFF
--- a/general/package/aws-webrtc/aws-webrtc.mk
+++ b/general/package/aws-webrtc/aws-webrtc.mk
@@ -4,8 +4,14 @@
 #
 ################################################################################
 
+# Pinned to OpenIPC/webrtc-c bump/upstream-v1.18.1 (awslabs upstream v1.18.1,
+# 2026-05-06, plus 6 OpenIPC-local commits replayed). The legacy 'develop' tip
+# (frozen at 078f1677, 2022-10) is intentionally left alone so other consumers
+# of the fork keep getting byte-identical bytes. The bumped SDK supports both
+# mbedTLS 2.x and 3.x via MBEDTLS_VERSION_NUMBER gating; firmware's
+# mbedtls-openipc (2.25.0) takes the 2.x branch.
 AWS_WEBRTC_SITE = $(call github,OpenIPC,webrtc-c,$(AWS_WEBRTC_VERSION))
-AWS_WEBRTC_VERSION = develop
+AWS_WEBRTC_VERSION = da92942bed42987c00a976c28b37d7e5ebcb5b85
 
 AWS_WEBRTC_INSTALL_STAGING = YES
 AWS_WEBRTC_LICENSE = Apache-2.0


### PR DESCRIPTION
## Summary

Pin `general/package/aws-webrtc/aws-webrtc.mk` to OpenIPC/webrtc-c commit `da92942b` — replays the OpenIPC-local commits on top of awslabs upstream **v1.18.1** (2026-05-06). The fork's `develop` ref stays frozen at `078f1677` so existing downstream consumers keep receiving byte-identical tarballs.

Four years of upstream picked up in one go:

- H.265 RTP payloader (already present in SDK; unblocks codec work)
- PLI/FIR + REMB receiver-driven feedback callbacks
- `configureTransceiverRollingBuffer` public API
- DTLS multi-fingerprint algorithm handling
- Transceiver direction SDP intersection fixes (Firefox / iOS Safari interop)
- mDNS-anonymised ICE candidates gracefully skipped (cross-host Chrome no longer stalls on `connecting`)

## mbedTLS 2.x compatibility

OpenIPC firmware ships `mbedtls-openipc` at **2.25.0**. The bumped SDK defaults to v3.6.3 when building its own dependency, but this package uses `BUILD_DEPENDENCIES=OFF`, so the SDK links against system mbedtls and version-gates its own source via `MBEDTLS_VERSION_NUMBER`:

- All `MBEDTLS_PRIVATE(field)` accesses in `Crypto/{Tls,Dtls}_mbedtls.c` are confined to `#if MBEDTLS_BEFORE_V3 ... #else <3.x branch> #endif` blocks (audited via grep — 10/10 uses guarded).
- MD5 / SHA helpers wrap the API drift (`mbedtls_md5_ret` 2.x vs `mbedtls_md5` 3.x) behind `KVS_MD5_DIGEST` etc.
- `MBEDTLS_TLS_SRTP_*` profile constants are present in 2.25.0 — `mbedtls-openipc`'s `MBEDTLS_ENABLE_SRTP` post-patch hook already enables `MBEDTLS_SSL_DTLS_SRTP` in `config.h`.

## Build options unchanged

`USE_MBEDTLS=ON`, `BUILD_DEPENDENCIES=OFF`, `ENABLE_DATA_CHANNEL=OFF`, `BUILD_SAMPLE=OFF` continue to work. Link deps (`kvspicUtils`, `kvspicState` from `aws-producer`) are unchanged — the old `develop` already links the same names.

## Test plan

- [ ] Build at least one `ultimate` defconfig that pulls aws-webrtc end-to-end. Suggested matrix:
  - `make BOARD=hi3516cv500_ultimate` (canonical webrtc-capable target)
  - one additional HiSilicon family (e.g. `hi3516ev300_ultimate`)
  - one non-HiSilicon ultimate (e.g. `gk7205v300_ultimate`) to catch toolchain quirks
- [ ] Flash on a hi3516cv500 lab camera; visit `http://<camera>/webrtc` from a browser on the camera's L2 broadcast domain (mDNS hint applies for cross-host); confirm video plays.
- [ ] Optional regression smoke: same flash on a non-HiSilicon `ultimate` camera.