### PR TITLE
gpio-motors: deliver sub-tick delays on HZ=100 kernels

### DIFF
--- a/general/package/gpio-motors/src/gpio-motors.c
+++ b/general/package/gpio-motors/src/gpio-motors.c
@@ -10,6 +10,10 @@ int PAN_PINS[4];
 int TILT_PINS[4];
 int SELECT_PIN = -1;
 
+int PAN_FDS[4] = {-1, -1, -1, -1};
+int TILT_FDS[4] = {-1, -1, -1, -1};
+int SELECT_FD = -1;
+
 int STEP_SEQUENCE[8][4] = {
 	{1, 0, 0, 0}, {1, 1, 0, 0}, {0, 1, 0, 0}, {0, 1, 1, 0},
 	{0, 0, 1, 0}, {0, 0, 1, 1}, {0, 0, 0, 1}, {1, 0, 0, 1}
@@ -40,10 +44,19 @@ void gpio_release(int pin) {
 
 void gpio_clean(int error) {
 	for (int i = 0; i < 4; i++) {
+		if (PAN_FDS[i] != -1) {
+			close(PAN_FDS[i]);
+		}
+		if (TILT_FDS[i] != -1) {
+			close(TILT_FDS[i]);
+		}
 		gpio_release(PAN_PINS[i]);
 		gpio_release(TILT_PINS[i]);
 	}
 
+	if (SELECT_FD != -1) {
+		close(SELECT_FD);
+	}
 	if (SELECT_PIN != -1) {
 		gpio_release(SELECT_PIN);
 	}
@@ -77,14 +90,22 @@ void gpio_export(int pin) {
 	}
 }
 
-void gpio_set(int pin, int value) {
+/* the value fds stay open for the whole run: a path lookup plus open/close per
+ * write costs ~0.5ms on these SoCs, which at 4 writes per micro-step dwarfs
+ * the step delay itself */
+int gpio_open(int pin) {
 	char path[64];
 	snprintf(path, sizeof(path), "/sys/class/gpio/gpio%d/value", pin);
-	FILE *file = fopen(path, "w");
-	if (file) {
-		fprintf(file, "%d", value);
-		fclose(file);
-	} else {
+	int fd = open(path, O_WRONLY);
+	if (fd == -1) {
+		printf("Unable to open value of GPIO %d: [%d] %s\n", pin, errno, strerror(errno));
+		gpio_clean(1);
+	}
+	return fd;
+}
+
+void gpio_set(int fd, int pin, int value) {
+	if (lseek(fd, 0, SEEK_SET) == -1 || write(fd, value ? "1" : "0", 1) != 1) {
 		printf("Unable to set value of GPIO %d: [%d] %s\n", pin, errno, strerror(errno));
 		gpio_clean(1);
 	}
@@ -167,7 +188,7 @@ void delay_us(long us) {
 	}
 }
 
-void axis_run(const int pins[4], int level, int steps, int delay) {
+void axis_run(const int pins[4], const int fds[4], int level, int steps, int delay) {
 	int remaining = abs(steps);
 	if (remaining == 0) {
 		return;
@@ -175,14 +196,14 @@ void axis_run(const int pins[4], int level, int steps, int delay) {
 
 	const int (*seq)[4] = (steps < 0) ? REVERSE_STEP_SEQUENCE : STEP_SEQUENCE;
 	if (SELECT_PIN != -1) {
-		gpio_set(SELECT_PIN, level);
+		gpio_set(SELECT_FD, SELECT_PIN, level);
 		usleep(100);
 	}
 
 	int micro = 0;
 	while (remaining > 0) {
 		for (int i = 0; i < 4; i++) {
-			gpio_set(pins[i], seq[micro][i]);
+			gpio_set(fds[i], pins[i], seq[micro][i]);
 		}
 
 		delay_us(delay);
@@ -193,7 +214,7 @@ void axis_run(const int pins[4], int level, int steps, int delay) {
 	}
 
 	for (int i = 0; i < 4; i++) {
-		gpio_set(pins[i], 0);
+		gpio_set(fds[i], pins[i], 0);
 	}
 }
 
@@ -222,8 +243,17 @@ int main(int argc, char *argv[]) {
 		gpio_export(SELECT_PIN);
 	}
 
-	axis_run(PAN_PINS, 0, pan_steps, delay);
-	axis_run(TILT_PINS, 1, tilt_steps, delay);
+	for (int i = 0; i < 4; i++) {
+		PAN_FDS[i] = gpio_open(PAN_PINS[i]);
+		TILT_FDS[i] = gpio_open(TILT_PINS[i]);
+	}
+
+	if (SELECT_PIN != -1) {
+		SELECT_FD = gpio_open(SELECT_PIN);
+	}
+
+	axis_run(PAN_PINS, PAN_FDS, 0, pan_steps, delay);
+	axis_run(TILT_PINS, TILT_FDS, 1, tilt_steps, delay);
 	gpio_clean(0);
 
 	return 0;

--- a/general/package/gpio-motors/src/gpio-motors.c
+++ b/general/package/gpio-motors/src/gpio-motors.c
@@ -140,17 +140,27 @@ void gpio_config() {
  * trade, and longer delays still go to usleep so we do not spin needlessly.
  */
 void delay_us(long us) {
+	if (us <= 0) {
+		return;
+	}
+
 	if (us >= 10000) {
 		usleep(us);
 		return;
 	}
 
 	struct timespec start, now;
-	clock_gettime(CLOCK_MONOTONIC, &start);
-	long target = us * 1000;
+	if (clock_gettime(CLOCK_MONOTONIC, &start) != 0) {
+		usleep(us);
+		return;
+	}
+
+	/* 64-bit on purpose: a 32-bit long overflows after ~2.1s of elapsed
+	 * time, which a preemption in the middle of the spin can reach */
+	long long target = (long long)us * 1000;
 	for (;;) {
 		clock_gettime(CLOCK_MONOTONIC, &now);
-		long elapsed = (now.tv_sec - start.tv_sec) * 1000000000L + (now.tv_nsec - start.tv_nsec);
+		long long elapsed = (long long)(now.tv_sec - start.tv_sec) * 1000000000LL + (now.tv_nsec - start.tv_nsec);
 		if (elapsed >= target) {
 			return;
 		}
@@ -195,7 +205,12 @@ int main(int argc, char *argv[]) {
 
 	int pan_steps = atoi(argv[1]);
 	int tilt_steps = atoi(argv[2]);
-	int delay = atoi(argv[3]) * 1000;
+	int delay_ms = atoi(argv[3]);
+	if (delay_ms < 0) {
+		fprintf(stderr, "delay must be >= 0\n");
+		return 1;
+	}
+	int delay = delay_ms * 1000;
 
 	gpio_config();
 	for (int i = 0; i < 4; i++) {

--- a/general/package/gpio-motors/src/gpio-motors.c
+++ b/general/package/gpio-motors/src/gpio-motors.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 
 int PAN_PINS[4];
@@ -128,6 +129,34 @@ void gpio_config() {
 	pclose(fp);
 }
 
+/*
+ * usleep() cannot deliver sub-tick delays on the kernels these cameras run:
+ * they are HZ=100 with no high-resolution timers, so every sleep rounds up to
+ * a 10ms tick. usleep(1500) waits ~10ms, and 8 micro-steps x 10ms puts a hard
+ * ~80ms floor under every step no matter how small the requested delay is
+ * (measured on Hi3518EV200: 200 steps took 33s at delay 15 and still 18s at
+ * delay 4). Spin on CLOCK_MONOTONIC for anything below a tick instead; moves
+ * are short and bounded, so burning the CPU for their duration is a fair
+ * trade, and longer delays still go to usleep so we do not spin needlessly.
+ */
+void delay_us(long us) {
+	if (us >= 10000) {
+		usleep(us);
+		return;
+	}
+
+	struct timespec start, now;
+	clock_gettime(CLOCK_MONOTONIC, &start);
+	long target = us * 1000;
+	for (;;) {
+		clock_gettime(CLOCK_MONOTONIC, &now);
+		long elapsed = (now.tv_sec - start.tv_sec) * 1000000000L + (now.tv_nsec - start.tv_nsec);
+		if (elapsed >= target) {
+			return;
+		}
+	}
+}
+
 void axis_run(const int pins[4], int level, int steps, int delay) {
 	int remaining = abs(steps);
 	if (remaining == 0) {
@@ -146,7 +175,7 @@ void axis_run(const int pins[4], int level, int steps, int delay) {
 			gpio_set(pins[i], seq[micro][i]);
 		}
 
-		usleep(delay);
+		delay_us(delay);
 		if (++micro >= 8) {
 			micro = 0;
 			--remaining;

--- a/general/package/gpio-motors/src/gpio-motors.c
+++ b/general/package/gpio-motors/src/gpio-motors.c
@@ -1,5 +1,6 @@
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -13,6 +14,10 @@ int SELECT_PIN = -1;
 int PAN_FDS[4] = {-1, -1, -1, -1};
 int TILT_FDS[4] = {-1, -1, -1, -1};
 int SELECT_FD = -1;
+
+/* CLOCK_MONOTONIC resolution, read once in main(): 1ns on kernels with
+ * high-resolution timers, one jiffy (10ms at HZ=100) without them */
+long CLOCK_RES_NS = 0;
 
 int STEP_SEQUENCE[8][4] = {
 	{1, 0, 0, 0}, {1, 1, 0, 0}, {0, 1, 0, 0}, {0, 1, 1, 0},
@@ -151,21 +156,24 @@ void gpio_config() {
 }
 
 /*
- * usleep() cannot deliver sub-tick delays on the kernels these cameras run:
- * they are HZ=100 with no high-resolution timers, so every sleep rounds up to
- * a 10ms tick. usleep(1500) waits ~10ms, and 8 micro-steps x 10ms puts a hard
- * ~80ms floor under every step no matter how small the requested delay is
- * (measured on Hi3518EV200: 200 steps took 33s at delay 15 and still 18s at
- * delay 4). Spin on CLOCK_MONOTONIC for anything below a tick instead; moves
+ * On kernels built without high-resolution timers every sleep rounds up to a
+ * whole tick, so at HZ=100 usleep(1500) waits ~10ms and 8 micro-steps x 10ms
+ * put a hard ~80ms floor under every step no matter how small the requested
+ * delay is (measured on Hi3518EV200: 200 steps took 33s at delay 15 and still
+ * 18s at delay 4). Kernels with hrtimers deliver usleep(1500) in ~1.5ms, and
+ * sleeping is strictly better there. clock_getres() tells the two apart, so
+ * sleep whenever the kernel can honour the delay - or when the delay is at
+ * least a tick, where rounding no longer dominates - and spin on
+ * CLOCK_MONOTONIC only for sub-tick delays on a coarse-timer kernel. Moves
  * are short and bounded, so burning the CPU for their duration is a fair
- * trade, and longer delays still go to usleep so we do not spin needlessly.
+ * trade in that remaining case.
  */
 void delay_us(long us) {
 	if (us <= 0) {
 		return;
 	}
 
-	if (us >= 10000) {
+	if (CLOCK_RES_NS <= 1000000 || us >= CLOCK_RES_NS / 1000) {
 		usleep(us);
 		return;
 	}
@@ -197,7 +205,7 @@ void axis_run(const int pins[4], const int fds[4], int level, int steps, int del
 	const int (*seq)[4] = (steps < 0) ? REVERSE_STEP_SEQUENCE : STEP_SEQUENCE;
 	if (SELECT_PIN != -1) {
 		gpio_set(SELECT_FD, SELECT_PIN, level);
-		usleep(100);
+		delay_us(100);
 	}
 
 	int micro = 0;
@@ -227,11 +235,16 @@ int main(int argc, char *argv[]) {
 	int pan_steps = atoi(argv[1]);
 	int tilt_steps = atoi(argv[2]);
 	int delay_ms = atoi(argv[3]);
-	if (delay_ms < 0) {
-		fprintf(stderr, "delay must be >= 0\n");
+	if (delay_ms < 0 || delay_ms > INT_MAX / 1000) {
+		fprintf(stderr, "delay must be between 0 and %d ms\n", INT_MAX / 1000);
 		return 1;
 	}
 	int delay = delay_ms * 1000;
+
+	struct timespec res;
+	if (clock_getres(CLOCK_MONOTONIC, &res) == 0) {
+		CLOCK_RES_NS = res.tv_sec ? 1000000000L : res.tv_nsec;
+	}
 
 	gpio_config();
 	for (int i = 0; i < 4; i++) {


### PR DESCRIPTION
## What

Two changes to how `gpio-motors` paces the stepper sequence:

1. **Hold the sysfs `value` fds open for the whole run.** `gpio_set()` used to do `snprintf` + `fopen` + `fprintf` + `fclose` per pin, 4× per micro-step — 2–5 ms of pure file churn per micro-step on these SoCs, more than the delay it was trying to honour. Stepping is now an `lseek` + 1-byte `write` on an fd opened once after export.
2. **Deliver sub-tick delays where the kernel cannot.** On coarse-timer kernels (`CONFIG_HIGH_RES_TIMERS` off, HZ=100 — the Hi35xx/GK72xx boards here) every `usleep` rounds up to a 10 ms tick, so `usleep(1500)` waits ~10 ms and every micro-step has a hard 10 ms floor. `delay_us()` consults `clock_getres(CLOCK_MONOTONIC)` once (1 ns with hrtimers, one jiffy without) and keeps `usleep()` everywhere except the one case it cannot handle: a sub-tick delay on a coarse-timer kernel, where it polls `CLOCK_MONOTONIC` instead. Platforms with hrtimers keep their working sleep and never spin.

Also: the `SELECT_PIN` settle goes through `delay_us()` (as a plain `usleep(100)` it silently cost a whole tick on coarse-timer kernels), and delay arguments that would overflow the ms→µs conversion are rejected.

## Why

Measured on a Hi3518EV200 (HZ=100, no hrtimers): 200 steps took 33 s at delay 15 and still 18 s at delay 4 — the requested delay barely matters because the tick floor dominates. @widgetii reproduced the same numbers on a GK7205V200. With the fd cache plus a delivered 1.5 ms delay, a micro-step drops from ~12 ms to ~1.6 ms.

The root fix would be `CONFIG_HIGH_RES_TIMERS=y` per board, but as the review measurements show it does not fit every kernel partition without per-board trims (hi3516ev300-lite has 203 bytes of headroom), so this stays a userspace accommodation that detects the kernel it got.

Note for existing installs on coarse-timer kernels: the 10 ms floor has been the de-facto pace, so moves tuned against it become faster once the requested delay is actually delivered. Callers that want the old pace can pass `delay >= 10`.

## Verification

- Both revisions compile clean with `-Wall -Wextra`.
- Hi3518EV200 field data above; per-thread measurements in review replies.
