### PR TITLE
sysupgrade: bound the online time sync and show download progress

### DIFF
--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -1,6 +1,6 @@
 #!/bin/sh
 # OpenIPC.org | 2025
-scr_version=1.0.54
+scr_version=1.0.55
 
 args="$@"
 LOCK_FILE=/tmp/sysupgrade.lock
@@ -322,7 +322,11 @@ download_firmware() {
 		[ -z "$url" ] && url=$(fw_printenv -n upgrade || echo "https://github.com/OpenIPC/${repo:-builder}/releases/download/latest/openipc.$build.tgz")
 		echo "Download from $url"
 		[ "$(curl -o /dev/null -s -k -w '%{http_code}\n' "$url")" = "000" ] && die "Check your network!"
-		curl --connect-timeout 30 -s -k -m 120 -L "$url" -s -o - | gzip -d | tar xf - -C /tmp && echo_c 32 "Received and unpacked" || die "Cannot retrieve $url"
+		# Show a transfer bar so the (silent, up-to-2-min) download doesn't look
+		# stuck — over /ws/upgrade this also gives the WebUI something to stream
+		# (issue #120). `-s` (silent_update) opts back out for a quiet console run.
+		[ "1" = "$silent_update" ] && dl_meter=-s || dl_meter=-#
+		curl --connect-timeout 30 $dl_meter -k -m 120 -L "$url" -o - | gzip -d | tar xf - -C /tmp && echo_c 32 "Received and unpacked" || die "Cannot retrieve $url"
 	fi
 	if [ "1" != "$skip_md5" ]; then
 		(cd /tmp && md5sum -s -c *.md5sum) || die "Wrong checksum!"
@@ -367,7 +371,14 @@ set_progress() {
 
 sync_time() {
 	echo_c 37 "\nSynchronizing time"
-	ntpd -Nnq
+	# Bound the sync: with no reachable NTP server `ntpd -q` can block for
+	# minutes and strand the upgrade at this step (WebUI issue #120). Everything
+	# after this fetches over `curl -k`, so an unsynced clock is not fatal.
+	if command -v timeout >/dev/null 2>&1; then
+		timeout 30 ntpd -Nnq
+	else
+		ntpd -Nnq
+	fi
 	echo_c 33 "$(date)"
 }
 


### PR DESCRIPTION
Two small robustness/UX fixes to the `/ws/upgrade` firmware-update flow, surfaced by OpenIPC/majestic-webui#120 ("progress gets stuck" — reported on t31x / ssc37x / ssc33x).

## Changes (`general/overlay/usr/sbin/sysupgrade`)

**1. Bound the online time sync.** `sync_time()` ran `ntpd -Nnq`, which can block for minutes when no NTP server is reachable — stranding the upgrade at *"Synchronizing time"* (the ssc378de report). It's now wrapped in `timeout 30` (guarded by `command -v timeout`, mirroring `mount_rootfs`). Everything after this fetches over `curl -k`, so an unsynced clock is not fatal — better to move on than hang.

**2. Show download progress.** The tgz download used `curl -s … -s` (fully silent), so the *"Download"* step looked frozen for up to 2 min (the ssc337de report). It now shows curl's transfer bar (`-#`); `-s` (`silent_update`) still opts back out for a quiet console run. Over `/ws/upgrade` this also keeps the streamed log lively.

Bumps `scr_version` 1.0.54 → 1.0.55.

## Context

The companion fixes for the same issue are already merged:
- **WebUI** (majestic-webui #123): `pollBack` now waits for a real down-then-up reboot instead of treating any socket close as success.
- **majestic daemon**: a periodic WebSocket keepalive PING on `/ws/upgrade` so the socket survives these silent phases (validated on hi3516ev300 hardware).

This PR is the third piece — making `sysupgrade` itself emit progress and not hang on time sync.

## Testing

- `sh -n` clean; matches the existing `command -v timeout` guard style.
- **Not** hardware-flash-tested end-to-end (a real flash is destructive); the changes are a bounded `ntpd` and a curl progress flag, both low-risk. A maintainer flash on any SoC would confirm the streamed progress + no time-sync hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)