### PR TITLE
hisilicon-opensdk: bump to ff20187b (dv500 +6 source modules)

### DIFF
--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = 666a0958
+HISILICON_OPENSDK_VERSION = ff20187b
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Bumps the `hisilicon-opensdk` pin to [openhisilicon #206](https://github.com/OpenIPC/openhisilicon/pull/206) (`ff20187b`), which added the remaining DV500 source modules — **mipi_tx, gfbg, cipher, km, otp, hardware_cryptodev**.

The dv500 install uses an `open_*.ko` glob, so the firmware now ships **all 59** `open_*.ko` (was 53). The bump is **additive** for the other hisilicon/goke chips (#206 only touched `hi3519dv500` paths).

Validated locally: `make BOARD=hi3519dv500_ultimate br-hisilicon-opensdk` installs **59/59** modules incl. the 6 new ones. The full CI matrix confirms no regression to the other chips.