### PR TITLE
ci: re-fetch moving-ref (VERSION=HEAD) package downloads each build

### DIFF
--- a/.github/workflows/build-one.yml
+++ b/.github/workflows/build-one.yml
@@ -62,6 +62,20 @@ jobs:
           key: dl-${{env.CACHE_DATE}}
           restore-keys: dl-
 
+      - name: Refresh moving-ref package downloads
+        run: |
+          # Packages pinned to a moving ref (VERSION = HEAD / branch) download as
+          # <pkg>-<ref>.tar.gz — a constant filename. The dl cache key is the month
+          # (date +%m) and actions/cache only saves on a key miss, so that snapshot
+          # is frozen for weeks; buildroot then keeps reusing the stale tarball and
+          # silently ships an old version. This is what desynced majestic-webui from
+          # majestic (blanking every settings field label). Drop those archives so
+          # buildroot re-fetches the current ref each run. Content-addressed packages
+          # (S3 / semver / SHA pins) keep their cache.
+          find output/dl -type f \
+            \( -name '*-HEAD.tar.gz' -o -name '*-master.tar.gz' -o -name '*-main.tar.gz' \) \
+            -print -delete 2>/dev/null || true
+
       - name: Build firmware
         env:
           BUILD_ID:  ${{ needs.resolve.outputs.tag_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,6 +250,20 @@ jobs:
           key: dl-${{env.CACHE_DATE}}
           restore-keys: dl-
 
+      - name: Refresh moving-ref package downloads
+        run: |
+          # Packages pinned to a moving ref (VERSION = HEAD / branch) download as
+          # <pkg>-<ref>.tar.gz — a constant filename. The dl cache key is the month
+          # (date +%m) and actions/cache only saves on a key miss, so that snapshot
+          # is frozen for weeks; buildroot then keeps reusing the stale tarball and
+          # the nightly silently ships an old version. This is what desynced
+          # majestic-webui from majestic (blanking every settings field label).
+          # Drop those archives so buildroot re-fetches the current ref each run.
+          # Content-addressed packages (S3 / semver / SHA pins) keep their cache.
+          find output/dl -type f \
+            \( -name '*-HEAD.tar.gz' -o -name '*-master.tar.gz' -o -name '*-main.tar.gz' \) \
+            -print -delete 2>/dev/null || true
+
       - name: Build firmware
         run: |
           export GIT_HASH=$(git rev-parse --short ${GITHUB_SHA})


### PR DESCRIPTION
## Problem

Packages pinned to a moving ref (`VERSION = HEAD` / a branch) download into the
buildroot dl cache under a **constant** filename — `<pkg>-<ref>.tar.gz` (e.g.
`majestic-webui-HEAD.tar.gz`). The dl cache is keyed on the **month**
(`CACHE_DATE=$(date +%m)`) and `actions/cache` only *saves* on a key miss, so the
first nightly of each month freezes `output/dl` for weeks. From then on buildroot
finds the constant filename already present and **never re-fetches** — the nightly
silently ships a weeks-old snapshot of every moving-ref package, while
content-addressed packages (majestic from S3, semver/SHA pins) keep refreshing.

This desynced a stale-cached **majestic-webui** from a fresh **majestic**: the
streamer's config schema moved field labels to a new key, but the frozen webui
still read the old one, so **every field/switch label in the settings UI went
blank** on affected nightlies. ~28 GitHub packages (ipctool, divinus, go2rtc,
msposd, the wifi/SDK drivers, …) share this same latent staleness hazard.

## Fix

Before the build, delete the cached moving-ref archives so buildroot re-fetches
the current ref each run:

```
find output/dl -type f \
  \( -name '*-HEAD.tar.gz' -o -name '*-master.tar.gz' -o -name '*-main.tar.gz' \) \
  -print -delete
```

Content-addressed downloads (S3 / semver / SHA pins) keep their cache untouched,
so this only re-fetches the handful of packages that are *supposed* to track a
moving ref. Runs right after the dl-cache restore, before `Build firmware`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)