### PR TITLE
ci: rebuild the nightly when majestic-webui's dist asset changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
       short_sha:    ${{ steps.gate.outputs.short_sha }}
       build_id:     ${{ steps.gate.outputs.build_id }}
       built_at:     ${{ steps.gate.outputs.built_at }}
+      webui_digest: ${{ steps.gate.outputs.webui_digest }}
     steps:
       - uses: actions/checkout@v4
       - id: gate
@@ -27,19 +28,34 @@ jobs:
           SHORT=$(git rev-parse --short HEAD)
           BUILD_ID="nightly-$(date -u +%Y%m%d)-${SHORT}"
           BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          PREV=$(gh release view nightly --json body -q .body 2>/dev/null \
-                  | sed -n 's/^sha=//p' | head -1 || true)
-          if [ "${{ github.event_name }}" = "schedule" ] && [ "$PREV" = "$HEAD" ]; then
-            echo "Skip: HEAD ($HEAD) already published as the latest nightly."
+          NOTES_PREV=$(gh release view nightly --json body -q .body 2>/dev/null || true)
+          PREV=$(printf '%s\n' "$NOTES_PREV" | sed -n 's/^sha=//p' | head -1)
+          PREV_WEBUI=$(printf '%s\n' "$NOTES_PREV" | sed -n 's/^webui=//p' | head -1)
+
+          # majestic-webui ships as a rolling `dist` release asset, so a WebUI fix
+          # changes what the nightly would contain without ever moving this repo's
+          # HEAD — on a quiet firmware tree the schedule would skip forever and the
+          # fix would never reach an image. Compare the asset's content digest as
+          # well. It is content-addressed, so a re-upload of identical bytes does
+          # not force a pointless rebuild. An empty value (API hiccup, or an asset
+          # with no digest) falls through to building: stale is worse than spare.
+          WEBUI=$(gh api repos/OpenIPC/majestic-webui/releases/tags/dist \
+                    --jq '.assets[]|select(.name=="majestic-webui-dist.tar.gz")|.digest // empty' \
+                    2>/dev/null || true)
+
+          if [ "${{ github.event_name }}" = "schedule" ] && [ "$PREV" = "$HEAD" ] \
+             && [ -n "$WEBUI" ] && [ "$PREV_WEBUI" = "$WEBUI" ]; then
+            echo "Skip: HEAD ($HEAD) already published as the latest nightly, majestic-webui dist unchanged ($WEBUI)."
             echo "should_build=false" >> "$GITHUB_OUTPUT"
           else
-            echo "Build: $BUILD_ID (event=${{ github.event_name }}, prev=$PREV)"
+            echo "Build: $BUILD_ID (event=${{ github.event_name }}, prev=$PREV, webui=$WEBUI, prev_webui=$PREV_WEBUI)"
             echo "should_build=true"  >> "$GITHUB_OUTPUT"
           fi
           echo "head_sha=$HEAD"   >> "$GITHUB_OUTPUT"
           echo "short_sha=$SHORT" >> "$GITHUB_OUTPUT"
           echo "build_id=$BUILD_ID" >> "$GITHUB_OUTPUT"
           echo "built_at=$BUILT_AT" >> "$GITHUB_OUTPUT"
+          echo "webui_digest=$WEBUI" >> "$GITHUB_OUTPUT"
 
   buildroot:
     name: Firmware
@@ -424,6 +440,7 @@ jobs:
           HEAD_SHA: ${{ needs.preflight.outputs.head_sha }}
           SHORT_SHA: ${{ needs.preflight.outputs.short_sha }}
           BUILT_AT: ${{ needs.preflight.outputs.built_at }}
+          WEBUI_DIGEST: ${{ needs.preflight.outputs.webui_digest }}
         run: |
           set -euo pipefail
 
@@ -465,7 +482,13 @@ jobs:
             done
           }
 
+          # `webui=` is what the next preflight diffs against to notice a WebUI-only
+          # change; drop the line rather than record an empty value, so a failed
+          # lookup reads as "unknown" and builds instead of matching a future empty.
           NOTES=$(printf 'sha=%s\nshort=%s\nbuilt_at=%s\n' "$HEAD_SHA" "$SHORT_SHA" "$BUILT_AT")
+          if [ -n "$WEBUI_DIGEST" ]; then
+            NOTES=$(printf '%s\nwebui=%s\n' "$NOTES" "$WEBUI_DIGEST")
+          fi
 
           # Full asset set (firmware images + sizes/kconfig sidecars) → dated.
           mapfile -t DATED < <(find dist -maxdepth 1 -type f | sort)


### PR DESCRIPTION
## Problem

The preflight gate skips a scheduled build when this repo's HEAD already matches the published nightly:

```sh
if [ "$event_name" = "schedule" ] && [ "$PREV" = "$HEAD" ]; then should_build=false
```

That assumes firmware HEAD alone determines what an image contains. It doesn't for `majestic-webui`, which is consumed as a rolling `dist` release asset — a WebUI fix changes the image without moving HEAD here.

The result is a silent hole: on a quiet firmware tree the nightly skips night after night and the WebUI fix never reaches a build. This is live right now — OpenIPC/majestic-webui#129 fixed two bugs from OpenIPC/firmware#2235, the `dist` asset refreshed 26s after merge, and tonight's nightly would still have skipped because HEAD hasn't moved since `0010f73`.

## Change

Compare the dist asset's content digest alongside HEAD, and record it in the nightly notes as `webui=` for the next run to diff against.

The digest is content-addressed (`sha256:…`), so re-uploading identical bytes doesn't force a pointless rebuild — only a genuine content change does.

Both unknown-value paths fall through to building rather than skipping blind:

- a failed lookup leaves the digest empty, and the `-n "$WEBUI"` guard means an empty value never matches;
- publish omits the `webui=` line entirely rather than writing an empty one that a later empty lookup would spuriously match.

The first run after this merges will build once (no `webui=` in the current notes), then settle.

## Testing

The gate body was extracted from the workflow and executed under `bash -e` against the real GitHub API for the digest:

| case | result |
|---|---|
| schedule, same sha, same digest | `should_build=false` |
| schedule, same sha, stale digest | `should_build=true` |
| schedule, same sha, no `webui=` (first run) | `should_build=true` |
| schedule, different sha | `should_build=true` |
| `workflow_dispatch`, everything same | `should_build=true` |
| digest lookup fails (API down) | `should_build=true`, step survives `set -e` |

Publish-side `NOTES` construction was also run under `bash -e` with and without a digest: the `webui=` line appears when set and is omitted when empty, with no `set -e` failure. YAML parses and `preflight.outputs` gains `webui_digest`.

## Scope

This covers `majestic-webui` only. Around twenty other packages track a moving ref (`majestic` itself, `mspod`, `motors`, `yaml-cli`, `rubyfpv`, …) and remain invisible to the gate — the same staleness the "Refresh moving-ref package downloads" step was added to fight, one layer up. Worth a follow-up; deliberately not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)