### PR TITLE
mt7601u-openipc: pin the source to a commit instead of HEAD

### DIFF
--- a/general/package/mt7601u-openipc/mt7601u-openipc.mk
+++ b/general/package/mt7601u-openipc/mt7601u-openipc.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 MT7601U_OPENIPC_SITE = $(call github,openipc,mt7601u,$(MT7601U_OPENIPC_VERSION))
-MT7601U_OPENIPC_VERSION = HEAD
+MT7601U_OPENIPC_VERSION = 0ac46553f3190d788b01c15cbeaa14f2951c55a3
 MT7601U_OPENIPC_LICENSE = GPL-2.0
 
 MT7601U_OPENIPC_MODULE_MAKE_OPTS = \


### PR DESCRIPTION
## What

Pin `MT7601U_OPENIPC_VERSION` to a commit SHA (`0ac4655`, current tip of openipc/mt7601u) instead of `HEAD`.

*Rescoped after review: the original PR also enabled `BR2_PACKAGE_MT7601U_OPENIPC` in `hi3518ev200_ultimate_defconfig`. Per @flyrouter, firmware images do not ship WiFi drivers — only WiFi utilities — and per-device customisation belongs in the Builder repository, so that change is dropped. The device profile for this camera will go through Builder instead.*

## Why

`VERSION = HEAD` is a moving target: anyone enabling this package gets whatever openipc/mt7601u happens to be at build time, so the same tree can produce different artifacts over time and can break with no change in this repo. Pinning to an immutable ref makes builds reproducible.

`0ac4655` is the lineage that was runtime-verified on a Hi3518EV200 camera: WPA2 join, RTSP streaming, 15–17 Mbps TX iperf3.
