### PR TITLE
ci: build hi3519dv500_ultimate in the firmware matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,9 @@ jobs:
           # Hisilicon [HI3516CV6XX]
           - hi3516cv6xx_ultimate
 
+          # Hisilicon [HI3519DV500]
+          - hi3519dv500_ultimate
+
           # Hisilicon [HI3516EV200]
           - hi3516dv200_lite
           - hi3516ev200_lite

--- a/br-ext-chip-hisilicon/board/hi3519dv500/fit-image.its
+++ b/br-ext-chip-hisilicon/board/hi3519dv500/fit-image.its
@@ -21,11 +21,11 @@
 
 		linux_kernel {
 			description = "Linux";
-			data = /incbin/("Image");
+			data = /incbin/("Image.gz");
 			type = "kernel";
 			arch = "arm64";
 			os = "Linux";
-			compression = "none";
+			compression = "gzip";
 			load = <0x40080000>;
 			entry = <0x40080000>;
 		};

--- a/br-ext-chip-hisilicon/board/hi3519dv500/post-image.sh
+++ b/br-ext-chip-hisilicon/board/hi3519dv500/post-image.sh
@@ -8,6 +8,9 @@ ERASEBLOCK_SIZE=$((64 * 1024))
 
 
 cp ${BINARIES_DIR}/hi35*.dtb ${BINARIES_DIR}/fdt.dtb
+# Compress the arm64 Image so the FIT + squashfs fit the 16 MiB NOR. U-Boot
+# decompresses it at boot (CONFIG_FIT + CONFIG_GZIP).
+gzip -9 -c ${BINARIES_DIR}/Image > ${BINARIES_DIR}/Image.gz
 cp ${BOARD_DIR}/${ITS_SOURCE} ${BINARIES_DIR}/
 mkimage -f ${BINARIES_DIR}/${ITS_SOURCE} ${BINARIES_DIR}/fitImage
 


### PR DESCRIPTION
Promotes `hi3519dv500_ultimate` (Hi3519DV500/Hi3516DV500, V5 aarch64) to the firmware build matrix.

The prerequisites are now on master:
- `toolchain.hisilicon-hi3519dv500` published with **5.10** kernel headers
- `openipc/linux` branch `hisilicon-hi3519dv500` (linux 5.10)
- the firmware itself (#2203): defconfig, board dir, `hisilicon-osdrv-hi3519dv500` MPP libs

This PR's own CI builds the image, so a green run confirms the aarch64 build works end-to-end before it lands on master. (`majestic`/`divinus`/`hisilicon-opensdk` remain off — no aarch64 build yet.)