### PR TITLE
majestic: make S95majestic stop work when the pidfile is stale

### DIFF
--- a/general/package/majestic/files/S95majestic
+++ b/general/package/majestic/files/S95majestic
@@ -28,6 +28,11 @@ stop() {
 		killall "$DAEMON" 2> /dev/null
 		sleep 2
 		killall -9 "$DAEMON" 2> /dev/null
+		sleep 1
+	fi
+	if pidof "$DAEMON" > /dev/null 2>&1; then
+		echo "FAIL"
+		return 1
 	fi
 	rm -f "$PIDFILE"
 	echo "OK"
@@ -39,7 +44,7 @@ case "$1" in
 		;;
 
 	restart)
-		stop
+		stop || exit 1
 		sleep 3
 		start
 		;;

--- a/general/package/majestic/files/S95majestic
+++ b/general/package/majestic/files/S95majestic
@@ -14,15 +14,23 @@ start() {
 	fi
 }
 
+# Stop by pidfile, then verify the daemon is actually gone. majestic's own
+# watchdog restarts it with a new pid that start-stop-daemon knows nothing
+# about, so the pidfile goes stale; -K on a stale pidfile kills nothing, and
+# "restart" then starts a SECOND majestic next to the running one - both
+# fighting over the encoder, with config edits silently never loaded. killall
+# matches by name, which is the one identity that cannot go stale.
 stop() {
 	echo -n "Stopping $DAEMON: "
 	start-stop-daemon -K -q -p "$PIDFILE"
-	if [ $? -eq 0 ]; then
-		rm -f "$PIDFILE"
-		echo "OK"
-	else
-		echo "FAIL"
+	sleep 1
+	if pidof "$DAEMON" > /dev/null 2>&1; then
+		killall "$DAEMON" 2> /dev/null
+		sleep 2
+		killall -9 "$DAEMON" 2> /dev/null
 	fi
+	rm -f "$PIDFILE"
+	echo "OK"
 }
 
 case "$1" in


### PR DESCRIPTION
majestic's built-in watchdog respawns the process outside start-stop-daemon's knowledge, so `/var/run/majestic.pid` goes stale. `stop` then kills nothing (`start-stop-daemon -K` targets the dead pid), and `restart` starts a **second** majestic next to the surviving one — two daemons fight over the encoder, and config edits appear to take effect while the running process never loaded them.

Observed on a Hi3518EV200 camera: the pidfile said 3408, majestic ran as pid 869; `/etc/init.d/S95majestic restart` exited 0 having restarted nothing, and `/api/v1/config.json` confirmed the old config was still live.

After the pidfile kill, this verifies the daemon is actually gone with `pidof` and falls back to `killall` (TERM, then KILL) — matching by name, the one identity that cannot go stale. The pidfile is always removed so the next start begins clean.
