### PR TITLE
uboot: set make_latest:false so the release upload stops 403-ing

### DIFF
--- a/.github/workflows/uboot.yml
+++ b/.github/workflows/uboot.yml
@@ -37,6 +37,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: latest
+          make_latest: false
           files: |
             u-boot-*/output/*-nor.bin
             u-boot-*/output/*-nand.bin


### PR DESCRIPTION
## Problem

The `uboot` workflow (`workflow_dispatch`) builds fine, but the final **Upload** step fails:

```
Found release latest (with id=41590008)
⚠️ Unexpected error fetching GitHub release for tag ...:
   HttpError: Resource not accessible by integration — .../update-a-release
##[error]Resource not accessible by integration
```

#2230 added `permissions: contents: write`, and the runner token log confirms the write scope **was** granted — yet the job still 403s. So the token is not the problem.

## Root cause

The failure is specific to `softprops/action-gh-release@v2` updating the `latest` release **without** `make_latest: false`. Without it, the action tries to reassign the repository's "latest release" pointer during the update, and that operation returns 403 even with `contents: write`.

Evidence it's not a permissions issue:
- `image.yml` and `toolchain.yml` use the same action with the same `contents: write` and succeed — both pin `make_latest: false`.
- `build.yml` writes the same `latest` release/tag with the same `github-actions[bot]` token via the `gh` CLI and succeeds (it never touches the make-latest pointer).
- `uboot.yml` was the only softprops job targeting `latest` that omitted `make_latest`.

## Fix

Add `make_latest: false` to the Upload step, matching `image.yml`/`toolchain.yml`. One line.

## Verification

This workflow is `workflow_dispatch`-only, so it needs a manual re-run of `uboot` after merge to confirm a green upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)