### PR TITLE
ci: publish nightly releases from a single job to stop upload 500s

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,50 +313,25 @@ jobs:
           if [ -e "$KCONFIG" ]; then echo "KCONFIG=$KCONFIG" >> ${GITHUB_ENV}; fi
           if [ -e "$KHELP" ]; then echo "KHELP=$KHELP" >> ${GITHUB_ENV}; fi
 
-      - name: Upload firmware (dated)
+      # Hand the firmware + sidecars to the single `publish` job instead of
+      # uploading to releases from here. ~90 matrix jobs all deleting and
+      # re-uploading assets on the SAME shared `nightly`/`latest` releases at
+      # once made the GitHub releases API return HTTP 500 ("Server Error") —
+      # e.g. run 27108181857, where every build succeeded but 14 jobs went red
+      # in their upload step. Consolidating every release write into one job
+      # removes the concurrent-writer contention.
+      - name: Upload build artifacts
         if: github.event_name != 'pull_request'
-        uses: softprops/action-gh-release@v2
+        uses: actions/upload-artifact@v4
         with:
-          tag_name: ${{ needs.preflight.outputs.build_id }}
-          prerelease: true
-          body: |
-            sha=${{ needs.preflight.outputs.head_sha }}
-            short=${{ needs.preflight.outputs.short_sha }}
-            built_at=${{ needs.preflight.outputs.built_at }}
-          files: |
-            ${{env.NORFW}}
-            ${{env.NANDFW}}
-            ${{env.SIZES}}
-            ${{env.KCONFIG}}
-            ${{env.KHELP}}
-
-      - name: Upload firmware (rolling nightly)
-        if: github.event_name != 'pull_request'
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: nightly
-          body: |
-            sha=${{ needs.preflight.outputs.head_sha }}
-            short=${{ needs.preflight.outputs.short_sha }}
-            built_at=${{ needs.preflight.outputs.built_at }}
-          files: |
-            ${{env.NORFW}}
-            ${{env.NANDFW}}
-            ${{env.SIZES}}
-            ${{env.KCONFIG}}
-            ${{env.KHELP}}
-
-      - name: Upload firmware (latest — legacy alias)
-        if: github.event_name != 'pull_request'
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: latest
-          files: |
-            ${{env.NORFW}}
-            ${{env.NANDFW}}
-            ${{env.SIZES}}
-            ${{env.KCONFIG}}
-            ${{env.KHELP}}
+          name: fw-${{ matrix.platform }}
+          if-no-files-found: ignore
+          retention-days: 1
+          path: |
+            output/images/openipc*.tgz
+            output/images/sizes.*.json
+            output/images/kconfig-graph.*.json
+            output/images/kconfig-help.*.json
 
       - name: Send binary
         if: github.event_name != 'pull_request' && env.NORFW
@@ -369,6 +344,74 @@ jobs:
           HTTP=$(curl -s -o /dev/null -w %{http_code} https://api.telegram.org/bot${TG_TOKEN}/sendDocument -F chat_id=${TG_CHANNEL} -F caption="${TG_HEADER}" -F document=@${NORFW})
           echo Telegram response: ${HTTP}
 
+  # All release writes happen here, once, so only a SINGLE job ever touches the
+  # shared `nightly`/`latest` releases (and the per-run dated release). The old
+  # design had every matrix job upload to these releases, so ~90 jobs raced to
+  # delete/re-upload assets on the same release and the GitHub releases API
+  # returned HTTP 500 ("Server Error") under that concurrency — run
+  # 27108181857 built fine on every board yet went red on 14 upload steps.
+  #
+  # Best-effort by design: publish whatever boards produced, even if some
+  # failed (matches enrich_manifest.py, which indexes whatever assets exist).
+  # Never runs on PRs (no artifacts) or on a scheduled no-op (buildroot skipped).
+  publish:
+    name: Publish releases
+    needs: [preflight, buildroot]
+    if: >-
+      github.event_name != 'pull_request' &&
+      needs.preflight.outputs.should_build == 'true' &&
+      contains(fromJSON('["success", "failure"]'), needs.buildroot.result)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: fw-*
+          path: dist
+          merge-multiple: true
+
+      - name: Collect assets
+        id: collect
+        run: |
+          mkdir -p dist
+          count=$(find dist -type f | wc -l)
+          echo "Collected ${count} asset(s):"
+          ls -la dist || true
+          echo "count=${count}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish firmware (dated)
+        if: steps.collect.outputs.count != '0'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.preflight.outputs.build_id }}
+          prerelease: true
+          body: |
+            sha=${{ needs.preflight.outputs.head_sha }}
+            short=${{ needs.preflight.outputs.short_sha }}
+            built_at=${{ needs.preflight.outputs.built_at }}
+          files: dist/*
+
+      - name: Publish firmware (rolling nightly)
+        if: steps.collect.outputs.count != '0'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: nightly
+          body: |
+            sha=${{ needs.preflight.outputs.head_sha }}
+            short=${{ needs.preflight.outputs.short_sha }}
+            built_at=${{ needs.preflight.outputs.built_at }}
+          files: dist/*
+
+      - name: Publish firmware (latest — legacy alias)
+        if: steps.collect.outputs.count != '0'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: latest
+          files: dist/*
+
   # Single umbrella status check that reflects the whole build matrix, so the
   # branch-protection required-checks list does not need one hardcoded
   # "Firmware (<board>)" context per board (adding/removing a board no longer
@@ -376,13 +419,13 @@ jobs:
   # instead of the per-board contexts.
   ci-gate:
     name: CI Gate
-    needs: [preflight, buildroot]
+    needs: [preflight, buildroot, publish]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Require preflight + firmware matrix to succeed
         run: |
-          echo "preflight=${{ needs.preflight.result }} buildroot=${{ needs.buildroot.result }}"
+          echo "preflight=${{ needs.preflight.result }} buildroot=${{ needs.buildroot.result }} publish=${{ needs.publish.result }}"
           if [ "${{ needs.preflight.result }}" != "success" ]; then
             echo "::error::preflight did not succeed"; exit 1
           fi
@@ -391,4 +434,10 @@ jobs:
           case "${{ needs.buildroot.result }}" in
             success|skipped) echo "firmware matrix OK (${{ needs.buildroot.result }})" ;;
             *) echo "::error::firmware matrix result=${{ needs.buildroot.result }}"; exit 1 ;;
+          esac
+          # publish is skipped on PRs and on scheduled no-ops; only a real
+          # failure of the single release-writer should fail the gate.
+          case "${{ needs.publish.result }}" in
+            success|skipped) echo "publish OK (${{ needs.publish.result }})" ;;
+            *) echo "::error::publish result=${{ needs.publish.result }}"; exit 1 ;;
           esac


### PR DESCRIPTION
## Why

Nightly run [27108181857](https://github.com/OpenIPC/firmware/actions/runs/27108181857) went red, but **nothing failed to build** — all 83 firmware matrix jobs compiled and verified successfully. 14 jobs went red in their **release-upload** step with a bare `##[error]Server Error`, and the `CI Gate` failed with them.

### Root cause

The `build` matrix fans out to ~90 jobs, and **each one** uploaded its firmware + sidecars to the shared `nightly` and `latest` releases (plus the per-run dated release) via `softprops/action-gh-release`. That action does *find release → delete existing asset → upload* against the GitHub releases API. With ~90 jobs concurrently listing/deleting/re-uploading assets on the **same** release, the API intermittently returns HTTP 500.

Evidence it's contention, not a regression:
- Failing boards are random and unrelated (ssc335, t21, gm8135, rv1106, nt98566, …).
- Failures clustered when batches of jobs finished together (12 within ~22 s, plus 2 stragglers when slow boards landed).
- Every failure is in an upload step; every `Build firmware` step is green.

## What

- Matrix jobs no longer write to releases. They publish their artifacts with `actions/upload-artifact` (`fw-<platform>`, 1-day retention).
- A new single **`publish`** job downloads all artifacts and writes the **dated**, **`nightly`**, and **`latest`** releases **once** — so exactly one job ever touches a shared release. Concurrent-writer contention is gone.
- `publish` is best-effort: it runs even on a partial matrix failure (matching `enrich_manifest.py`, which indexes whatever assets exist), and is skipped on PRs and scheduled no-ops.
- `CI Gate` now also gates on `publish` (`success|skipped`).

## Compatibility

Tags, release body (`sha=`/`short=`/`built_at=`), and asset filenames are **unchanged**, so downstream consumers are unaffected:
- `enrich_manifest.py` indexes the dated `nightly-YYYYMMDD-<short>` releases and their `.tgz` assets — still produced, same names/body.
- `image.yml` reads uboot from the `latest` release — still populated.
- `manifest.yml`/`image.yml` trigger on `workflow_run [build] completed`, which now fires after `publish` finishes — they read fully-uploaded releases (slightly more robust than before).

## Validation

- `actionlint` passes clean.
- YAML parses; job graph: `preflight → buildroot (matrix) → publish → ci-gate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)