### PR TITLE
ci: evict majestic's moving S3 tarball from the dl cache too

### DIFF
--- a/.github/workflows/build-one.yml
+++ b/.github/workflows/build-one.yml
@@ -64,17 +64,20 @@ jobs:
 
       - name: Refresh moving-ref package downloads
         run: |
-          # Packages pinned to a moving ref (VERSION = HEAD / branch) download as
-          # <pkg>-<ref>.tar.gz — a constant filename. The dl cache key is the month
-          # (date +%m) and actions/cache only saves on a key miss, so that snapshot
-          # is frozen for weeks; buildroot then keeps reusing the stale tarball and
-          # silently ships an old version. This is what desynced majestic-webui from
-          # majestic (blanking every settings field label). Drop those archives so
-          # buildroot re-fetches the current ref each run. Also covers rolling release
-          # assets named <pkg>-dist.tar.gz (e.g. the pre-minified majestic-webui dist).
-          # Content-addressed packages (S3 / semver / SHA pins) keep their cache.
-          find output/dl -type f \
-            \( -name '*-HEAD.tar.gz' -o -name '*-master.tar.gz' -o -name '*-main.tar.gz' -o -name '*-dist.tar.gz' \) \
+          # Packages pinned to a moving ref keep a constant download filename. The dl
+          # cache key is the month (date +%m) and actions/cache only saves on a key
+          # miss, so that snapshot is frozen for weeks; buildroot then keeps reusing the
+          # stale tarball and silently ships an old version. This is what desynced
+          # majestic-webui from majestic (blanking settings labels; later a t31 lite
+          # image shipped a pre-x-groups majestic vs the current webui — "No settings
+          # groups in schema"). Drop both naming forms so buildroot re-fetches each run:
+          #   - dash:  <pkg>-<ref>.tar.gz   e.g. majestic-webui-dist.tar.gz
+          #   - dot:   <pkg>.<ref>.tar.bz2  e.g. majestic.t31.lite.master.tar.bz2
+          # The dot form is majestic's S3 tarball — it LOOKS S3-pinned but is a moving
+          # `master` build re-uploaded every majestic CI run, with no .hash to force a
+          # refetch. Only genuinely content-addressed tarballs (semver / SHA) keep cache.
+          find output/dl -type f -regextype posix-extended \
+            -regex '.*[-.](HEAD|master|main|dist)\.tar\.(gz|bz2|xz)' \
             -print -delete 2>/dev/null || true
 
       - name: Build firmware

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,18 +255,20 @@ jobs:
 
       - name: Refresh moving-ref package downloads
         run: |
-          # Packages pinned to a moving ref (VERSION = HEAD / branch) download as
-          # <pkg>-<ref>.tar.gz — a constant filename. The dl cache key is the month
-          # (date +%m) and actions/cache only saves on a key miss, so that snapshot
-          # is frozen for weeks; buildroot then keeps reusing the stale tarball and
-          # the nightly silently ships an old version. This is what desynced
-          # majestic-webui from majestic (blanking every settings field label).
-          # Drop those archives so buildroot re-fetches the current ref each run.
-          # Also covers rolling release assets named <pkg>-dist.tar.gz (e.g. the
-          # pre-minified majestic-webui dist). Content-addressed packages
-          # (S3 / semver / SHA pins) keep their cache.
-          find output/dl -type f \
-            \( -name '*-HEAD.tar.gz' -o -name '*-master.tar.gz' -o -name '*-main.tar.gz' -o -name '*-dist.tar.gz' \) \
+          # Packages pinned to a moving ref keep a constant download filename. The dl
+          # cache key is the month (date +%m) and actions/cache only saves on a key
+          # miss, so that snapshot is frozen for weeks; buildroot then keeps reusing the
+          # stale tarball and the nightly silently ships an old version. This is what
+          # desynced majestic-webui from majestic (blanking settings labels; later a t31
+          # lite image shipped a pre-x-groups majestic vs the current webui — "No
+          # settings groups in schema"). Drop both naming forms so buildroot re-fetches:
+          #   - dash:  <pkg>-<ref>.tar.gz   e.g. majestic-webui-dist.tar.gz
+          #   - dot:   <pkg>.<ref>.tar.bz2  e.g. majestic.t31.lite.master.tar.bz2
+          # The dot form is majestic's S3 tarball — it LOOKS S3-pinned but is a moving
+          # `master` build re-uploaded every majestic CI run, with no .hash to force a
+          # refetch. Only genuinely content-addressed tarballs (semver / SHA) keep cache.
+          find output/dl -type f -regextype posix-extended \
+            -regex '.*[-.](HEAD|master|main|dist)\.tar\.(gz|bz2|xz)' \
             -print -delete 2>/dev/null || true
 
       - name: Build firmware


### PR DESCRIPTION
Mirrors **OpenIPC/builder#109**.

The *"Refresh moving-ref package downloads"* step evicts `*-{HEAD,master,main,dist}.tar.gz` so buildroot re-fetches moving refs each run. That covers the webui dist (`majestic-webui-dist.tar.gz`) but **not majestic**, which downloads from S3 as:

```
majestic.<family>.<variant>.master.tar.bz2     # majestic.mk
```

— **dot** separator, **`.tar.bz2`**, on the S3 host the old pattern spared as "content-addressed". But that S3 object is a **moving `master` build** (re-uploaded each majestic CI run, **no `.hash`**), so it froze in the monthly `output/dl` cache while the webui refreshed. That desync shipped a pre-`x-groups` majestic against the current webui → **"No settings groups in schema."** on the settings page.

Broaden the eviction to a regex covering both `-ref`/`.ref` separators across gz/bz2/xz:

```
find output/dl -type f -regextype posix-extended \
  -regex '.*[-.](HEAD|master|main|dist)\.tar\.(gz|bz2|xz)' \
  -print -delete
```

Evicts `majestic.*.master.tar.bz2` **and** `majestic-webui-dist.tar.gz` while sparing semver/SHA pins. The builder side (#109) is already merged and verified end-to-end: a republished `t31_lite_xiaomi-mjsxj03hl-nor.tgz` now bundles a 2026-06-25 majestic with the `x-groups` manifest (was 2026-05-24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)