### PR TITLE
majestic: re-read /etc/TZ on every start so restarts pick up TZ changes

### DIFF
--- a/general/package/majestic/files/S95majestic
+++ b/general/package/majestic/files/S95majestic
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# rcS exports TZ once at boot, so a later edit to /etc/TZ is shadowed by the
+# stale value inherited through majestic's own children (web UI, sysupgrade).
+# Re-read it here so a restart picks up the new zone without a reboot.
+# musl never reads /etc/TZ itself; it uses $TZ, else /etc/localtime.
+[ -r /etc/TZ ] && export TZ=$(cat /etc/TZ)
+
 DAEMON="majestic"
 PIDFILE="/var/run/$DAEMON.pid"
 DAEMON_ARGS="-s"


### PR DESCRIPTION
## What

`S95majestic` re-reads `/etc/TZ` and exports `TZ` before starting the daemon, guarded by `[ -r /etc/TZ ]`.

## Why

`rcS` exports `TZ` once at boot, and every descendant inherits that snapshot. Restarting majestic through one of its own children — the web UI, or `sysupgrade` (which calls `S95majestic restart`) — hands the daemon the stale boot-time value, which shadows any later edit of `/etc/TZ`. The OSD clock then keeps rendering the old zone until a full reboot, or until a restart from a fresh SSH login (which re-sources `/etc/profile`).

Re-reading the file in the init script makes every start pick up the current `/etc/TZ`, so a timezone change takes effect on `S95majestic restart` without a reboot.

The `[ -r ]` guard matters on its own: on musl an *empty* `TZ` pins UTC and skips the `/etc/localtime` fallback that an *unset* `TZ` would use, so exporting unguarded when `/etc/TZ` is missing would force UTC. (`rcS:4` and `profile:6` currently have this latent footgun; happy to port the guard there as a follow-up.)

*The original description blamed `/etc/profile` not being sourced by init; @widgetii correctly pointed out that `rcS` already exports `TZ` on the boot path, and the real defect is the staleness above. Description and commit message rewritten accordingly.*

## Verification

On a Hi3518EV200 camera with TZ `CET-1CEST,M3.5.0,M10.5.0/3`: the OSD clock follows local time including DST, and `tr '\0' '\n' < /proc/$(pidof majestic)/environ` shows `TZ` set. Staleness-path checks from the review are reported in the PR comments.
