### PR TITLE
majestic: make S95majestic init script independent of a pidfile

### DIFF
--- a/general/package/majestic/files/S95majestic
+++ b/general/package/majestic/files/S95majestic
@@ -6,21 +6,24 @@ DAEMON_ARGS="-s"
 start() {
 	echo -n "Starting $DAEMON: "
 	start-stop-daemon -b -S -q -x "$DAEMON" -- $DAEMON_ARGS
-	if [ $? -eq 0 ]; then
-		echo "OK"
-	else
-		echo "FAIL (already running)"
-	fi
+	case $? in
+		0) echo "OK" ;;
+		1) echo "FAIL (already running)" ;;
+		*) echo "FAIL" ;;
+	esac
 }
 
 stop() {
 	echo -n "Stopping $DAEMON: "
-	start-stop-daemon -K -q -x "$DAEMON"
-	if [ $? -eq 0 ]; then
+	if start-stop-daemon -K -q -x "$DAEMON"; then
 		echo "OK"
 	else
 		echo "FAIL"
 	fi
+}
+
+reload() {
+	start-stop-daemon -K -s 1 -q -x "$DAEMON"
 }
 
 case "$1" in
@@ -35,7 +38,7 @@ case "$1" in
 		;;
 
 	reload)
-		killall -1 "$DAEMON"
+		reload
 		;;
 
 	*)

--- a/general/package/majestic/files/S95majestic
+++ b/general/package/majestic/files/S95majestic
@@ -1,24 +1,22 @@
 #!/bin/sh
 
-DAEMON="majestic"
-PIDFILE="/var/run/$DAEMON.pid"
+DAEMON="/usr/bin/majestic"
 DAEMON_ARGS="-s"
 
 start() {
 	echo -n "Starting $DAEMON: "
-	start-stop-daemon -b -m -S -q -p "$PIDFILE" -x "$DAEMON" -- $DAEMON_ARGS
+	start-stop-daemon -b -S -q -x "$DAEMON" -- $DAEMON_ARGS
 	if [ $? -eq 0 ]; then
 		echo "OK"
 	else
-		echo "FAIL"
+		echo "FAIL (already running)"
 	fi
 }
 
 stop() {
 	echo -n "Stopping $DAEMON: "
-	start-stop-daemon -K -q -p "$PIDFILE"
+	start-stop-daemon -K -q -x "$DAEMON"
 	if [ $? -eq 0 ]; then
-		rm -f "$PIDFILE"
 		echo "OK"
 	else
 		echo "FAIL"


### PR DESCRIPTION
## Summary

Fix the `S95majestic` init script so a camera whose `majestic` died (OOM-kill, `kill -9`, power glitch) can actually be revived by the common crond watchdog line (`* * * * * pgrep majestic || /etc/init.d/S95majestic start`) and by repeated `S95majestic start` calls in general.

## Problem

On an OpenIPC SSC335DE camera (52 MB RAM) `majestic` was OOM-killed and stayed dead for 13+ minutes even though crond executed the watchdog every minute. The camera went fully offline (RTSP dead, no audio, no restart).

Reproduction with the stock script:

- `kill -9` a healthy `majestic`
- wait two minutes: `majestic` stays dead, while `cron.info` in the log shows the watchdog line executing every minute
- `/var/run/majestic.pid` ends up containing pids that never correspond to a live `majestic` (observed 456, 1355, 1843, 1856, 1870 vs. real daemon pids 4032, 1156, 1546, ...)

## Root cause

`start()`/`stop()` rely on `start-stop-daemon -b -m -S -p $PIDFILE -x majestic`, which has two problems on busybox 1.36 (see `debianutils/start_stop_daemon.c`):

1. **The pidfile becomes the single source of truth about "is it running" -- and it gets corrupt.** With `-b`, busybox `start-stop-daemon` double-forks and the pidfile is written by the final child right before `exec()`; if the daemon later dies uncleanly, the pidfile keeps a stale pid. With `-p` given, `do_procinit()` checks *only* the pidfile pid and never scans `/proc`, so a stale pidfile silently breaks both `start` and `stop` (`stop` signals nothing, its `rm -f` never runs).

2. **`-x majestic` (bare name) can only match by luck.** `pid_is_exec()` compares the pattern against the full `/proc/PID/exe` symlink (e.g. `/usr/bin/majestic`) and then against `argv[0]` from `/proc/PID/cmdline`; a bare `majestic` never matches the exe link, so detection is fragile.

A liveness pre-check in the crontab (`pgrep majestic`) is extra state that can also go stale -- e.g. a lingering zombie whose `comm` is still `majestic` makes `pgrep` succeed while no usable daemon exists.

## Fix

- Use the absolute path `/usr/bin/majestic` as `DAEMON` so busybox `-x` matches via `/proc/PID/exe`.
- Drop the pidfile entirely: `start` = `-b -S -q -x "$DAEMON"`, `stop` = `-K -q -x "$DAEMON"`. Without `-p`, `start-stop-daemon` scans `/proc` itself, so there is no stale state to poison it. Repeated `start` calls are idempotent: busybox refuses with a non-zero exit when the daemon is already running and does not touch the live instance.

This also makes the script safe for an **unconditional** crond watchdog (`* * * * * /etc/init.d/S95majestic start`): the daemon manager itself decides whether a copy is already running, with no `pgrep`/`pidof` pre-check to go stale.

## Verification (on device, OpenIPC SSC335DE, busybox 1.36.1)

- Stock script + stock watchdog line: `kill -9` -> `majestic` still dead at t+75 s and t+135 s while cron runs the line every minute; pidfile holds a wrong pid.
- Fixed script + unconditional cron line: `kill -9` -> the next cron tick restarts `majestic` (RTSP `:554` listening, stable across a 3-minute observation window); while healthy, the per-minute `start` is refused cleanly (`FAIL (already running)`, rc=1) and the running daemon is untouched.
- Nine consecutive `kill -9` -> restart cycles with the fixed invocation all succeeded; `start`, `stop` and `restart` actions verified individually.
- The production camera has been running the fixed script continuously since deployment.

## Notes

- `general/overlay/etc/init.d/S60crond` uses the same `-b -m -p` pattern; it did not fail on the test hardware, so it is intentionally left untouched.
- On this SoC family a freshly killed `majestic` can refuse to re-initialize the sensor/VENC HAL for a couple of minutes (silent exit, no kernel messages). A per-minute watchdog absorbs this by simply retrying; a one-shot restart does not.
