### PR TITLE
image: assemble per-DDR-binning full NOR images for hi3516cv610/cv608 (#2208)

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -109,6 +109,44 @@ jobs:
               echo -e "Created: $release\n"
             }
 
+            # create_hisi <uboot_artifact> <firmware_soc> <variant> <release_tag> <fw_off_kib>
+            #   HiSilicon V4/V5: u-boot is published per DDR binning (the
+            #   boot-ROM DDR init table is baked into each boot image), and the
+            #   firmware .tgz holds a single pre-packed kernel+rootfs blob
+            #   (firmware.bin.<soc>) flashed at the SoC's firmware-partition
+            #   offset. So assemble one full NOR image per DDR binning:
+            #   u-boot at 0, firmware.bin at <fw_off_kib>.
+            create_hisi() {
+              local uboot="$1" soc="$2" variant="$3" tag="$4" off="$5"
+              local release="target/openipc-${tag}-nor-${variant}.bin"
+
+              mkdir -p output target
+              if ! wget -nv "$UBOOT_URL/$uboot" -O "output/$uboot"; then
+                echo -e "Download failed: $UBOOT_URL/$uboot\n"
+                return 0
+              fi
+
+              url=$(firmware_url "$soc" "$variant")
+              if [ -z "$url" ]; then
+                echo -e "Skip: no firmware in $BUILD_ID for ${soc}_${variant}\n"
+                return 0
+              fi
+              if ! wget -nv "$url" -O "output/$soc.tgz"; then
+                echo -e "Download failed: $url\n"
+                return 0
+              fi
+
+              tar -xf "output/$soc.tgz" -C output
+              # 16 MiB NOR, erased (0xff); u-boot at 0, firmware.bin at its
+              # partition offset (cv6xx MTDPARTS: firmware @ 0x50000 = 320 KiB).
+              dd if=/dev/zero bs=1K count=16384 status=none | tr '\000' '\377' > "$release"
+              dd if="output/$uboot" of="$release" bs=1K seek=0 conv=notrunc status=none
+              dd if="output/firmware.bin.$soc" of="$release" bs=1K seek="$off" conv=notrunc status=none
+              rm -rf output
+
+              echo -e "Created: $release\n"
+            }
+
             for soc in $SIGMASTAR $ALLWINNER; do
               create $soc $soc lite
               create $soc $soc ultimate
@@ -117,6 +155,22 @@ jobs:
             for soc in $INGENIC; do
               create $soc ${soc:0:3} lite
               create $soc ${soc:0:3} ultimate
+            done
+
+            # HiSilicon Hi3516CV610/CV608 (cv6xx family). The kernel+rootfs blob
+            # is identical across DDR variants; only the per-binning u-boot (DDR
+            # init table) differs, so emit one full image per DDR topology.
+            # cv610 spans three topologies (DDR2-64M / DDR3-128M / DDR3-512M);
+            # cv608 is a single DDR2-64M part. firmware partition @ 0x50000.
+            # The 20s/00s u-boots are picked per DDR (their 20g/00g siblings
+            # carry the same DDR table, differing only in the socmodel env tag).
+            # Hi3519DV500 is intentionally omitted: its NOR boot path is not yet
+            # wired in u-boot (empty MTDPARTS, bootcmd "bootm <ram>").
+            for variant in ultimate; do
+              create_hisi boot-hi3516cv610-10b-nor.bin hi3516cv6xx "$variant" hi3516cv610-ddr2-64m  320
+              create_hisi boot-hi3516cv610-20s-nor.bin hi3516cv6xx "$variant" hi3516cv610-ddr3-128m 320
+              create_hisi boot-hi3516cv610-00s-nor.bin hi3516cv6xx "$variant" hi3516cv610-ddr3-512m 320
+              create_hisi boot-hi3516cv608-nor.bin     hi3516cv6xx "$variant" hi3516cv608           320
             done
 
       - name: Upload


### PR DESCRIPTION
Closes #2208 for cv6xx (cv610/cv608).

## Root cause

The cv6xx u-boot is published **per DDR binning** (`boot-hi3516cv610-{10b,20s,20g,00s,00g}-nor.bin`, `boot-hi3516cv608-nor.bin`) because the boot-ROM DDR init table (`reg_info.bin`) is baked into each boot image. `CONFIG_CMD_DDR_TRAINING` is a runtime PHY-timing calibration command — it can't detect DDR type/size — so **hi3516cv610 has three genuinely different topologies** (DDR2-64M-QFN / DDR3-128M-QFN / DDR3-512M-BGA) and there is **no single universal image**.

The `create()` assembly loop in `image.yml` only iterated Sigmastar/Ingenic/Allwinner and assumed one `u-boot-<soc>-nor.bin` + separate `uImage`/`rootfs.squashfs` at fixed offsets. cv6xx ships neither (its `.tgz` is a single pre-packed `firmware.bin.<soc>` = FIT + squashfs), so **no full flashable NOR image was produced for cv6xx at all** — the gap behind #2208.

## Change

Add `create_hisi()` and a cv6xx loop. Per DDR topology, assemble: u-boot at offset 0, `firmware.bin.<soc>` at the firmware partition (**0x50000 / 320 KiB**, per the cv6xx u-boot `MTDPARTS "256k(boot),64k(env),…,7168k@0x50000(firmware),…"`). Produces:

- `openipc-hi3516cv610-ddr2-64m-nor-ultimate.bin`
- `openipc-hi3516cv610-ddr3-128m-nor-ultimate.bin`
- `openipc-hi3516cv610-ddr3-512m-nor-ultimate.bin`
- `openipc-hi3516cv608-nor-ultimate.bin`

(The `20g`/`00g` u-boots carry the same DDR table as `20s`/`00s`, differing only in the `socmodel` env tag, so one image per DDR suffices.) Missing artifacts/manifest entries are skipped gracefully — no broken images.

## Validation

Assembled from the **live `latest`-release artifacts**: `boot-hi3516cv610-20s-nor.bin` (236 KiB) + `firmware.bin.hi3516cv6xx` (9.94 MiB) at `0x50000` → fits the 16 MiB NOR with the squashfs magic landing at `0x310000` (the post-image internal offset), u-boot reset vector at 0.

## Not included: Hi3519DV500

dv500's NOR boot path is **not yet wired** in u-boot (`# CONFIG_USE_BOOTCOMMAND is not set`, `CONFIG_MTDPARTS_DEFAULT=""`, bootcmd `bootm 0x42000000` with no `sf read`), so a full NOR image can't boot. Deferred until that lands.

Follow-up candidates: QEMU full-flash-boot of an assembled cv610 image; `repack_firmware.sh` hisilicon support (manual flow).

Refs #2208.