### PR TITLE
majestic-webui: install renamed bin/ntfy.sh (closes #2173)

### DIFF
--- a/general/package/majestic-webui/majestic-webui.mk
+++ b/general/package/majestic-webui/majestic-webui.mk
@@ -18,6 +18,7 @@ endif
 define MAJESTIC_WEBUI_INSTALL
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/usr
 	cp -r $(@D)/sbin $(TARGET_DIR)/usr
+	[ -d $(@D)/bin ] && cp -r $(@D)/bin $(TARGET_DIR)/usr || true
 
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/var
 	cp -r $(@D)/www $(TARGET_DIR)/var


### PR DESCRIPTION
## Summary

- Upstream [majestic-webui PR #57](https://github.com/OpenIPC/majestic-webui/pull/57) renamed `sbin/ntfy` → `bin/ntfy.sh` (and updated `www/cgi-bin/ext-ntfy.cgi` to invoke `/usr/bin/ntfy.sh`) to resolve the package name conflict with the in-tree `ntfy` CLI (`BR2_PACKAGE_NTFY`), which installs its own `/usr/bin/ntfy` ELF.
- `general/package/majestic-webui/majestic-webui.mk` only copied `$(@D)/sbin` and `$(@D)/www`. Without this change, the renamed script silently disappears from the rootfs and the webui "Send Test Notification" button breaks.
- Adds a guarded `cp -r $(@D)/bin $(TARGET_DIR)/usr` so the script lands at `/usr/bin/ntfy.sh` where the CGI now expects it. The `[ -d ... ]` guard keeps the same `.mk` happy if an older majestic-webui revision (no `bin/`) is ever pulled.

Closes #2173.

## Test plan

- [ ] `make BOARD=<any> br-majestic-webui-rebuild` succeeds.
- [ ] `output/<board>/target/usr/bin/ntfy.sh` is present (script).
- [ ] `output/<board>/target/usr/sbin/ntfy` is gone.
- [ ] With `BR2_PACKAGE_NTFY=y` toggled on, `output/<board>/target/usr/bin/ntfy` (ELF) coexists with `ntfy.sh` and `which ntfy` resolves to the ELF.
- [ ] On a lab camera with `majestic-webui` enabled, the Ntfy page → "Send Test Notification" button returns "OK".

🤖 Generated with [Claude Code](https://claude.com/claude-code)