### PR TITLE
hisilicon-osdrv-hi3516cv200: add GC2023 MIPI sensor variant

### DIFF
--- a/general/package/hisilicon-osdrv-hi3516cv200/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516cv200/files/script/load_hisilicon
@@ -193,9 +193,10 @@ insert_sns() {
                 # ov2735_i2c_1080p.ini. All share the same MIPI pinmux +
                 # clock — sensor differentiation happens in libsns / .ini.
                 # gc2023_mipi is for boards with the GC2023 wired to MIPI
-                # (e.g. VStarcam Hi3518EV200): the plain gc2023 entry below
-                # muxes the parallel VI pads, which disables the MIPI PHY —
-                # VI then sees no VSYNC at all (IntCnt=0 in /proc/umap/vi).
+                # (e.g. VStarcam Hi3518EV200): the plain gc2023 entry in the
+                # first arm above muxes the parallel VI pads, which disables
+                # the MIPI PHY — VI then sees no VSYNC at all (IntCnt=0 in
+                # /proc/umap/vi).
                 devmem 0x200f0040 32 0x2 # I2C0_SCL
                 devmem 0x200f0044 32 0x2 # I2C0_SDA
 

--- a/general/package/hisilicon-osdrv-hi3516cv200/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516cv200/files/script/load_hisilicon
@@ -187,11 +187,15 @@ insert_sns() {
 
                 devmem 0x2003002c 32 0x94001 # sensor unreset, clk 37.125MHz, VI 99MHz
                 ;;
-        ov2710_mipi | ov2735_i2c_1080p | ov2735)
+        ov2710_mipi | ov2735_i2c_1080p | ov2735 | gc2023_mipi)
                 # MIPI variant. OV2710 uses libsns_ov2710_mipi.so via
                 # ov2710_mipi_1080p.ini; OV2735 uses libsns_ov2735.so via
-                # ov2735_i2c_1080p.ini. Both share the same MIPI pinmux +
+                # ov2735_i2c_1080p.ini. All share the same MIPI pinmux +
                 # clock — sensor differentiation happens in libsns / .ini.
+                # gc2023_mipi is for boards with the GC2023 wired to MIPI
+                # (e.g. VStarcam Hi3518EV200): the plain gc2023 entry below
+                # muxes the parallel VI pads, which disables the MIPI PHY —
+                # VI then sees no VSYNC at all (IntCnt=0 in /proc/umap/vi).
                 devmem 0x200f0040 32 0x2 # I2C0_SCL
                 devmem 0x200f0044 32 0x2 # I2C0_SDA
 

--- a/general/package/hisilicon-osdrv-hi3516cv200/files/sensor/config/gc2023_mipi_1080p.ini
+++ b/general/package/hisilicon-osdrv-hi3516cv200/files/sensor/config/gc2023_mipi_1080p.ini
@@ -1,0 +1,284 @@
+; GC2023 1080p - MIPI (CSI-2) variant, 2-lane RAW10.
+; Select with: fw_setenv sensor gc2023_mipi
+;              cli -s .isp.sensorConfig /etc/sensors/gc2023_mipi_1080p.ini
+; Verified on a VStarcam Hi3518EV200 board with the GC2023 wired to MIPI.
+;
+[sensor]
+Sensor_type   =gc2023                   ;sensor name
+Mode          =0                        ;WDR_MODE_NONE = 0
+                                        ;WDR_MODE_BUILT_IN = 1
+                                        ;WDR_MODE_2To1_LINE = 2
+                                        ;WDR_MODE_2To1_FRAME = 3
+                                        ;WDR_MODE_2To1_FRAME_FULL_RATE =4 ...etc
+DllFile   =/usr/lib/sensors/libsns_gc2023.so    ;sensor lib path
+
+
+[mode]
+input_mode = 0                          ;INPUT_MODE_MIPI = 0
+                                        ;INPUT_MODE_SUBLVDS = 1
+                                        ;INPUT_MODE_LVDS = 2 ...etc
+
+dev_attr = 0                            ;mipi_dev_attr_t = 0
+                                        ;lvds_dev_attr_t = 1
+                                        ;NULL =2
+
+[mipi]
+;----------only for mipi_dev---------
+data_type = 2                           ;raw data type: 8/10/12/14 bit
+                                        ;RAW_DATA_8BIT = 1
+                                        ;RAW_DATA_10BIT = 2
+                                        ;RAW_DATA_12BIT = 3
+                                        ;RAW_DATA_14BIT = 4
+lane_id = 0|1|-1|-1|-1|-1|-1|-1|        ;lane_id: -1 - disable
+
+[lvds]
+;----------only for lvds_dev---------
+img_size_w = -1                         ;oringnal sensor input image size W
+img_size_h = -1                         ;oringnal sensor input image size H
+wdr_mode = -1                           ;HI_WDR_MODE_NONE =0
+                                        ;HI_WDR_MODE_2F = 1
+                                        ;HI_WDR_MODE_3F = 2
+                                        ;HI_WDR_MODE_4F =3
+sync_mode = -1                          ;LVDS_SYNC_MODE_SOL = 0
+                                        ;LVDS_SYNC_MODE_SAV = 1
+raw_data_type = -1                      ;RAW_DATA_8BIT = 0
+                                        ;RAW_DATA_10BIT = 1
+                                        ;RAW_DATA_12BIT = 2
+                                        ;RAW_DATA_14BIT = 3
+data_endian = -1                        ;LVDS_ENDIAN_LITTLE = 0
+                                        ;LVDS_ENDIAN_BIG = 1
+sync_code_endian =-1                    ;LVDS_ENDIAN_LITTLE = 0
+                                        ;LVDS_ENDIAN_BIG = 1
+lane_id = -1|-1|-1|-1|-1|-1|-1|-1|      ;lane_id: -1 - disable
+lvds_lane_num = -1                      ;LVDS_LANE_NUM
+wdr_vc_num = -1                         ;WDR_VC_NUM
+sync_code_num = -1                      ;SYNC_CODE_NUM
+sync_code_0 = -1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|
+sync_code_1 = -1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|
+sync_code_2 = -1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|
+sync_code_3 = -1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|
+sync_code_4 = -1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|
+sync_code_5 = -1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|
+sync_code_6 = -1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|
+sync_code_7 = -1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|-1|
+
+[isp_image]
+Isp_x      =0
+Isp_y      =0
+Isp_W      =1920
+Isp_H      =1080
+Isp_FrameRate=25
+Isp_Bayer  =0   ;BAYER_RGGB=0, BAYER_GRBG=1, BAYER_GBRG=2, BAYER_BGGR=3 - GC2023 is SRGGB10
+
+
+[vi_dev]
+Input_mod =5    ;VI_INPUT_MODE_BT656 = 0
+                ;VI_INPUT_MODE_BT601,
+                ;VI_INPUT_MODE_DIGITAL_CAMERA
+Work_mod =0     ;VI_WORK_MODE_1Multiplex = 0
+                ;VI_WORK_MODE_2Multiplex,
+                ;VI_WORK_MODE_4Multiplex
+Combine_mode =0 ;Y/C composite or separation mode
+                ;VI_COMBINE_COMPOSITE = 0 /*Composite mode */
+                ;VI_COMBINE_SEPARATE,     /*Separate mode */
+Comp_mode    =0 ;Component mode (single-component or dual-component)
+                ;VI_COMP_MODE_SINGLE = 0, /*single component mode */
+                ;VI_COMP_MODE_DOUBLE = 1, /*double component mode */
+Clock_edge   =1 ;Clock edge mode (sampling on the rising or falling edge)
+                ;VI_CLK_EDGE_SINGLE_UP=0, /*rising edge */
+                ;VI_CLK_EDGE_SINGLE_DOWN, /*falling edge */
+Mask_num     =2 ;Component mask
+Mask_0       =0xFFF00000
+Mask_1       =0x0
+Scan_mode    = 1;VI_SCAN_INTERLACED = 0
+                ;VI_SCAN_PROGRESSIVE,
+Data_seq     =2 ;data sequence (ONLY for YUV format)
+                ;----2th component U/V sequence in bt1120
+                ;    VI_INPUT_DATA_VUVU = 0,
+                ;    VI_INPUT_DATA_UVUV,
+                ;----input sequence for yuv
+                ;    VI_INPUT_DATA_UYVY = 0,
+                ;    VI_INPUT_DATA_VYUY,
+                ;    VI_INPUT_DATA_YUYV,
+                ;    VI_INPUT_DATA_YVYU
+
+Vsync   =0      ; vertical synchronization signal
+                ;VI_VSYNC_FIELD = 0,
+                ;VI_VSYNC_PULSE,
+VsyncNeg=0      ;Polarity of the vertical synchronization signal
+                ;VI_VSYNC_NEG_HIGH = 0,
+                ;VI_VSYNC_NEG_LOW /*if VIU_VSYNC_E
+Hsync  =0       ;Attribute of the horizontal synchronization signal
+                ;VI_HSYNC_VALID_SINGNAL = 0,
+                ;VI_HSYNC_PULSE,
+HsyncNeg =0     ;Polarity of the horizontal synchronization signal
+                ;VI_HSYNC_NEG_HIGH = 0,
+                ;VI_HSYNC_NEG_LOW
+VsyncValid =1   ;Attribute of the valid vertical synchronization signal
+                ;VI_VSYNC_NORM_PULSE = 0,
+                ;VI_VSYNC_VALID_SINGAL,
+VsyncValidNeg =0;Polarity of the valid vertical synchronization signal
+                ;VI_VSYNC_VALID_NEG_HIGH = 0,
+                ;VI_VSYNC_VALID_NEG_LOW
+Timingblank_HsyncHfb =0     ;Horizontal front blanking width
+Timingblank_HsyncAct =1920  ;Horizontal effetive width
+Timingblank_HsyncHbb =0     ;Horizontal back blanking width
+Timingblank_VsyncVfb =0     ;Vertical front blanking height
+Timingblank_VsyncVact =1080  ;Vertical effetive width
+Timingblank_VsyncVbb=0      ;Vertical back blanking height
+Timingblank_VsyncVbfb =0    ;Even-field vertical front blanking height(interlace, invalid progressive)
+Timingblank_VsyncVbact=0    ;Even-field vertical effetive width(interlace, invalid progressive)
+Timingblank_VsyncVbbb =0    ;Even-field vertical back blanking height(interlace, invalid progressive)
+
+;----- only for bt656 ----------
+FixCode   =0    ;BT656_FIXCODE_1 = 0,
+                ;BT656_FIXCODE_0
+FieldPolar=0    ;BT656_FIELD_POLAR_STD = 0
+                ;BT656_FIELD_POLAR_NSTD
+DataPath  =1    ;ISP enable or bypass
+                ;VI_PATH_BYPASS    = 0,/* ISP bypass */
+                ;VI_PATH_ISP       = 1,/* ISP enable */
+                ;VI_PATH_RAW       = 2,/* Capture raw data, for debug */
+InputDataType=1 ;VI_DATA_TYPE_YUV = 0,VI_DATA_TYPE_RGB = 1,
+DataRev      =FALSE ;Data reverse. FALSE = 0; TRUE = 1
+DevRect_x=0     ;
+DevRect_y=0     ;
+DevRect_w=1920  ;
+DevRect_h=1080  ;
+
+[vi_chn]
+CapRect_X    =0
+CapRect_Y    =0
+CapRect_Width=1920
+CapRect_Height=1080
+DestSize_Width=1920
+DestSize_Height=1080
+CapSel       =2 ;Frame/field select. ONLY used in interlaced mode
+                ;VI_CAPSEL_TOP = 0,                  /* top field */
+                ;VI_CAPSEL_BOTTOM,                   /* bottom field */
+                ;VI_CAPSEL_BOTH,                     /* top and bottom field */
+
+PixFormat    =23;PIXEL_FORMAT_YUV_SEMIPLANAR_422 = 22
+                ;PIXEL_FORMAT_YUV_SEMIPLANAR_420 = 23 ...etc
+CompressMode =0 ;COMPRESS_MODE_NONE = 0
+                ;COMPRESS_MODE_SEG =1 ...etc
+
+SrcFrameRate=-1 ;Source frame rate. -1: not controll
+FrameRate   =-1 ;Target frame rate. -1: not controll
+[wdr]
+;only for wdr mode
+Compress =FALSE ;WDR Compress. FALSE = 0; TRUE = 1
+
+[vpss_group]
+Vpss_DciEn  =FALSE
+Vpss_IeEn   =FALSE
+Vpss_NrEn   =TRUE
+Vpss_HistEn =FALSE
+Vpss_DieMode=1  ;Define de-interlace mode
+                ;VPSS_DIE_MODE_AUTO  = 0,
+                ;VPSS_DIE_MODE_NODIE = 1,
+                ;VPSS_DIE_MODE_DIE   = 2,
+
+[vpss_corp]
+Crop_enable =FALSE
+Coordinate  =1  ;VPSS_CROP_RATIO_COOR = 0,   /*Ratio coordinate*/
+            ;VPSS_CROP_ABS_COOR = 1      /*Absolute coordinate*/
+Crop_X      =128
+Crop_Y      =128
+Crop_W      =1664
+Crop_H      =824
+
+[vpss_chn]
+Vpss_W    =1920
+Vpss_H    =1080
+CompressMode=0  ;COMPRESS_MODE_NONE = 0
+           ;COMPRESS_MODE_SEG =1 ...etc
+Mirror     =FALSE;Whether to mirror
+Flip       =TRUE;Whether to flip
+
+[vb_conf]
+VbCnt=10
+vbTimes=15     ;when raw=8bit  vbTimes = 10
+               ;when raw=10/12 bit  vbTimes = 15
+               ;when raw=14/16 bit   vbTimes = 20
+[venc_comm]
+venc_chn =1     ;create venc chn number;(0,2]
+BufCnt = 1      ;network meida-trans bufcnt
+
+[venc_0]
+PicWidth  =1920
+PicHeight =1080
+Profile   =2
+RcMode   =VENC_RC_MODE_H264CBR
+
+Gop    =50
+StatTime =2
+ViFrmRate  =25
+TargetFrmRate=25
+;----- only for VENC_RC_MODE_H264CBR ----------
+BitRate=4096
+FluctuateLevel=0
+;----- only for VENC_RC_MODE_H264VBR ----------
+MaxBitRate =10000
+
+MaxQp=32
+MinQp=24
+;----- only for VENC_RC_MODE_H264FIXQP ----------
+IQp=45
+
+PQp=40
+;-------- for REF_EX IsliceEnable------
+IsliceEnable = FALSE  ;IsliceEnable and ViEnable  is mutual exclusion
+IsRefreshEnable = FALSE  ;IsliceEnable  and  bRefreshEnable  both TRUE is effective
+RefreshLineNum = 12  ;PicHeight/16/6  6 is empirical value,ask Fuyang
+ReqIQp = 30
+;-------- for REF_EX ViEnable------
+ViEnable = TRUE
+ViInterval = 50 ; 2s
+ViQpDelta = 2
+
+[venc_1]
+PicWidth  =1920
+PicHeight =1080
+Profile   =2
+RcMode   =VENC_RC_MODE_H264CBR
+
+Gop    =50
+StatTime =2
+ViFrmRate  =25
+TargetFrmRate=25
+;----- only for VENC_RC_MODE_H264CBR ----------
+BitRate=4096
+FluctuateLevel=0
+;----- only for VENC_RC_MODE_H264VBR ----------
+MaxBitRate =10000
+
+MaxQp=32
+
+MinQp=24
+;----- only for VENC_RC_MODE_H264FIXQP ----------
+IQp=40
+
+PQp=45
+;-------- for REF_EX IsliceEnable------
+IsliceEnable = FALSE  ;IsliceEnable and ViEnable  is mutual exclusion
+IsRefreshEnable = FALSE  ;IsliceEnable  and  bRefreshEnable  both TRUE is effective
+RefreshLineNum = 12  ;PicHeight/16/6  6 is empirical value,ask Fuyang
+ReqIQp = 30
+;-------- for REF_EX ViEnable------
+ViEnable = TRUE
+ViInterval = 50 ; 2s
+ViQpDelta = 2
+
+[bind]
+ViDev   =0
+ViChn   =0
+VpssGrp =0
+VpssChn = 0
+VoDev   =0
+VoChn   =0
+ViSnapChn =0
+VpssSnapGrp=0
+VpssSnapChn=1
+VencSnapGrp=1
+VencSnapChn=3

--- a/general/package/hisilicon-osdrv-hi3516cv200/files/sensor/config/gc2023_mipi_1080p.ini
+++ b/general/package/hisilicon-osdrv-hi3516cv200/files/sensor/config/gc2023_mipi_1080p.ini
@@ -1,7 +1,13 @@
 ; GC2023 1080p - MIPI (CSI-2) variant, 2-lane RAW10.
 ; Select with: fw_setenv sensor gc2023_mipi
 ;              cli -s .isp.sensorConfig /etc/sensors/gc2023_mipi_1080p.ini
-; Verified on a VStarcam Hi3518EV200 board with the GC2023 wired to MIPI.
+;
+; NOTE: this does NOT stream with the libsns_gc2023.so that OpenIPC ships -
+; that library appears to program the sensor for DVP output and yields no
+; frames on a MIPI-wired board (VENC timeout). DllFile below must point at
+; a GC2023 MIPI sensor library, which OpenIPC does not currently ship.
+; The MIPI geometry here was validated on a VStarcam Hi3518EV200 using the
+; vendor's MIPI libsns - see https://github.com/OpenIPC/firmware/issues/2243
 ;
 [sensor]
 Sensor_type   =gc2023                   ;sensor name
@@ -67,7 +73,9 @@ Isp_x      =0
 Isp_y      =0
 Isp_W      =1920
 Isp_H      =1080
-Isp_FrameRate=25
+Isp_FrameRate=25 ;value present during the vendor-libsns verification, but the
+                 ;vendor init table is sensor_linear_1080p30_init - 30 may be
+                 ;more correct and is untested (see issue #2243)
 Isp_Bayer  =0   ;BAYER_RGGB=0, BAYER_GRBG=1, BAYER_GBRG=2, BAYER_BGGR=3 - GC2023 is SRGGB10
 
 


### PR DESCRIPTION
Some GC2023 boards wire the sensor to MIPI CSI-2, not DVP — e.g. VStarcam Hi3518EV200 pan/tilt cameras (2-lane RAW10). For those boards the existing `gc2023` entry in `load_hisilicon` is fatal: it muxes the parallel VI pads (`0x200f007c..0x200f0094`), which disables the MIPI PHY. The tell is `/proc/umap/vi` showing `IntCnt=0` with `TmgErr=0` and `ccErrN=0` — VI receives no VSYNC at all, while bad ini timings would at least raise the error counters.

Following the OV2710 precedent (#2035/#2038), this adds:

- a `gc2023_mipi` sensor identity that only muxes I2C0 and sets the 24 MHz sensor clock — the plain `gc2023` DVP entry is untouched;
- `gc2023_mipi_1080p.ini`, cloned from `ov2735_mipi_1080p.ini` (same SoC, same 2-lane RAW10 MIPI geometry) with the sensor identity swapped and `Isp_Bayer` corrected to 0 (RGGB — GC2023 is SRGGB10; the symptom of getting this wrong is red and blue swapping).

Verified on a VStarcam Hi3518EV200: with this identity and ini, VI `IntCnt` climbs and majestic delivers 1920×1080 at the sensor's native timing.

One honest caveat, detailed in #2243: the shipped closed-source `libsns_gc2023.so` did not produce frames on the tested unit (VENC timeout; it appears to program the sensor for DVP output) — the working setup used the vendor's MIPI libsns plus an init-table replay. The platform side fixed here is required either way, and #2243 carries the full recovered init table (123 writes, including the digital-gain `0xb1` trap) toward an open-source driver.
