### PR TITLE
uboot: publish binaries to `latest` via gh CLI (fixes 403 on Upload)

### DIFF
--- a/.github/workflows/uboot.yml
+++ b/.github/workflows/uboot.yml
@@ -33,11 +33,41 @@ jobs:
           cd u-boot-sigmastar
           bash build.sh
 
+      # softprops/action-gh-release@v2 cannot update the `latest` release: its
+      # updateRelease PATCH re-sends the release's stored target_commitish, which
+      # for `latest` is a frozen commit SHA that diverges from where the tag now
+      # points (build.yml force-moves the `latest` tag every nightly). GitHub
+      # rejects that reconciliation with 403 "Resource not accessible by
+      # integration" even with contents:write. Drive the upload with the gh CLI
+      # instead, the same way build.yml publishes to `latest`.
       - name: Upload
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: latest
-          make_latest: false
-          files: |
-            u-boot-*/output/*-nor.bin
-            u-boot-*/output/*-nand.bin
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(u-boot-*/output/*-nor.bin u-boot-*/output/*-nand.bin)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "::error::no u-boot binaries found to upload"; exit 1
+          fi
+          echo "Uploading ${#files[@]} file(s) to release 'latest':"
+          printf '  %s\n' "${files[@]}"
+
+          gh_retry() { # retry gh through transient 403/429/5xx with backoff
+            local n=0 max=5 delay=10
+            until "$@"; do
+              n=$((n + 1))
+              if [ "$n" -ge "$max" ]; then
+                echo "::error::gh failed after ${max} attempts: $*"; return 1
+              fi
+              echo "::warning::gh attempt ${n} failed, retrying in ${delay}s"
+              sleep "$delay"; delay=$((delay * 2))
+            done
+          }
+
+          gh release view latest >/dev/null 2>&1 || \
+            gh_retry gh release create latest --title latest --notes "U-Boot binaries (nor/nand)"
+          for f in "${files[@]}"; do
+            gh_retry gh release upload latest "$f" --clobber
+          done


### PR DESCRIPTION
## Problem

The `uboot` workflow builds fine but the **Upload** step 403s:

```
Found release latest (with id=41590008)
⚠️ Unexpected error ... HttpError: Resource not accessible by integration — .../update-a-release
```

This persists **with** `permissions: contents: write` (#2230) and **with** `make_latest: false` (#2232) — confirmed on runs `30105924069` and `30118735222`.

## Root cause

`softprops/action-gh-release@v2`'s `updateRelease` PATCH re-sends the existing release's `target_commitish`. For the `latest` release that value is a **frozen commit SHA** (`e118e4e7`) that no longer matches where the `latest` **tag** points (`613acf1e`) — `build.yml` force-moves the `latest` tag every nightly while the release object keeps its old target. GitHub rejects that reconciliation with 403, even with `contents: write`.

The `image` and `toolchain` releases carry `target_commitish: master`, so softprops updates them without issue — which is why only this workflow broke.

The token is **not** the problem: `build.yml` publishes to this same `latest` release with the same `github-actions[bot]` token via the `gh` CLI (its "Publish releases" job is green).

## Fix

Drop softprops for this step and upload with the `gh` CLI, mirroring `build.yml`: ensure the release exists, then `gh release upload latest <file> --clobber`, with a small backoff retry for transient 403/429/5xx. `contents: write` is already granted.

## Verification

`workflow_dispatch`-only, so it needs a manual `uboot` re-run after merge to confirm a green Upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)