### PR TITLE
hisilicon-opensdk: bump b958db4 → 073e6e8 (V2A sensor_i2c i2c-in-IRQ fix)

### DIFF
--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = b958db4
+HISILICON_OPENSDK_VERSION = 073e6e8
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE


### PR DESCRIPTION
## Summary

Pulls in [OpenIPC/openhisilicon#197](https://github.com/OpenIPC/openhisilicon/pull/197) — restores vendor's IRQ-safe `hi_i2c_master_send` on the cv200 sensor_i2c module.

Background: `abadb7cf` ([openhisilicon#162](https://github.com/OpenIPC/openhisilicon/pull/162) "kernel/hi3516cv200: bring up V2 generation against Linux 7.0") added a `#ifndef hi_i2c_master_send` macro check guarding a `#define hi_i2c_master_send i2c_master_send` fallback. The vendor symbol is an `extern` function (declared in `drivers/i2c/busses/i2c-hibvt.c`), **not** a preprocessor macro, so the `#ifndef` always evaluated to true and the alias fired on vendor kernel too. Every sensor write from `ISP_DRV_RegConfigSensor → hi_sensor_i2c_write` got silently routed through `i2c_master_send → i2c_transfer → rt_mutex_trylock`, which WARNs from hardirq/softirq context and returns `-EAGAIN`. Sensor exposure/gain registers never updated → AE became an open loop.

Per-sensor symptom for OpenIPC/firmware#2144:

- **OV2735** (reporter): sensor's internal AGC takes over when ISP writes fail → image >96 % white.
- **soi_f22** (lab cam): sensor stays at boot-default → image dim but "stable" because nothing is changing.

#197 gates the entire fallback block on `I2C_M_16BIT_REG` (a real macro on the vendor kernel), so both halves of the shim activate together on mainline and stay out of the way on vendor.

## Verified on hardware

`openipc-hi3518ev200.dlab.torturelabs.com` (soi_f22 sensor), same scene throughout:

| metric | this repo @ `b958db4` (opensdk pre-#197) | this PR (opensdk `073e6e8`) |
|---|---|---|
| `rt_mutex_trylock` WARN | 3+ at boot | **0** |
| AE Error | -44 (diverging) | 10 (converged) |
| `/image.jpg` size | 53 KB (sensor stuck) | 108 KB (proper exposure) |
| RTSP 20 s frame luma stdev (10 fps, 160×90) | n/a — stuck | **0.16** (0.15 % variance) |

`sensor_i2c.ko` shipped in the built `openipc.hi3518ev200-nor-lite.tgz` from this commit is byte-identical (`20c9cacb…`) to the module flashed to the lab cam over overlay during #197 verification — the firmware tgz inherits the same verified behaviour.

## Test plan

- [x] github tarball at `073e6e8` downloads + builds clean (uImage 1831/2048 KB, rootfs.squashfs 4816/5120 KB, build time 4 m)
- [x] Built `sensor_i2c.ko` hash matches the lab-verified module
- [x] Lab cam (V2A) with that module shows 0 rt_mutex WARN + AE converged + frame stdev 0.16 / 200 frames
- [ ] CI matrix on this PR confirms no regression on other SoC families

## Closes

- OpenIPC/firmware#2144

🤖 Generated with [Claude Code](https://claude.com/claude-code)
