### PR TITLE
image: assemble Hi3519DV500 full NOR images (#2208)

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -164,13 +164,21 @@ jobs:
             # cv608 is a single DDR2-64M part. firmware partition @ 0x50000.
             # The 20s/00s u-boots are picked per DDR (their 20g/00g siblings
             # carry the same DDR table, differing only in the socmodel env tag).
-            # Hi3519DV500 is intentionally omitted: its NOR boot path is not yet
-            # wired in u-boot (empty MTDPARTS, bootcmd "bootm <ram>").
             for variant in ultimate; do
               create_hisi boot-hi3516cv610-10b-nor.bin hi3516cv6xx "$variant" hi3516cv610-ddr2-64m  320
               create_hisi boot-hi3516cv610-20s-nor.bin hi3516cv6xx "$variant" hi3516cv610-ddr3-128m 320
               create_hisi boot-hi3516cv610-00s-nor.bin hi3516cv6xx "$variant" hi3516cv610-ddr3-512m 320
               create_hisi boot-hi3516cv608-nor.bin     hi3516cv6xx "$variant" hi3516cv608           320
+            done
+
+            # HiSilicon Hi3519DV500 (aarch64 V5). Same scheme: a single shared
+            # kernel+rootfs blob (firmware.bin.hi3519dv500) plus a per-binning
+            # u-boot whose baked DDR reg table differs by board layout — dmeb
+            # (6-layer) and dmebpro (4-layer flyby), both DDR4-2666 2 GB. NOR
+            # layout (16 MiB): u-boot @0, env @0x80000, firmware @0xC0000 = 768 KiB.
+            for variant in ultimate; do
+              create_hisi boot-hi3519dv500-dmeb-nor.bin    hi3519dv500 "$variant" hi3519dv500-dmeb    768
+              create_hisi boot-hi3519dv500-dmebpro-nor.bin hi3519dv500 "$variant" hi3519dv500-dmebpro 768
             done
 
       - name: Upload


### PR DESCRIPTION
Completes the Hi3519DV500 half of #2208 by assembling the full 16 MiB NOR images in the release `image` workflow, the same way #2210 did for cv6xx.

Now that the dv500 NOR boot path is wired in U-Boot (OpenIPC/u-boot-hi3519dv500#3, merged) and the emulator (widgetii/qemu-hisilicon#126, merged), the per-binning signed boot images (`boot-hi3519dv500-{dmeb,dmebpro}-nor.bin`) are published to the `latest` release. Same scheme as cv6xx — one shared kernel+rootfs blob (`firmware.bin.hi3519dv500`) plus the per-binning U-Boot whose baked DDR reg table differs by board layout:

| variant | board | DDR |
|---|---|---|
| `dmeb` | 6-layer | DDR4-2666 2 GB |
| `dmebpro` | 4-layer flyby | DDR4-2666 2 GB |

NOR layout (16 MiB): U-Boot @0, env @0x80000, firmware @0xC0000 (768 KiB) — matching the U-Boot MTDPARTS. Produces `openipc-hi3519dv500-{dmeb,dmebpro}-nor-ultimate.bin`. `create_hisi` skips gracefully if an artifact is missing, so this can't break the existing cv6xx/sigmastar/etc. assembly.

### Verified
The assembled image (this U-Boot + `firmware.bin.hi3519dv500`) boots end-to-end to the login prompt on the emulated dual Cortex-A55, 3/3 runs, no Oops/panic:
```
VFS: Mounted root (squashfs filesystem) readonly on device 31:3.
Run /init as init process
Welcome to OpenIPC
openipc-hi3519dv500 login:
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)