### PR TITLE
sysupgrade: route manifest by BUILD_PLATFORM, not BUILD_OPTION (1.0.52)

### DIFF
--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -1,22 +1,31 @@
 #!/bin/sh
 # OpenIPC.org | 2025
-scr_version=1.0.51
+scr_version=1.0.52
 
 args="$@"
 LOCK_FILE=/tmp/sysupgrade.lock
-# Route to firmware or builder manifest based on BUILD_OPTION (variant).
-# Mirrors the legacy URL repo selector at download_firmware ("case $osr in
-# lite|ultimate|neo) repo=firmware"). lite/ultimate/neo cameras come from
-# OpenIPC/firmware; everything else (fpv, rubyfpv, apfpv, lte, venc, mini,
-# ...) is built by OpenIPC/builder and indexed in its own manifest.
-_osr=$(grep '^BUILD_OPTION=' /etc/os-release 2>/dev/null | cut -d= -f2)
-case "${_osr:-lite}" in
-	lite|ultimate|neo) _manifest_repo=firmware ;;
-	*)                 _manifest_repo=builder  ;;
+# Route to firmware or builder manifest. A stock OpenIPC/firmware build
+# stamps BUILD_PLATFORM=${soc}_${variant} with variant in {lite,ultimate,
+# neo}. Anything else — a per-device override (${soc}_${variant}_${device},
+# two or more underscores) or a non-stock variant (${soc}_fpv etc.) — is
+# built by OpenIPC/builder. Pre-1.0.51 cameras lack BUILD_PLATFORM; fall
+# back to BUILD_OPTION (variant) alone.
+_plat=$(grep '^BUILD_PLATFORM=' /etc/os-release 2>/dev/null | cut -d= -f2)
+case "$_plat" in
+	*_*_*)                            _manifest_repo=builder  ;;
+	*_lite|*_ultimate|*_neo)          _manifest_repo=firmware ;;
+	?*)                               _manifest_repo=builder  ;;
+	*)
+		_osr=$(grep '^BUILD_OPTION=' /etc/os-release 2>/dev/null | cut -d= -f2)
+		case "${_osr:-lite}" in
+			lite|ultimate|neo) _manifest_repo=firmware ;;
+			*)                 _manifest_repo=builder  ;;
+		esac
+		;;
 esac
 MANIFEST_URL=${MANIFEST_URL:-https://openipc.github.io/${_manifest_repo}/manifest.flat}
 MANIFEST_CACHE=/tmp/manifest.flat
-unset _osr _manifest_repo
+unset _osr _plat _manifest_repo
 
 echo_c() {
 	# 31 red, 32 green, 33 yellow, 34 blue, 35 magenta, 36 cyan, 37 white, 38 grey


### PR DESCRIPTION
## Summary

User report from a builder-built `gk7205v210_lite_vixand-ivg-g4h` camera (per-device override):

```
root@openipc-gk7205v210:~# sysupgrade --list-builds
…
No builds available for gk7205v210_lite_vixand-ivg-g4h yet.
Manifest: https://openipc.github.io/firmware/manifest.flat
```

Root cause: routing was variant-based. `BUILD_OPTION=lite` sent the camera to firmware's manifest, but the compound platform key only lives in builder's manifest (firmware ships just the generic `gk7205v210_lite`).

This switches the discriminator to **BUILD_PLATFORM structure**:
- `${soc}_${variant}_${device}` (≥ 2 underscores) → builder
- `${soc}_{lite,ultimate,neo}` → firmware
- `${soc}_{fpv,rubyfpv,apfpv,lte,venc,mini,…}` → builder
- `BUILD_PLATFORM` missing (pre-1.0.51 cameras) → existing `BUILD_OPTION` fallback

Bumps `scr_version` 1.0.51 → 1.0.52 so the existing `self_update()` loop picks up the new script.

## Test plan

- [x] Patched script piped to `root@172.17.32.104` (the reporter's camera): `--list-builds=5` now returns 4 nightlies with `*` on `nightly-20260526-ee40da8` (the running build). Manifest hits `openipc.github.io/builder/manifest.flat`.
- [ ] `root@openipc-hi3520dv200.dlab.torturelabs.com` (stock `hi3516dv200_lite` from firmware) — confirm `--list-builds` still hits firmware manifest after release.
- [ ] `root@openipc-gk7205v200.dlab.torturelabs.com` (builder fpv variant) — confirm `gk7205v200_fpv` still routes to builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)