### PR TITLE
hi3516av100/dv100: ship + load the VDA kernel module (enable HW motion detection)

### DIFF
--- a/general/package/hisilicon-osdrv-hi3516av100/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516av100/files/script/load_hisilicon
@@ -292,6 +292,7 @@ insert_ko() {
         insmod hi3516a_h264e.ko H264eMiniBufMode=1
         insmod hi3516a_h265e.ko H265eMiniBufMode=1
         insmod hi3516a_jpege.ko
+        insmod hi3516a_vda.ko
         #insmod hi3516a_ive.ko save_power=0
         #insmod hi3516a_ive.ko
 
@@ -315,6 +316,7 @@ remove_ko() {
         rmmod -w pwm
         #rmmod -w piris
         #rmmod -w hi3516a_ive
+        rmmod -w hi3516a_vda
 
         rmmod -w hi3516a_rc
         rmmod -w hi3516a_jpege

--- a/general/package/hisilicon-osdrv-hi3516av100/hisilicon-osdrv-hi3516av100.mk
+++ b/general/package/hisilicon-osdrv-hi3516av100/hisilicon-osdrv-hi3516av100.mk
@@ -35,7 +35,7 @@ define HISILICON_OSDRV_HI3516AV100_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/4.9.37/hisilicon $(HISILICON_OSDRV_HI3516AV100_PKGDIR)/files/kmod/hi3516a_region.ko
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/4.9.37/hisilicon $(HISILICON_OSDRV_HI3516AV100_PKGDIR)/files/kmod/hi3516a_sys.ko
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/4.9.37/hisilicon $(HISILICON_OSDRV_HI3516AV100_PKGDIR)/files/kmod/hi3516a_tde.ko
-	# $(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/4.9.37/hisilicon $(HISILICON_OSDRV_HI3516AV100_PKGDIR)/files/kmod/hi3516a_vda.ko
+	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/4.9.37/hisilicon $(HISILICON_OSDRV_HI3516AV100_PKGDIR)/files/kmod/hi3516a_vda.ko
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/4.9.37/hisilicon $(HISILICON_OSDRV_HI3516AV100_PKGDIR)/files/kmod/hi3516a_venc.ko
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/4.9.37/hisilicon $(HISILICON_OSDRV_HI3516AV100_PKGDIR)/files/kmod/hi3516a_vgs.ko
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/lib/modules/4.9.37/hisilicon $(HISILICON_OSDRV_HI3516AV100_PKGDIR)/files/kmod/hi3516a_viu.ko


### PR DESCRIPTION
## Problem

On Hi3516A/D V100 (`hi3516av100` / `hi3516dv100`) the firmware shipped the VDA **userspace** API — `libmpi` exports `HI_MPI_VDA_*` — but **not the VDA kernel driver**:

- `hi3516a_vda.ko` is present in `files/kmod/` but its `$(INSTALL)` line was **commented out**, so it never reached the rootfs.
- `load_hisilicon` (the loader run at boot via `S70vendor → load_$(ipcinfo -v) -i`) had **no `insmod hi3516a_vda.ko`**.

Result: no `/proc/umap/vda`, so any `HI_MPI_VDA_*` call fails — in particular majestic's hardware motion detection (the VDA backend used for Gen1/Gen2 HiSilicon) can't start on these SoCs.

## Change

- **`.mk`**: install `hi3516a_vda.ko` to `/lib/modules/4.9.37/hisilicon`.
- **`load_hisilicon`**: `insmod hi3516a_vda.ko` after the encoders, and `rmmod -w hi3516a_vda` on teardown.

No userspace changes — the VDA API and the consuming app code already exist.

## Validation

On a `hi3516dv100` board: after loading the module, `/proc/umap/vda` appears and `hi3516a_vda` shows in `lsmod` alongside the rest of the MPP stack. majestic's VDA motion detection then runs end-to-end — `HI_MPI_VDA_CreateChn` succeeds, 960×528 MD frame, object bounding boxes, with localized detections tracking real motion. No regression to the other modules (VDA loads next to the streaming stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)