### PR TITLE
overlay/S01syslogd: make the syslog ring size configurable (default 64 KiB)

### DIFF
--- a/general/overlay/etc/init.d/S01syslogd
+++ b/general/overlay/etc/init.d/S01syslogd
@@ -2,7 +2,13 @@
 
 DAEMON="syslogd"
 PIDFILE="/var/run/$DAEMON.pid"
-DAEMON_ARGS="-n -C64 -t"
+
+# Size (KiB) of the in-RAM circular log buffer. Defaults to 64 KiB so stock
+# cameras spend no extra memory; the WebUI (Information > Logs) can raise it by
+# writing SYSLOG_SIZE to /etc/default/syslogd for users who want more backlog.
+SYSLOG_SIZE=64
+[ -r /etc/default/syslogd ] && . /etc/default/syslogd
+DAEMON_ARGS="-n -C${SYSLOG_SIZE:-64} -t"
 
 start() {
 	echo -n "Starting $DAEMON: "


### PR DESCRIPTION
`S01syslogd` hardcoded `-C64`. Source `/etc/default/syslogd` (`SYSLOG_SIZE`) with a **64 KiB default**, so the WebUI (Information > Logs) can raise the in-RAM log buffer for users who want more backlog — without spending extra memory on the millions of stock cameras, which keep 64 KiB.

Pairs with the webui control (OpenIPC/majestic-webui#62). Verified on hi3516av300: no file → `syslogd -C64`; `/etc/default/syslogd` with `SYSLOG_SIZE=256` → `syslogd -C256`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)