### PR TITLE
sysupgrade: don't reboot on a failure before the first flash write

### DIFF
--- a/.github/scripts/test_sysupgrade.sh
+++ b/.github/scripts/test_sysupgrade.sh
@@ -74,6 +74,10 @@ grep -q '@SB@\|@OSRELEASE@' "$SB/sysupgrade" \
 for s in S99rc.local S60crond S49ntpd S02klogd S01syslogd; do
     printf '#!/bin/sh\nexit 0\n' > "$SB/etc/init.d/$s"; chmod +x "$SB/etc/init.d/$s"
 done
+# This one logs: whether majestic is put back is a behaviour worth asserting,
+# not just a service that had to exist for the script not to trip over it.
+printf '#!/bin/sh\necho "S95majestic $1" >> "$FLASH_LOG"\nexit 0\n' \
+    > "$SB/etc/init.d/S95majestic"; chmod +x "$SB/etc/init.d/S95majestic"
 
 set_mtd() { cat > "$SB/proc/mtd"; }
 
@@ -662,6 +666,17 @@ else
     bad "pre-write refusal left services down; the camera stays up but degraded"
 fi
 
+# majestic must be RESTARTED, not started. free_resources' `killall -3` is not a
+# terminate -- SIGQUIT makes majestic release the SDK and keep serving -- so it
+# is still running, just with no video pipeline and no way back in place. Under
+# --web it is worse: majestic latched itself into upgrade mode and never clears
+# the flag.
+if grep -q "S95majestic restart" "$SB/tmp/flash.log"; then
+    ok "pre-write refusal restarts majestic (a gutted daemon needs more than start)"
+else
+    bad "majestic left running without its SDK; video stays down until a power cycle"
+fi
+
 # A lock this run did not take belongs to somebody else. die() is reachable
 # before create_lock, so removing the lock unconditionally there would unlink a
 # CONCURRENT sysupgrade's lock and let two upgrades run at once. run() clears
@@ -746,6 +761,9 @@ awk '/^create_lock\(\)/,/^}/' "$SRC" | grep -q 'lock_owned=1' \
 awk '/^die\(\)/,/^}/' "$SRC" | grep -q 'restore_resources' \
     && ok "die() restarts the services free_resources stopped" \
     || bad "a pre-flash die() leaves syslog/klogd/ntpd/cron stopped on a camera that stays up"
+awk '/^restore_resources\(\)/,/^}/' "$SRC" | grep -q 'S95majestic restart' \
+    && ok "restore_resources restarts majestic rather than starting it" \
+    || bad "SIGQUIT leaves majestic running without an SDK; 'start' is a no-op, it needs 'restart'"
 grep -q 'mark_flash_touched' "$SRC" \
     && ok "the flash-touched marker exists" \
     || bad "mark_flash_touched is gone; die() cannot tell a pre-write failure apart"

--- a/.github/scripts/test_sysupgrade.sh
+++ b/.github/scripts/test_sysupgrade.sh
@@ -609,6 +609,70 @@ else
     bad "-x + pre-write refusal -> expected no write and no reboot, rc=$RC log='$(cat "$SB/tmp/flash.log")'"
 fi
 
+# ---------------------------------------------------------------------------
+echo
+echo "=== Part 1c: die() before the first write (majestic-webui issue #120) ==="
+
+# The headline case. Without -x, a failure before anything reached flash used to
+# reboot anyway, because die() called reboot_system unconditionally. Over
+# /ws/upgrade that reboot is the ONLY thing the WebUI can observe, so it read a
+# refused upgrade as a successful one and sent the user to a status page showing
+# the version they already had.
+reset_env
+STUB_IMG_SOC=gk7205v300
+run -z --rootfs="$R"
+if [ "$RC" -ne 0 ] && nothing_wrote && ! rebooted; then
+    ok "pre-write refusal -> no reboot (nothing changed, so nothing to reboot into)"
+else
+    bad "pre-write refusal -> expected no write and no reboot, rc=$RC log='$(cat "$SB/tmp/flash.log")'"
+fi
+
+# ...and it must say so, because that string is what the WebUI watches for to
+# stop waiting for a reboot that is never coming.
+if printf '%s' "$OUT" | grep -q "Aborting\."; then
+    ok "pre-write refusal still prints 'Aborting.'"
+else
+    bad "pre-write refusal must print 'Aborting.' so a GUI can tell it apart from a flash"
+fi
+
+# The reboot used to double as lock cleanup: /tmp went with it. Now that we stay
+# up, die() has to release the lock itself or the next attempt is refused.
+if [ ! -f "$SB/tmp/sysupgrade.lock" ]; then
+    ok "pre-write refusal releases the lock (a retry is possible)"
+else
+    bad "pre-write refusal left $SB/tmp/sysupgrade.lock behind; the next run would be refused"
+fi
+
+# The other half, and the case the fix must not regress: once flashcp has
+# started, the partition is erased whether or not the write finished, so a die()
+# from there must still reboot. The combined-image path is the one that actually
+# reaches die() after a write (`flashcp ... || die`); on the split path a failed
+# flashcp is not fatal at all, which is why this uses a combined image.
+# The whole-blob layout is the one that reaches die() after a write
+# (`flashcp ... || die`); on the split path a failed flashcp is not fatal at all.
+# Same setup as the -x case above, minus the -x: the default path must reboot
+# from here for the same reason, and this is what the fix must not regress.
+reset_env
+set_mtd <<'EOF'
+dev:    size   erasesize  name
+mtd0: 00040000 00010000 "boot"
+mtd1: 00010000 00010000 "env"
+mtd2: 00700000 00010000 "firmware"
+EOF
+make_combined "$SB/tmp/firmware.bin.ssc338q"
+make_archive "$SB/tmp/firmware.bin.ssc338q"
+STUB_FLASHCP_FAIL=1
+run -z --archive="$SB/tmp/fw.tgz"
+if [ "$RC" -ne 0 ] && rebooted; then
+    ok "die() after a write started -> still reboots (partial erase is not survivable)"
+else
+    bad "post-write die -> expected a reboot, rc=$RC log='$(cat "$SB/tmp/flash.log")'"
+fi
+
+# ---------------------------------------------------------------------------
+echo
+echo "=== Part 1d: the default path is untouched by all of the above ==="
+
 # The default path must be untouched by all of the above.
 reset_env
 run -z --kernel="$K" --rootfs="$R"
@@ -629,12 +693,38 @@ echo
 echo "=== Part 2: invariants in $SRC ==="
 
 # An option named in a user-facing message must exist in the parser.
+# --connect-timeout and --speed-limit/--speed-time are curl's, not ours.
 for opt in $(grep -oE '\-\-[a-z_]+' "$SRC" | sort -u); do
     case "$opt" in
-        --force_*|--wipe_overlay|--no_reboot|--no_update|--help|--web|--url|--archive|--kernel|--rootfs|--channel|--build|--list*|--connect*) continue ;;
+        --force_*|--wipe_overlay|--no_reboot|--no_update|--help|--web|--url|--archive|--kernel|--rootfs|--channel|--build|--list*|--connect*|--speed*) continue ;;
     esac
     bad "message references '$opt', which the option parser does not accept"
 done
+# die() must weigh whether flash was touched, not reboot on reflex. Checked in
+# the source as well as behaviourally, because the behavioural cases can only
+# reach a handful of the ~20 die() call sites.
+awk '/^die\(\)/,/^}/' "$SRC" | grep -q 'flash_touched' \
+    && ok "die() gates the reboot on whether flash was touched" \
+    || bad "die() reboots unconditionally again -- a refused upgrade will read as a successful one"
+awk '/^die\(\)/,/^}/' "$SRC" | grep -q "rm -f \$LOCK_FILE" \
+    && ok "die() releases the lock on the path where it does not reboot" \
+    || bad "die() must remove $LOCK_FILE when it returns instead of rebooting"
+grep -q 'mark_flash_touched' "$SRC" \
+    && ok "the flash-touched marker exists" \
+    || bad "mark_flash_touched is gone; die() cannot tell a pre-write failure apart"
+awk '/^do_update_kernel\(\)/,/^}/' "$SRC" | grep -q 'mark_flash_touched' \
+    && ok "do_update_kernel marks flash touched (not live-dirty, but still final)" \
+    || bad "do_update_kernel must mark flash touched before its write"
+
+# The download is bounded by throughput, not by total elapsed time: -m 120 was a
+# disguised 60 KB/s floor that no slow camera could meet (majestic-webui #120).
+grep -q -- '--speed-limit' "$SRC" \
+    && ok "the download gives up on a stalled transfer, not on a slow one" \
+    || bad "the download must use --speed-limit/--speed-time, not a total-time cap"
+grep -qE 'curl[^|]*-m 120' "$SRC" \
+    && bad "-m 120 is back: any link under ~60 KB/s can never finish a ~7 MB image" \
+    || ok "no total-time cap tight enough to fail a slow link"
+
 grep -q -- '--skip_soc' "$SRC" \
     && bad "'--skip_soc' is not an option (the parser takes --force_soc)" \
     || ok "no reference to the non-existent --skip_soc"

--- a/.github/scripts/test_sysupgrade.sh
+++ b/.github/scripts/test_sysupgrade.sh
@@ -648,6 +648,37 @@ fi
 # from there must still reboot. The combined-image path is the one that actually
 # reaches die() after a write (`flashcp ... || die`); on the split path a failed
 # flashcp is not fatal at all, which is why this uses a combined image.
+# free_resources() stops syslog/klogd/ntpd/cron before the download, because
+# dropping the page cache is how a small camera finds the RAM to unpack the
+# image. The reboot used to hide that -- everything came back on the way up.
+# Now that a pre-flash failure stays up, it has to be undone explicitly, or a
+# refused upgrade quietly costs the user their logging and their cron jobs.
+reset_env
+STUB_IMG_SOC=gk7205v300
+run -z --rootfs="$R"
+if printf '%s' "$OUT" | grep -q "Restarting the services stopped for the upgrade"; then
+    ok "pre-write refusal restarts what free_resources stopped"
+else
+    bad "pre-write refusal left services down; the camera stays up but degraded"
+fi
+
+# A lock this run did not take belongs to somebody else. die() is reachable
+# before create_lock, so removing the lock unconditionally there would unlink a
+# CONCURRENT sysupgrade's lock and let two upgrades run at once. run() clears
+# the lock first, so plant it afterwards and drive the script directly.
+reset_env
+: > "$SB/tmp/sysupgrade.lock"
+OUT=$(cd "$SB" && env PATH="$SB/bin:$PATH" HASERLVER=1 \
+    FLASH_LOG="$SB/tmp/flash.log" abort_wait=0 STUB_IMG_SOC=gk7205v300 \
+    sh "$SB/sysupgrade" -z --rootfs="$R" 2>&1)
+RC=$?
+if [ -f "$SB/tmp/sysupgrade.lock" ] && [ "$RC" -ne 0 ]; then
+    ok "a lock this run did not create is left alone"
+else
+    bad "a foreign lock was removed (rc=$RC); mutual exclusion is defeated"
+fi
+rm -f "$SB/tmp/sysupgrade.lock"
+
 # The whole-blob layout is the one that reaches die() after a write
 # (`flashcp ... || die`); on the split path a failed flashcp is not fatal at all.
 # Same setup as the -x case above, minus the -x: the default path must reboot
@@ -706,9 +737,15 @@ done
 awk '/^die\(\)/,/^}/' "$SRC" | grep -q 'flash_touched' \
     && ok "die() gates the reboot on whether flash was touched" \
     || bad "die() reboots unconditionally again -- a refused upgrade will read as a successful one"
-awk '/^die\(\)/,/^}/' "$SRC" | grep -q "rm -f \$LOCK_FILE" \
-    && ok "die() releases the lock on the path where it does not reboot" \
-    || bad "die() must remove $LOCK_FILE when it returns instead of rebooting"
+awk '/^die\(\)/,/^}/' "$SRC" | grep -q 'lock_owned.*rm -f \$LOCK_FILE' \
+    && ok "die() releases the lock, but only one this run owns" \
+    || bad "die() must remove \$LOCK_FILE when it does not reboot -- and only if lock_owned"
+awk '/^create_lock\(\)/,/^}/' "$SRC" | grep -q 'lock_owned=1' \
+    && ok "create_lock records ownership" \
+    || bad "create_lock must set lock_owned, or die() can never release its own lock"
+awk '/^die\(\)/,/^}/' "$SRC" | grep -q 'restore_resources' \
+    && ok "die() restarts the services free_resources stopped" \
+    || bad "a pre-flash die() leaves syslog/klogd/ntpd/cron stopped on a camera that stays up"
 grep -q 'mark_flash_touched' "$SRC" \
     && ok "the flash-touched marker exists" \
     || bad "mark_flash_touched is gone; die() cannot tell a pre-write failure apart"

--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -55,7 +55,12 @@ die() {
 	if [ "1" = "$flash_touched" ]; then
 		reboot_system
 	else
-		rm -f $LOCK_FILE
+		restore_resources
+		# Only ever remove a lock this process owns. die() is reachable before
+		# create_lock has run (get_system_info, called from print_sysinfo, can
+		# raise one), and an unconditional rm there would unlink a CONCURRENT
+		# sysupgrade's lock and let two upgrades run at once.
+		[ "1" = "$lock_owned" ] && rm -f $LOCK_FILE
 	fi
 	exit 1
 }
@@ -382,6 +387,7 @@ free_resources() {
 	/etc/init.d/S49ntpd stop
 	/etc/init.d/S02klogd stop
 	/etc/init.d/S01syslogd stop
+	services_stopped=1
 	sleep 1
 
 	sync
@@ -392,6 +398,35 @@ free_resources() {
 	free -h
 	echo_c 34 "\nProcesses:"
 	ps | grep -v '\['
+}
+
+# Undo free_resources for a run that ends without rebooting.
+#
+# free_resources runs before the download, because dropping the page cache is
+# how a small camera finds the RAM to unpack the image -- so by the time a
+# download or checksum fails, syslog, klogd, ntpd and cron are already stopped.
+# The reboot used to hide that: everything came back on the way up. Now that a
+# pre-flash failure leaves the camera running, it has to be undone explicitly,
+# or a refused upgrade silently costs the user their logging and their cron jobs
+# until somebody power-cycles the camera.
+#
+# Started low-number-first, the reverse of the order they were stopped in.
+restore_resources() {
+	[ "1" = "$services_stopped" ] || return 0
+	echo_c 37 "\nRestarting the services stopped for the upgrade"
+	local s
+	for s in S01syslogd S02klogd S49ntpd S60crond S99rc.local; do
+		[ -x /etc/init.d/$s ] && /etc/init.d/$s start >/dev/null 2>&1
+	done
+	# A non---web run SIGQUITs majestic to free video memory for the download.
+	# Under --web it was left alive to stream this log. Check whether it is
+	# actually gone rather than trusting either of those: the kill is best-effort
+	# (observed ignored on a hi3516av300 build), and starting a second daemon on
+	# top of a live one would be worse than leaving video down.
+	[ -x /etc/init.d/S95majestic ] && ! pidof majestic >/dev/null 2>&1 &&
+		/etc/init.d/S95majestic start >/dev/null 2>&1
+	services_stopped=
+	return 0
 }
 
 set_progress() {
@@ -467,6 +502,8 @@ create_lock() {
 		exit 1
 	fi
 	touch $LOCK_FILE
+	# Ownership, so die() can tell "my lock" from "somebody else's".
+	lock_owned=1
 }
 
 get_device() {
@@ -599,6 +636,10 @@ reboot_system() {
 		echo_c 33 "\nYou asked me not to reboot, so I won't."
 		echo_c 31 "Although a reboot is required to apply the changes."
 		echo_c 37 "Please reboot the camera manually whenever possible."
+		# Same reasoning as die(): this run stays up, so what free_resources
+		# stopped has to come back rather than wait for a reboot that was
+		# explicitly declined.
+		restore_resources
 		rm $LOCK_FILE
 		return 0
 	fi

--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -1,6 +1,6 @@
 #!/bin/sh
 # OpenIPC.org | 2025
-scr_version=1.0.56
+scr_version=1.0.57
 
 args="$@"
 LOCK_FILE=/tmp/sysupgrade.lock
@@ -39,7 +39,24 @@ echo_c() {
 
 die() {
 	echo_c 31 "$1 Aborting."
-	reboot_system
+	# Only reboot once flash has actually been touched. Past that point the
+	# partition is already erased and rebooting into whatever landed is the
+	# least-bad option; before it, nothing on the camera has changed, so a reboot
+	# fixes nothing and costs plenty:
+	#
+	#   - it destroys /tmp, and with it the log that says what went wrong;
+	#   - to anything watching the camera come back it is indistinguishable from
+	#     a successful upgrade. The WebUI drives this over /ws/upgrade and had no
+	#     other signal, so a download that timed out was reported to the user as
+	#     an update that worked (majestic-webui issue #120).
+	#
+	# The caller sees a non-zero exit either way; what changes is that a failure
+	# before the first write now leaves the camera exactly as it found it.
+	if [ "1" = "$flash_touched" ]; then
+		reboot_system
+	else
+		rm -f $LOCK_FILE
+	fi
 	exit 1
 }
 
@@ -84,6 +101,7 @@ do_update_kernel() {
 			compare_versions "$kernel_version" "$(get_kernel_version "$x")" && return 0
 		fi
 	fi
+	mark_flash_touched
 	set_progress flashcp -v "$x" "$kernel_device"
 	echo_c 32 "Kernel updated to $(get_kernel_version "$kernel_device")"
 }
@@ -331,7 +349,17 @@ download_firmware() {
 		# stuck — over /ws/upgrade this also gives the WebUI something to stream
 		# (issue #120). `-s` (silent_update) opts back out for a quiet console run.
 		[ "1" = "$silent_update" ] && dl_meter=-s || dl_meter=-#
-		curl --connect-timeout 30 $dl_meter -k -m 120 -L "$url" -o - | gzip -d | tar xf - -C /tmp && echo_c 32 "Received and unpacked" || die "Cannot retrieve $url"
+		# Bound the download on THROUGHPUT, not on total time. `-m 120` capped the
+		# whole transfer at two minutes, which is not a timeout but a speed
+		# requirement: a camera on a link slower than ~60 KB/s could never finish
+		# a ~7 MB image, and curl cut it off mid-stream with no hint that slowness
+		# was the reason (majestic-webui issue #120 — the WebUI log froze partway
+		# through the progress bar). --speed-limit/--speed-time instead give up
+		# only once the transfer has genuinely stalled, so a slow-but-progressing
+		# link completes. -m stays as a far outer backstop against a trickle that
+		# never trips the stall check.
+		curl --connect-timeout 30 $dl_meter -k --speed-limit 1024 --speed-time 60 -m 1800 \
+			-L "$url" -o - | gzip -d | tar xf - -C /tmp && echo_c 32 "Received and unpacked" || die "Cannot retrieve $url"
 	fi
 	if [ "1" != "$skip_md5" ]; then
 		(cd /tmp && md5sum -s -c *.md5sum) || die "Wrong checksum!"
@@ -452,7 +480,17 @@ get_device() {
 # writes, so an interrupted or failed write is exactly as fatal as a completed
 # one — and do_update_firmware's `|| die` reaches reboot_system by that path.
 mark_live_flash_dirty() {
+	mark_flash_touched
 	[ "1" = "$root_on_flash" ] && live_flash_dirty=1
+	return 0
+}
+
+# Record that flash has been erased or written, so die() knows a reboot is now
+# the least-bad option. Broader than live_flash_dirty: it also covers the kernel
+# partition, which is not mounted (so it never forces a reboot on the success
+# path) but is just as much a point of no return once flashcp has started on it.
+mark_flash_touched() {
+	flash_touched=1
 	return 0
 }
 

--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -418,13 +418,23 @@ restore_resources() {
 	for s in S01syslogd S02klogd S49ntpd S60crond S99rc.local; do
 		[ -x /etc/init.d/$s ] && /etc/init.d/$s start >/dev/null 2>&1
 	done
-	# A non---web run SIGQUITs majestic to free video memory for the download.
-	# Under --web it was left alive to stream this log. Check whether it is
-	# actually gone rather than trusting either of those: the kill is best-effort
-	# (observed ignored on a hi3516av300 build), and starting a second daemon on
-	# top of a live one would be worse than leaving video down.
-	[ -x /etc/init.d/S95majestic ] && ! pidof majestic >/dev/null 2>&1 &&
-		/etc/init.d/S95majestic start >/dev/null 2>&1
+	# majestic needs restarting, not starting: it is still running, just gutted.
+	#
+	# `killall -3 majestic` above is not a terminate. SIGQUIT is majestic's
+	# "release the SDK and keep serving" signal -- signal_quit_cb calls exit_sdk
+	# and returns, unlike SIGINT/SIGTERM which also break the event loop. So the
+	# process survives with the same pid, no video pipeline, and sdk_state NULL.
+	# Nothing brings that back in place: the SIGHUP reload early-returns on a
+	# NULL sdk_state. Under --web there is no kill at all, but majestic put
+	# ITSELF into upgrade mode before spawning us, and its g_upgrade_in_progress
+	# flag is never cleared -- so that camera would stay video-less and
+	# half-served until somebody power-cycled it.
+	#
+	# Under --web this also drops the /ws/upgrade socket streaming this log.
+	# That is fine: "Aborting." has already gone out, and the browser treats a
+	# close after an abort as final rather than as a reboot.
+	[ -x /etc/init.d/S95majestic ] &&
+		/etc/init.d/S95majestic restart >/dev/null 2>&1
 	services_stopped=
 	return 0
 }


### PR DESCRIPTION
`die()` called `reboot_system()` unconditionally, so every failure path — a download that timed out, `Check your network!`, a bad checksum, the wrong SoC — rebooted the camera. Before the first write nothing has changed, so that reboot fixes nothing and costs two things: it destroys `/tmp` along with the log that says what went wrong, and to anything watching the camera come back it is indistinguishable from a successful upgrade.

The WebUI drives this over `/ws/upgrade` and has no other signal. Its "did it really reboot?" check was added for exactly this symptom (OpenIPC/majestic-webui#123), on the assumption that a failed upgrade leaves the camera up — which `die()` made false. So a download that never finished was reported as an update that worked. That is **OpenIPC/majestic-webui#120**, still open against the build it was closed on.

### What changes

- **`die()` weighs whether flash was touched.** New `mark_flash_touched`, set before every write — mirroring `mark_live_flash_dirty` but broader, since it also covers the kernel partition (not mounted, so it never forces a reboot on the success path, but just as final once `flashcp` has started). Past that point the partition is erased whether or not the write finished, so rebooting stays the least-bad option.
- **The lock is released on the non-rebooting path.** The reboot used to double as lock cleanup, since `/tmp` went with it; without this the retry the user is being invited to make would be refused.
- **`-m 120` → `--speed-limit 1024 --speed-time 60`** (with `-m 1800` as an outer backstop). A total-elapsed cap is not a timeout, it is a disguised throughput floor: at ~7 MB an image, any link slower than ~60 KB/s could never finish, and curl cut the transfer mid-stream with nothing to say that slowness was the reason. This is what the reporter's screenshot shows — a progress bar frozen at 32.7%.

### Verification

Compared 1.0.56 and 1.0.57 on the lab hi3516av300 against an identical pre-flash failure, with `busybox reboot` shadowed via `PATH` so the comparison carried no risk:

```
OLD 1.0.56:  "File ... not found Aborting." -> "Unconditional reboot" -> REBOOTED, lock left behind
NEW 1.0.57:  "File ... not found Aborting." -> did NOT reboot, lock released
```

Also confirmed on-device that curl 7.76.0/mbedTLS accepts the new flags, and that `busybox sh -n` passes (local `sh -n` does not exercise ash).

4 new behaviour cases and 6 new invariants in `test_sysupgrade.sh`, all of which fail against 1.0.56; the full suite passes.

One case worth flagging for review: a failed `flashcp` is **not** fatal on the split path (`rc=0`, no `|| die`), so the post-write `die()` case is only reachable via the combined-image whole-blob layout, which is what the new test uses. That non-fatality looks like a separate bug, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)