### PR TITLE
Fix wrong comment character

### DIFF
--- a/general/package/grainmedia-osdrv-gm8136/files/script/load_grainmedia
+++ b/general/package/grainmedia-osdrv-gm8136/files/script/load_grainmedia
@@ -306,7 +306,7 @@ devmem 0x9a1000c4 32 0x08000f08
 devmem 0x9a1000c8 32 0x061f0606
 devmem 0x9a100030 32 0xDF000f04
 
-// uncomment below to disable jpeg
+# uncomment below to disable jpeg
 #devmem 0x90c00044 32 0x00000007
 #devmem 0x90c000b4 32 0xFFD374F0 #close SD card and mjpeg
 


### PR DESCRIPTION
On the last pull request i wrote // instead of # for a comment inside the script, this fixes the warning on the console.