### PR TITLE
sysupgrade: flash from a ramfs, so the reboot cannot be eaten by the flash

### DIFF
--- a/.github/scripts/test_sysupgrade.sh
+++ b/.github/scripts/test_sysupgrade.sh
@@ -64,6 +64,7 @@ sed -e 's|grep "GITHUB_VERSION" "$1/etc/os-release"|grep "GITHUB_VERSION" "${1:-
     -e "s|/proc/cmdline|@SB@/proc/cmdline|g" \
     -e "s|/proc/sys/vm/drop_caches|@SB@/tmp/drop_caches|g" \
     -e "s|/etc/init.d/|@SB@/etc/init.d/|g" \
+    -e "s|/bin/busybox|@SB@/bin/busybox|g" \
     -e "s|@OSRELEASE@|/etc/os-release|g" \
     -e "s|@SB@|$SB|g" \
     "$SRC" > "$SB/sysupgrade"
@@ -110,6 +111,10 @@ stub killall    'exit 0'
 stub ntpd       'exit 0'
 stub curl       'exit 0'
 stub umount     'exit 0'
+# Logs so ordering can be asserted, and fails by default: an unprivileged test
+# host cannot really pivot, and the fallback is the safety property that matters
+# most here (a camera that cannot build a ramfs must still upgrade).
+stub pivot_root 'echo "pivot_root $*" >> "$FLASH_LOG"; exit ${STUB_PIVOT_RC:-1}'
 stub losetup    'case "$1" in -f) echo /dev/loop0;; *) exit 0;; esac'
 
 # download_firmware runs `md5sum -s -c`. -s (silent) is a busybox extension; GNU
@@ -150,6 +155,15 @@ exit 0'
 stub mount '
 [ $# -eq 0 ] && exit 0
 target=${!#}
+# STUB_MOUNT models the VERIFY-mount (a squashfs image over a loop device). The
+# ramfs pivot mounts tmpfs and relocates existing mounts; those are a different
+# operation and must not inherit the fault being injected, or the hang case
+# wedges before the code under test is even reached.
+for a in "$@"; do
+    case "$a" in
+        move|tmpfs|--move|-M) exit 0 ;;
+    esac
+done
 case "${STUB_MOUNT:-ok}" in
     ok)
         mkdir -p "$target/etc"
@@ -225,7 +239,8 @@ run() {
     : > "$SB/tmp/flash.log"
     OUT=$(cd "$SB" && env PATH="$SB/bin:$PATH" \
         HASERLVER=1 FLASH_LOG="$SB/tmp/flash.log" mount_wait="${MOUNT_WAIT:-3}" \
-        abort_wait=0 \
+        abort_wait=0 RAM_ROOT="$SB/ram" \
+        STUB_PIVOT_RC="${STUB_PIVOT_RC:-1}" \
         STUB_MOUNT="${STUB_MOUNT:-ok}" STUB_VENDOR="${STUB_VENDOR:-sigmastar}" \
         STUB_SOC="${STUB_SOC:-ssc338q}" \
         STUB_IMG_SOC="${STUB_IMG_SOC:-ssc338q}" \
@@ -245,7 +260,8 @@ at() { printf '%s\n' "$OUT" | grep -n -- "$1" | head -1 | cut -d: -f1; }
 
 reset_env() {
     unset STUB_MOUNT STUB_VENDOR STUB_SOC STUB_IMG_SOC STUB_IMG_VERSION MOUNT_WAIT
-    unset STUB_FLASHCP_FAIL
+    unset STUB_FLASHCP_FAIL STUB_PIVOT_RC
+    rm -rf "$SB/ram"
     rm -f "$SB"/tmp/*.ssc338q "$SB"/tmp/firmware.bin.* "$SB"/tmp/*.tgz "$SB"/tmp/*.md5sum
     make_uimage "$SB/tmp/uImage.ssc338q" ssc338q
     make_rootfs "$SB/tmp/rootfs.squashfs.ssc338q"
@@ -736,13 +752,59 @@ fi
 
 # ---------------------------------------------------------------------------
 echo
+echo "=== Part 1e: flashing from a ramfs (majestic-webui issue #120) ==="
+
+# flashcp rewrites the partition backing the live squashfs, so from the first
+# write onwards any rootfs page that is not resident reads back as the new image
+# at a stale offset. The reboot is a fork+exec of busybox FROM that partition, so
+# on a small camera it fails with EIO and the box never reboots -- it just stops,
+# needing a power cycle. Everything after the first write therefore has to run
+# from RAM.
+reset_env
+run -z --kernel="$K" --rootfs="$R"
+pline=$(grep -n "pivot_root" "$SB/tmp/flash.log" | head -1 | cut -d: -f1)
+fline=$(grep -n "flashcp"    "$SB/tmp/flash.log" | head -1 | cut -d: -f1)
+if [ -n "$pline" ] && [ -n "$fline" ] && [ "$pline" -lt "$fline" ]; then
+    ok "the ramfs pivot is attempted before the first write"
+else
+    bad "pivot must be attempted before any write (pivot=$pline first-write=$fline)"
+fi
+
+# ...but a camera that cannot build one must still upgrade. The pivot_root stub
+# fails by default, so this run took the fallback.
+if [ "$RC" -eq 0 ] && flashed /dev/mtd2 && flashed /dev/mtd3 && rebooted; then
+    ok "a failed pivot falls back to flashing in place"
+else
+    bad "failed pivot -> expected both flashed and a reboot, rc=$RC log='$(cat "$SB/tmp/flash.log")'"
+fi
+
+# The fallback path is the one that still has to reboot off the rewritten rootfs,
+# so it lines up the least fragile reboot it can rather than assuming busybox
+# will still be readable.
+if printf '%s' "$OUT" | grep -q "Reboot path:"; then
+    ok "the fallback reports which reboot primitive it will use"
+else
+    bad "the in-place fallback must prepare (and name) a reboot primitive"
+fi
+
+# The escape hatch for board bring-up.
+reset_env
+run -z --kernel="$K" --rootfs="$R" --no_ramfs
+if ! grep -q "pivot_root" "$SB/tmp/flash.log" && flashed /dev/mtd3 && rebooted; then
+    ok "--no_ramfs skips the pivot and flashes in place"
+else
+    bad "--no_ramfs -> expected no pivot but a normal flash, log='$(cat "$SB/tmp/flash.log")'"
+fi
+
+# ---------------------------------------------------------------------------
+echo
 echo "=== Part 2: invariants in $SRC ==="
 
 # An option named in a user-facing message must exist in the parser.
 # --connect-timeout and --speed-limit/--speed-time are curl's, not ours.
 for opt in $(grep -oE '\-\-[a-z_]+' "$SRC" | sort -u); do
     case "$opt" in
-        --force_*|--wipe_overlay|--no_reboot|--no_update|--help|--web|--url|--archive|--kernel|--rootfs|--channel|--build|--list*|--connect*|--speed*) continue ;;
+        --force_*|--wipe_overlay|--no_reboot|--no_update|--no_ramfs|--help|--web|--url|--archive|--kernel|--rootfs|--channel|--build|--list*|--connect*|--speed*) continue ;;
     esac
     bad "message references '$opt', which the option parser does not accept"
 done
@@ -779,6 +841,56 @@ grep -q -- '--speed-limit' "$SRC" \
 grep -qE 'curl[^|]*-m 120' "$SRC" \
     && bad "-m 120 is back: any link under ~60 KB/s can never finish a ~7 MB image" \
     || ok "no total-time cap tight enough to fail a slow link"
+
+# A pivot without a re-exec is theatre: pivot_root changes what paths resolve to,
+# but the running shell keeps its text mapped from the old squashfs inode, which
+# is the very thing that has to stop being true.
+awk '/^enter_ramfs\(\)/,/^}/' "$SRC" | grep -q '^\s*exec ' \
+    && ok "enter_ramfs re-execs (pivot alone leaves the shell on the old rootfs)" \
+    || bad "enter_ramfs must exec after pivoting, or the shell stays mapped to the flash"
+awk '/^enter_ramfs\(\)/,/^}/' "$SRC" | grep -q 'chroot' \
+    && ok "enter_ramfs chroots (pivot_root alone does not move this process's root)" \
+    || bad "enter_ramfs must chroot after pivot_root"
+awk '/^enter_ramfs\(\)/,/^}/' "$SRC" | grep -q 'ldd ' \
+    && ok "enter_ramfs stages the shared libraries busybox needs" \
+    || bad "busybox is dynamically linked; staging it without its libs gives an unrunnable ramfs"
+for m in /dev /proc /tmp; do
+    awk '/^enter_ramfs\(\)/,/^}/' "$SRC" | grep -q "mount -o move $m" \
+        && ok "enter_ramfs carries $m into the new root" \
+        || bad "enter_ramfs must move $m across, or the flash phase loses it"
+done
+case "$(grep -m1 '^RAM_ROOT=' "$SRC")" in
+    *'/tmp'*) bad "RAM_ROOT must not live under /tmp -- /tmp is moved into it" ;;
+    *)        ok  "RAM_ROOT is outside /tmp" ;;
+esac
+grep -q '_ramfs_phase' "$SRC" \
+    && ok "the second phase has an entry point" \
+    || bad "the re-exec'd process has no way to skip to the flash"
+# busybox dispatches on argv[0]; without symlinks the new root has no tools.
+awk '/^enter_ramfs\(\)/,/^}/' "$SRC" | grep -q 'ln -sf busybox' \
+    && ok "enter_ramfs installs busybox applet symlinks" \
+    || bad "without applet symlinks the pivoted root cannot run od/cut/grep/flashcp"
+awk '/^enter_ramfs\(\)/,/^}/' "$SRC" | grep -q 'for applet in sh flashcp reboot' \
+    && ok "enter_ramfs refuses to pivot into a root missing the essentials" \
+    || bad "enter_ramfs must verify the staged root can actually flash and reboot"
+# After the pivot the old system is behind /mnt, so exiting without a reboot
+# leaves exactly the corpse this change exists to prevent.
+awk '/^die\(\)/,/^}/' "$SRC" | grep -q '_ramfs_phase' \
+    && ok "die() reboots unconditionally once we are in the ramfs" \
+    || bad "a die() inside the ramfs must reboot; there is no system left to return to"
+# The WebUI keeps majestic alive on purpose: it is the server streaming the log,
+# and SIGQUIT to a majestic already in upgrade mode is a use-after-free
+# (widgetii/majestic#288). The only legitimate one left is free_resources'
+# non---web kill, which frees video memory for the download.
+if [ "$(grep -c 'killall -q -3 majestic' "$SRC")" = "1" ] &&
+    awk '/^free_resources\(\)/,/^}/' "$SRC" | grep -q 'killall -q -3 majestic'; then
+    ok "the only SIGQUIT at majestic is free_resources' non---web one"
+else
+    bad "a SIGQUIT at majestic outside free_resources -- in upgrade mode that is a use-after-free"
+fi
+grep -q "Stopping web server before flashing" "$SRC" \
+    && bad "the pre-flash 'stop the web server' step is back; --web exists to keep it serving" \
+    || ok "no pre-flash stop of the web server"
 
 grep -q -- '--skip_soc' "$SRC" \
     && bad "'--skip_soc' is not an option (the parser takes --force_soc)" \

--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -4,6 +4,10 @@ scr_version=1.0.57
 
 args="$@"
 LOCK_FILE=/tmp/sysupgrade.lock
+# Where the flash phase is moved to before it starts writing. Deliberately not
+# under /tmp: /tmp is moved into it, and a mount cannot be relocated under
+# itself. See enter_ramfs.
+RAM_ROOT=${RAM_ROOT:-/ram}
 # Seconds the rootfs verify-mount may take before it is treated as unmountable.
 mount_wait=${mount_wait:-45}
 # Seconds the operator gets to Ctrl-C out of a run that will force a reboot.
@@ -52,7 +56,12 @@ die() {
 	#
 	# The caller sees a non-zero exit either way; what changes is that a failure
 	# before the first write now leaves the camera exactly as it found it.
-	if [ "1" = "$flash_touched" ]; then
+	# Once we have pivoted there is no sane system left to hand back: the mount
+	# namespace belongs to the ramfs, so the services, /etc and the rootfs the
+	# operator would return to are all behind /mnt. Exiting without rebooting
+	# from there is the corpse state this whole change exists to avoid, so any
+	# failure in the second phase reboots regardless of what was written.
+	if [ "1" = "$flash_touched" ] || [ "1" = "$_ramfs_phase" ]; then
 		reboot_system
 	else
 		restore_resources
@@ -439,11 +448,158 @@ restore_resources() {
 	return 0
 }
 
+# Everything from the first flash write onwards runs on borrowed time.
+#
+# flashcp rewrites the MTD partition that backs the mounted squashfs rootfs, and
+# the page cache is not invalidated by that (the write goes to the raw /dev/mtdN
+# character device, behind the block layer's back). So the running system keeps
+# working for exactly as long as the pages it needs stay RESIDENT. Any page that
+# has to be faulted back in after the write reads the NEW image at the OLD
+# offset: garbage, or EIO. free_resources() has already dropped the page cache to
+# make room for the download, so on a small camera the eviction is likely rather
+# than theoretical.
+#
+# That is what kills the reboot. `busybox reboot` is a fork+exec of an 867 KB
+# binary that lives on the partition just overwritten, so on a 64 MB board it
+# fails with EIO and the camera never reboots -- it sits there with a corrupt
+# live filesystem until somebody power-cycles it. Reported as
+# OpenIPC/majestic-webui#120; the same mechanism was described for the -x path in
+# #2231, where forcing a reboot fixed the symptom without removing the hazard.
+#
+# Reproduced deterministically without touching MTD: copy the rootfs squashfs to
+# tmpfs, loop-mount it, exec a binary from it (fine), overwrite the backing file
+# (fine -- pages still cached), then drop caches and exec again: I/O error.
+#
+# Two defences, prepared BEFORE the first write while the rootfs is still whole:
+safe_bb=
+safe_sysrq=
+
+prepare_safe_reboot() {
+	# 1. sysrq. `read`, `[` and `echo` are shell builtins, so triggering a reboot
+	#    this way forks nothing, execs nothing and maps nothing -- it is the only
+	#    reboot the flash cannot defeat. Not universal though: some kernel configs
+	#    build without CONFIG_MAGIC_SYSRQ, hence the fallback below.
+	if [ -w /proc/sysrq-trigger ]; then
+		local v=
+		read v < /proc/sys/kernel/sysrq 2>/dev/null
+		# 1 means "everything enabled"; otherwise it is a bitmask and 0x80 is the
+		# bit that allows reboot/poweroff.
+		if [ "1" = "$v" ]; then
+			safe_sysrq=1
+		elif [ -n "$v" ] && [ "$v" -gt 0 ] 2>/dev/null &&
+			[ $((v & 128)) -ne 0 ] 2>/dev/null; then
+			safe_sysrq=1
+		fi
+	fi
+
+	# 2. A copy of busybox in tmpfs is RAM-backed, so exec'ing it never reads the
+	#    flash. Used for the post-write applets too, not just the reboot.
+	if cp /bin/busybox /tmp/busybox 2>/dev/null && chmod +x /tmp/busybox 2>/dev/null; then
+		safe_bb=/tmp/busybox
+	fi
+
+	echo_c 34 "Reboot path: ${safe_sysrq:+sysrq }${safe_bb:+tmpfs-busybox }${safe_sysrq:-${safe_bb:-rootfs-busybox (no fallback available)}}"
+	return 0
+}
+
+# Move the whole flashing phase into a RAM filesystem and re-exec there, so that
+# nothing it needs afterwards lives on the partition it is about to overwrite.
+#
+# pivot_root on its own is not enough: it changes what paths resolve to, but the
+# already-running shell keeps its text mapped from the old squashfs inode. The
+# re-exec is what actually gets us off the doomed partition, which is why this
+# ends in `exec` and why the caller treats a return as failure.
+#
+# On success this never returns. On any failure it returns and the caller
+# flashes in place, exactly as before — a camera that cannot build a ramfs is
+# still better off upgrading than not.
+enter_ramfs() {
+	[ "1" = "$skip_ramfs" ] && return 1
+	command -v pivot_root >/dev/null 2>&1 || return 1
+
+	echo_c 37 "\nMoving the flash phase into RAM"
+
+	# Not under /tmp: /tmp is moved into the new root below, and a mount point
+	# cannot be moved underneath itself.
+	mkdir -p "$RAM_ROOT" 2>/dev/null || return 1
+	mount -t tmpfs -o size=16m tmpfs "$RAM_ROOT" 2>/dev/null || return 1
+	mkdir -p "$RAM_ROOT/bin" "$RAM_ROOT/lib" "$RAM_ROOT/dev" "$RAM_ROOT/proc" \
+		"$RAM_ROOT/tmp" "$RAM_ROOT/sys" "$RAM_ROOT/mnt" 2>/dev/null || return 1
+
+	# busybox is dynamically linked here, so the loader and every library it
+	# names have to come too, or the re-exec dies with the rootfs still mapped.
+	cp /bin/busybox "$RAM_ROOT/bin/" 2>/dev/null || return 1
+	local lib
+	for lib in $(ldd /bin/busybox 2>/dev/null | grep -oE '/[^ ]*\.so[^ ]*'); do
+		[ -f "$lib" ] && cp "$lib" "$RAM_ROOT/lib/" 2>/dev/null
+	done
+	# busybox dispatches on argv[0], so without symlinks every tool the flash
+	# phase reaches for -- od, xxd, cut, grep, losetup, flashcp -- is simply "not
+	# found" once we are in the new root. The first hardware run pivoted
+	# perfectly and then could not find a single one of them.
+	local applet
+	for applet in $("$RAM_ROOT/bin/busybox" --list 2>/dev/null); do
+		ln -sf busybox "$RAM_ROOT/bin/$applet" 2>/dev/null
+	done
+	# --list is a build option; fall back to what the flash phase actually uses.
+	for applet in sh ash awk basename cat cut dd flash_eraseall flashcp grep \
+		head ln losetup ls mkdir mount od printf reboot rm sed sleep sync \
+		tail timeout umount xxd; do
+		[ -e "$RAM_ROOT/bin/$applet" ] || ln -sf busybox "$RAM_ROOT/bin/$applet" 2>/dev/null
+	done
+	# If the essentials are not there, the ramfs is worse than useless: better to
+	# hand back to the in-place path than to pivot into a root with no tools.
+	for applet in sh flashcp reboot; do
+		[ -e "$RAM_ROOT/bin/$applet" ] || return 1
+	done
+	cp "$0" "$RAM_ROOT/sysupgrade" 2>/dev/null || return 1
+	chmod +x "$RAM_ROOT/sysupgrade" 2>/dev/null
+
+	# Carry over the mounts the flash still needs: /dev for the MTD nodes, /proc
+	# for get_device and sysrq, /tmp for the unpacked images. Moving rather than
+	# binding leaves nothing pointing back into the old root.
+	mount -o move /dev "$RAM_ROOT/dev" 2>/dev/null || return 1
+	mount -o move /proc "$RAM_ROOT/proc" 2>/dev/null || return 1
+	mount -o move /tmp "$RAM_ROOT/tmp" 2>/dev/null || return 1
+	mount -o move /sys "$RAM_ROOT/sys" 2>/dev/null
+
+	# State the second phase cannot recompute once the old root is behind it.
+	# NOT _ramfs_phase: that one is set only after the pivot has actually
+	# happened. Setting it here leaks into the fallback, where it would tell
+	# die() to reboot on a failure that never touched flash -- the exact
+	# false-success this script was fixed to stop doing.
+	export model kernel_file rootfs_file kernel_device fw_dev flash_type vendor
+	export update_kernel update_rootfs clear_overlay image_combined exit_update
+	export skip_soc skip_ver skip_reboot skip_md5 web_update silent_update
+	export live_flash_dirty root_on_flash flash_touched services_stopped
+	export kernel_version system_version rootfs_version mount_wait abort_wait
+
+	cd "$RAM_ROOT" || return 1
+	# After this the old root is at ./mnt and still mounted — deliberately: the
+	# MTD partitions are addressed through /dev, not through it.
+	if ! pivot_root . mnt 2>/dev/null; then
+		# Back to where the caller left us: the fallback flashes in place and
+		# must not inherit a working directory inside a half-built ramfs.
+		cd / 2>/dev/null
+		return 1
+	fi
+
+	# Past the pivot there is no way back, so this is where the second phase is
+	# declared -- see the note above the other exports.
+	export _ramfs_phase=1
+
+	# `chroot .` is what actually re-points this process's root; pivot_root only
+	# moved the mounts. Then exec so the shell interpreting the rest is the copy
+	# in RAM, not the one on the flash we are about to erase.
+	exec ./bin/busybox chroot . /bin/busybox ash /sysupgrade
+	return 1
+}
+
 set_progress() {
 	if [ "1" = "$silent_update" ]; then
-		busybox "$@" | awk '{print NR, $1}'
+		"${safe_bb:-busybox}" "$@" | awk '{print NR, $1}'
 	else
-		busybox "$@"
+		"${safe_bb:-busybox}" "$@"
 	fi
 }
 
@@ -629,8 +785,11 @@ Where:
                         rewrites the flash the camera is running from, which
                         no running system survives.
   -z, --no_update       Do not update self.
-      --web             Invoked by the WebUI: keep majestic alive to stream
-                        progress over /ws/upgrade, stop it only before flashing.
+      --no_ramfs        Flash from the rootfs instead of moving into RAM first.
+                        Reinstates the failure this guards against; for board
+                        bring-up only.
+      --web             Invoked by the WebUI: keep majestic alive so it can
+                        stream progress over /ws/upgrade.
   -h, --help            Display this help and exit.
 
 Manifest URL: \$MANIFEST_URL (default: $MANIFEST_URL)
@@ -666,7 +825,44 @@ reboot_system() {
 		echo_c 31 "The running filesystem cannot survive that; only a reboot applies it."
 	fi
 	echo_c 37 "\nUnconditional reboot"
+	# Ordered by how little of the rootfs each one needs. See
+	# prepare_safe_reboot: by now the partition these live on may already read
+	# back as the new image.
+	if [ "1" = "$safe_sysrq" ]; then
+		# Builtins only -- no fork, no exec, no new mapping. `s` syncs (the jffs2
+		# overlay may have dirty pages), `b` reboots immediately. If sysrq is
+		# there but wedged, execution simply continues to the next attempt.
+		echo s > /proc/sysrq-trigger
+		echo b > /proc/sysrq-trigger
+	fi
+	# tmpfs copy first, the rootfs one only as a last resort.
+	[ -n "$safe_bb" ] && "$safe_bb" reboot -d 1 -f
 	busybox reboot -d 1 -f
+}
+
+# Do everything that writes flash, then reboot. A function because it is entered
+# from two places: normally after enter_ramfs has re-exec'd us inside the ramfs,
+# and directly when there is no ramfs to move into.
+flash_and_reboot() {
+if [ "1" = "$image_combined" ]; then
+	# One blob covers both kernel and rootfs; any of -k/-r/--url/--channel
+	# maps to a single combined write.
+	{ [ "1" = "$update_kernel" ] || [ "1" = "$update_rootfs" ]; } && do_update_firmware
+else
+	# Verify the rootfs BEFORE the first write. The kernel is flashed first, and
+	# this check used to live inside do_update_rootfs — so a rootfs that failed
+	# verification was only ever discovered once the kernel had already been
+	# committed, leaving a half-upgraded device: new kernel, old rootfs, and no
+	# way back except a manual flash. Checking first means a failure costs nothing.
+	[ "1" = "$update_rootfs" ] && verify_rootfs "$rootfs_file"
+	[ "1" = "$update_kernel" ] && do_update_kernel "$kernel_file"
+	[ "1" = "$update_rootfs" ] && do_update_rootfs "$rootfs_file"
+fi
+[ "1" = "$clear_overlay" ] && do_wipe_overlay
+
+reboot_system
+
+exit 0
 }
 
 for i in "$@"; do
@@ -760,6 +956,14 @@ for i in "$@"; do
 			shift
 			;;
 
+		--no_ramfs)
+			# Escape hatch: flash from the rootfs the old way. For bringing up a
+			# board where the pivot itself is suspect — it gives back the failure
+			# mode this option exists to avoid, so it is not a general-purpose flag.
+			skip_ramfs=1
+			shift
+			;;
+
 		-z | --no_update)
 			skip_selfupdate=1
 			shift
@@ -786,6 +990,16 @@ for i in "$@"; do
 			;;
 	esac
 done
+
+# Second phase of a ramfs upgrade. enter_ramfs re-exec'd us with no arguments
+# inside the new root, so everything before the flash — probing, download,
+# verification, stopping services — has already happened in the process that
+# pivoted us here, and its results arrived in the environment. Go straight to
+# the writes; flash_and_reboot never returns.
+if [ "1" = "$_ramfs_phase" ]; then
+	echo_c 34 "Flashing from RAM (pid $$)"
+	flash_and_reboot
+fi
 
 print_sysinfo
 
@@ -845,31 +1059,8 @@ fi
 trap '' HUP INT TERM PIPE
 echo_c 37 "\nProtected: flashing continues even if this terminal disconnects."
 
-# --web: stop majestic now (the web server that streamed progress until here).
-# The browser switches to "rebooting" when its /ws/upgrade socket closes; this
-# detached sysupgrade keeps flashing (setsid + the trap above) and reboots.
-if [ "1" = "$web_update" ]; then
-	echo_c 37 "Stopping web server before flashing"
-	killall -q -3 majestic
-	sleep 1
-fi
-
-if [ "1" = "$image_combined" ]; then
-	# One blob covers both kernel and rootfs; any of -k/-r/--url/--channel
-	# maps to a single combined write.
-	{ [ "1" = "$update_kernel" ] || [ "1" = "$update_rootfs" ]; } && do_update_firmware
-else
-	# Verify the rootfs BEFORE the first write. The kernel is flashed first, and
-	# this check used to live inside do_update_rootfs — so a rootfs that failed
-	# verification was only ever discovered once the kernel had already been
-	# committed, leaving a half-upgraded device: new kernel, old rootfs, and no
-	# way back except a manual flash. Checking first means a failure costs nothing.
-	[ "1" = "$update_rootfs" ] && verify_rootfs "$rootfs_file"
-	[ "1" = "$update_kernel" ] && do_update_kernel "$kernel_file"
-	[ "1" = "$update_rootfs" ] && do_update_rootfs "$rootfs_file"
-fi
-[ "1" = "$clear_overlay" ] && do_wipe_overlay
-
-reboot_system
-
-exit 0
+# On success this never comes back — the rest runs in the re-exec'd process
+# inside the ramfs. If the camera could not give us one, fall back to flashing
+# in place and at least line up the least fragile reboot available.
+enter_ramfs || prepare_safe_reboot
+flash_and_reboot

--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -522,7 +522,11 @@ enter_ramfs() {
 	# Not under /tmp: /tmp is moved into the new root below, and a mount point
 	# cannot be moved underneath itself.
 	mkdir -p "$RAM_ROOT" 2>/dev/null || return 1
-	mount -t tmpfs -o size=16m tmpfs "$RAM_ROOT" 2>/dev/null || return 1
+	# A cap, not a reservation: the staged root is busybox plus its libraries and
+	# the script, around 1.5 MB. Kept small because the cameras that need this
+	# most have 34 MB of RAM in total, and /tmp (holding the unpacked image) is
+	# a separate mount that does not draw on this budget.
+	mount -t tmpfs -o size=8m tmpfs "$RAM_ROOT" 2>/dev/null || return 1
 	mkdir -p "$RAM_ROOT/bin" "$RAM_ROOT/lib" "$RAM_ROOT/dev" "$RAM_ROOT/proc" \
 		"$RAM_ROOT/tmp" "$RAM_ROOT/sys" "$RAM_ROOT/mnt" 2>/dev/null || return 1
 


### PR DESCRIPTION
A WebUI upgrade could leave a camera needing a **physical power cycle**: the log froze, the box stopped answering, and after the power cycle it was running the *new* firmware. So the flash completed and the reboot did not.

Reported in OpenIPC/majestic-webui#120 (gk7205v300, 64 MB), and distinct from the false-success bug fixed in #2249.

### Mechanism

`flashcp` rewrites the MTD partition backing the mounted squashfs rootfs, and that write goes to the raw `/dev/mtdN` character device — behind the block layer, so the page cache is never invalidated. The running system therefore keeps working for exactly as long as the pages it needs stay **resident**; anything faulted back in afterwards reads the new image at a stale offset. `free_resources()` has already dropped the cache to make room for the download, so on a 64 MB camera eviction is likely rather than theoretical — and on a 754 MB one it never happens, which is why this reproduces for some users and never in the lab.

What that kills is the reboot: `busybox reboot` is a fork+exec of an 867 KB binary living on the partition just overwritten, so it fails with EIO and nothing reboots.

Same mechanism @widgetii documented for the `-x` path in #2231; #2236 forced a reboot there, which cured that symptom without removing the hazard.

**Reproduced deterministically with no MTD writes at all** — copy the rootfs squashfs to tmpfs, loop-mount it, and rewrite the backing file:

```
exec from loop-squashfs         -> OK
overwrite backing store         -> (what flashcp does to mtd3)
exec again, pages still cached  -> OK        <- why it looks fine on a big camera
drop_caches, exec again         -> Input/output error, rc=126
```

### Fix

Move the flashing phase into RAM, the way OpenWrt's sysupgrade does. `enter_ramfs` stages busybox, its loader and libraries, and the script into a tmpfs, moves `/dev`, `/proc` and `/tmp` across, `pivot_root`s and **re-execs**.

The re-exec is the part that matters: `pivot_root` changes what paths resolve to, but the running shell keeps its text mapped from the old squashfs inode — a pivot without one is theatre.

Failure is always backwards-compatible: any step that does not work returns, and the caller flashes in place exactly as before, after lining up the least fragile reboot available (sysrq needs no fork, no exec and no new mapping; a tmpfs copy of busybox is next). `--no_ramfs` forces that path for board bring-up.

Two things only the hardware found:
- busybox dispatches on `argv[0]`, so the first run pivoted perfectly and then could not find `od`, `cut`, `grep` or `flashcp`. Applet symlinks are not optional.
- a `die()` after the pivot must reboot whatever it was doing — the old system is behind `/mnt`, so exiting there leaves precisely the corpse this change exists to prevent.

### Also: drop the `--web` pre-flash `killall -q -3 majestic`

`--web` exists so majestic can keep streaming the log; the daemon has already released its video pipeline by that point; and SIGQUIT to a majestic already in upgrade mode is unsafe, and is fixed in the daemon. The log survives the pivot anyway — `tail`'s fd and the websocket are open file descriptors, and moving a mount does not disturb them.

### Verified on a lab hi3516av300

After the pivot: `/` is tmpfs, busybox is on tmpfs, the old root is at `/mnt`, `/dev/mtd3`, `/proc/mtd` and the staged image are all reachable, all 14 tools the flash phase uses resolve, and `od`/`grep` still work after an explicit `drop_caches`. Rebooted from RAM via sysrq and came back clean.

7 new behaviour cases and 12 new invariants; **83 checks pass**.

One thing reviewers should weigh: the real pivot cannot be exercised by the offline suite (it needs root and real mounts), so it is covered by source invariants plus the hardware run above. The fallback — the property that a camera which cannot build a ramfs still upgrades — *is* covered behaviourally, since the stub fails by default.

Refs OpenIPC/majestic-webui#120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)