### PR TITLE
ci: drop sizes.json URLs from manifest.json (CORS-blocked in browsers)

### DIFF
--- a/.github/scripts/enrich_manifest.py
+++ b/.github/scripts/enrich_manifest.py
@@ -29,7 +29,6 @@ REPO = os.environ.get("GITHUB_REPOSITORY", "OpenIPC/firmware")
 RETENTION = 90
 TAG_RE = re.compile(r"^nightly-(\d{8})-([0-9a-f]{7})$")
 ASSET_RE = re.compile(r"^openipc\.([^.]+)-(nor|nand)-(lite|ultimate|neo)\.tgz$")
-SIZES_RE = re.compile(r"^sizes\.([^.]+)-(lite|ultimate|neo)\.json$")
 
 # Retry budget for transient GitHub API failures (HTTP 401 Bad credentials,
 # 5xx, rate-limit) observed on workflow_run-triggered runs 2026-05-23.
@@ -126,20 +125,13 @@ def main() -> None:
         platforms: dict[str, dict[str, dict]] = {}
         for a in info.get("assets") or []:
             parsed = parse_asset(a["name"])
-            if parsed:
-                platform, flash = parsed
-                platforms.setdefault(platform, {})[flash] = {
-                    "url": a["url"],
-                    "size": a["size"],
-                }
+            if not parsed:
                 continue
-            m = SIZES_RE.match(a["name"])
-            if m:
-                soc, variant = m.groups()
-                platforms.setdefault(f"{soc}_{variant}", {})["sizes"] = {
-                    "url": a["url"],
-                    "size": a["size"],
-                }
+            platform, flash = parsed
+            platforms.setdefault(platform, {})[flash] = {
+                "url": a["url"],
+                "size": a["size"],
+            }
         builds.append({
             "id": info["tagName"],
             "sha": sha,
@@ -162,19 +154,11 @@ def main() -> None:
         "# OpenIPC firmware build index",
         f"# generated_at={now}",
         "# columns: build_id platform flash size url",
-        "# also: @sizes <build_id> <platform> <size> <url>  (per-platform size report sidecar)",
     ]
     for b in builds:
         for platform, flashes in sorted(b["platforms"].items()):
             for flash, info in sorted(flashes.items()):
-                if flash == "sizes":
-                    continue
                 lines.append(f"{b['id']} {platform} {flash} {info['size']} {info['url']}")
-            sizes = flashes.get("sizes")
-            if sizes:
-                lines.append(
-                    f"@sizes {b['id']} {platform} {sizes['size']} {sizes['url']}"
-                )
     lines.append("# channels")
     for ch, target in manifest["channels"].items():
         lines.append(f"@channel {ch} {target}")


### PR DESCRIPTION
## Summary

Reverts the manifest-indexing half of #2166 — the part that linked to
`sizes.<plat>.json` release assets from `manifest.json` and emitted
matching `@sizes` lines in `manifest.flat`. Those URLs point at
`github.com/.../releases/download/...`, which returns no
`Access-Control-Allow-Origin` header, so every browser-side fetch was
blocked by CORS. The \"CORS verified\" line in #2166's test plan was a
`curl -sfL`, which doesn't enforce CORS — the gap propagated to
OpenIPC/builder#102 and to a downstream PoC that shipped broken.

## What stays

- `general/scripts/size_report.py` and the `size-report` Makefile target
  (working developer tool).
- `.github/workflows/build.yml`'s _Build size report_ step.
- The `\${{env.SIZES}}` line in all three upload steps — release tags
  keep carrying `sizes.*.json` as the canonical artefact, addressable
  server-side via `gh release download` and consumable by any CI
  workflow (no CORS gate there).

## What goes

- `SIZES_RE` in `.github/scripts/enrich_manifest.py`.
- The asset-loop branch that recorded `platforms[<plat>].sizes`.
- The `@sizes` line type in `manifest.flat`.

Result: `enrich_manifest.py` is bit-for-bit identical to the
pre-#2166 state (file hash \`a4a556a5\`).

## Why not also drop the release-asset upload

The release-asset \`sizes.json\` is still useful in non-browser contexts.
A downstream firmware-explorer rebuild (separate PR) will run a
build-time aggregator that downloads them server-side and bakes the
data into a static site, avoiding the cross-origin fetch entirely.
Keeping releases as the canonical artefact source means no
duplication across stores.

## On-device impact

None. The on-device sysupgrade reads positional 4-column lines from
\`manifest.flat\` and skips \`@\`-prefixed directives it doesn't
recognise. Dropping \`@sizes\` lines is a strict superset of what it
already ignored.

## Test plan

- [x] \`python3 -m py_compile .github/scripts/enrich_manifest.py\` — syntax OK.
- [x] Diff confirmed bit-for-bit revert of #2166's manifest changes
      (file hash matches pre-PR state).
- [ ] CI green on this branch.
- [ ] Post-merge: the next \`manifest\` workflow run drops the \`sizes\`
      blocks from \`builds[].platforms.*\` in
      https://openipc.github.io/firmware/manifest.json and stops
      emitting \`@sizes\` lines in
      https://openipc.github.io/firmware/manifest.flat .

🤖 Generated with [Claude Code](https://claude.com/claude-code)