### PR TITLE
ci: skip manifest/image runs on PR-triggered builds

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -16,13 +16,19 @@ jobs:
   toolchain:
     name: Image
     runs-on: ubuntu-latest
+    # Run after nightly (schedule) or operator dispatch only — PR builds do
+    # not produce new release assets, so reassembling images on every PR
+    # build is wasted compute. Mirrors the gate in manifest.yml.
+    #
     # Publish on success AND on partial-failure: see manifest.yml rationale.
     # A flaky board doesn't deny image assembly for the platforms that did
     # upload a firmware tgz — firmware_url returns empty for missing ones and
     # create() skips them.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion)
+      ((github.event.workflow_run.event == 'schedule' ||
+        github.event.workflow_run.event == 'workflow_dispatch') &&
+       contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion))
     env:
       SIGMASTAR: ssc30kd ssc30kq ssc325 ssc333 ssc335 ssc335de ssc337 ssc337de ssc338q ssc377 ssc377d ssc377de ssc377qe ssc378de ssc378qe
       INGENIC: t10 t10l t20 t20l t20x t21n t23n t30a t30a1 t30l t30n t30x t31a t31al t31l t31lc t31n t31x

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -15,6 +15,10 @@ concurrency:
 jobs:
   generate:
     name: Generate manifest
+    # Run after nightly (schedule) or operator dispatch only — PR builds do
+    # not upload to any release, so re-emitting the manifest after each PR
+    # build is wasted compute (and noisily triggers gh-pages deploys).
+    #
     # Publish on success AND on partial-failure: one flaky board (e.g. a
     # transient toolchain 502) should not deny manifest updates for the 90+
     # platforms that did upload artifacts. enrich_manifest.py reads whatever
@@ -22,7 +26,9 @@ jobs:
     # up with fewer platforms in its `platforms` map.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion)
+      ((github.event.workflow_run.event == 'schedule' ||
+        github.event.workflow_run.event == 'workflow_dispatch') &&
+       contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master (for the script)


### PR DESCRIPTION
## Summary

`manifest.yml` and `image.yml` both listen on `workflow_run: build` for every completed `build`, including the ones that PRs trigger. PR builds don't upload any new release assets, so:

- re-emitting the manifest is a no-op that nevertheless pushes a noisy commit to `gh-pages` and fires `pages-build-deployment`,
- reassembling NOR images downloads the same artifacts and produces the same `image` release.

Each merged PR therefore spawns roughly three extra workflow runs (manifest + image + pages-build-deployment). With the current PR cadence this is why image/manifest/pages jobs appear throughout the day instead of only after the nightly cron.

Tighten the existing job-level `if:` on both workflows to require `workflow_run.event == 'schedule' || workflow_run.event == 'workflow_dispatch'`. PR-triggered build completions are now ignored. Nightly cron and manual dispatch paths unchanged.

## Test plan

- [ ] Open this PR → `build` runs (expected) but `manifest`/`image` skip (expected); confirm in Actions tab.
- [ ] After merge, manually dispatch `build.yml` via `gh workflow run build.yml` → confirm `manifest`/`image` both run.
- [ ] Tonight's 22:30 UTC scheduled `build` → confirm `manifest`/`image` both run, single `pages-build-deployment` follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)