### PR TITLE
ci: run scheduled workflows only on the canonical repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,13 +10,17 @@ on:
 jobs:
   preflight:
     name: Preflight
-    # Only the canonical repo builds unattended. A clone pushed to a new
+    # Only the canonical repo builds on the cron. A clone pushed to a new
     # repository (a private mirror, an internal re-host) inherits this file
-    # along with its cron, and would run the full platform matrix nightly on
-    # someone else's Actions bill while publishing nightlies nobody reads.
+    # along with its schedule, and would run the full platform matrix nightly
+    # on someone else's Actions bill while publishing nightlies nobody reads.
     # Forks are already covered — GitHub disables scheduled workflows there —
-    # but a fresh repository is not. Manual dispatch still works everywhere.
-    if: github.repository == 'OpenIPC/firmware' || github.event_name == 'workflow_dispatch'
+    # but a fresh repository is not.
+    #
+    # Scoped to the schedule event alone: pull_request and workflow_dispatch
+    # are somebody deliberately asking for a build, and keep working here and
+    # in every mirror.
+    if: github.event_name != 'schedule' || github.repository == 'OpenIPC/firmware'
     runs-on: ubuntu-latest
     outputs:
       should_build: ${{ steps.gate.outputs.should_build }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,13 @@ on:
 jobs:
   preflight:
     name: Preflight
+    # Only the canonical repo builds unattended. A clone pushed to a new
+    # repository (a private mirror, an internal re-host) inherits this file
+    # along with its cron, and would run the full platform matrix nightly on
+    # someone else's Actions bill while publishing nightlies nobody reads.
+    # Forks are already covered — GitHub disables scheduled workflows there —
+    # but a fresh repository is not. Manual dispatch still works everywhere.
+    if: github.repository == 'OpenIPC/firmware' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
       should_build: ${{ steps.gate.outputs.should_build }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -16,7 +16,8 @@ jobs:
   prune:
     name: Prune old nightly releases
     # Canonical repo only on the weekly cron — see build.yml's preflight.
-    if: github.repository == 'OpenIPC/firmware' || github.event_name == 'workflow_dispatch'
+    # Dispatch runs are unaffected.
+    if: github.event_name != 'schedule' || github.repository == 'OpenIPC/firmware'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -15,6 +15,8 @@ concurrency:
 jobs:
   prune:
     name: Prune old nightly releases
+    # Canonical repo only on the weekly cron — see build.yml's preflight.
+    if: github.repository == 'OpenIPC/firmware' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/gcc-compat.yml
+++ b/.github/workflows/gcc-compat.yml
@@ -16,7 +16,8 @@ jobs:
   gcc-compat:
     name: GCC ${{matrix.gcc}}
     # Canonical repo only on the weekly cron — see build.yml's preflight.
-    if: github.repository == 'OpenIPC/firmware' || github.event_name == 'workflow_dispatch'
+    # PR and dispatch runs are unaffected.
+    if: github.event_name != 'schedule' || github.repository == 'OpenIPC/firmware'
     runs-on: ubuntu-latest
     container:
       image: gcc:${{matrix.gcc}}

--- a/.github/workflows/gcc-compat.yml
+++ b/.github/workflows/gcc-compat.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   gcc-compat:
     name: GCC ${{matrix.gcc}}
+    # Canonical repo only on the weekly cron — see build.yml's preflight.
+    if: github.repository == 'OpenIPC/firmware' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     container:
       image: gcc:${{matrix.gcc}}

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -25,11 +25,13 @@ jobs:
     # upload a firmware tgz — firmware_url returns empty for missing ones and
     # create() skips them.
     #
-    # First clause: canonical repo only, since a skipped build still completes
-    # and fires workflow_run on a mirror — see build.yml's preflight.
+    # First clause: on a mirror the nightly's jobs skip, but the run still
+    # completes and fires workflow_run, so gate the cron-originated path on
+    # the canonical repo too — see build.yml's preflight. Dispatch-driven
+    # reassembly is untouched anywhere.
     if: >-
-      (github.repository == 'OpenIPC/firmware' ||
-       github.event_name == 'workflow_dispatch') &&
+      (github.event.workflow_run.event != 'schedule' ||
+       github.repository == 'OpenIPC/firmware') &&
       (github.event_name == 'workflow_dispatch' ||
        ((github.event.workflow_run.event == 'schedule' ||
          github.event.workflow_run.event == 'workflow_dispatch') &&

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -24,11 +24,16 @@ jobs:
     # A flaky board doesn't deny image assembly for the platforms that did
     # upload a firmware tgz — firmware_url returns empty for missing ones and
     # create() skips them.
+    #
+    # First clause: canonical repo only, since a skipped build still completes
+    # and fires workflow_run on a mirror — see build.yml's preflight.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      ((github.event.workflow_run.event == 'schedule' ||
-        github.event.workflow_run.event == 'workflow_dispatch') &&
-       contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion))
+      (github.repository == 'OpenIPC/firmware' ||
+       github.event_name == 'workflow_dispatch') &&
+      (github.event_name == 'workflow_dispatch' ||
+       ((github.event.workflow_run.event == 'schedule' ||
+         github.event.workflow_run.event == 'workflow_dispatch') &&
+        contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion)))
     env:
       SIGMASTAR: ssc30kd ssc30kq ssc325 ssc333 ssc335 ssc335de ssc337 ssc337de ssc338q ssc377 ssc377d ssc377de ssc377qe ssc378de ssc378qe
       INGENIC: t10 t10l t20 t20l t20x t21n t23n t30a t30a1 t30l t30n t30x t31a t31al t31l t31lc t31n t31x

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -24,11 +24,16 @@ jobs:
     # platforms that did upload artifacts. enrich_manifest.py reads whatever
     # assets actually exist on the release, so a partial release just shows
     # up with fewer platforms in its `platforms` map.
+    #
+    # First clause: canonical repo only, since a skipped build still completes
+    # and fires workflow_run on a mirror — see build.yml's preflight.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      ((github.event.workflow_run.event == 'schedule' ||
-        github.event.workflow_run.event == 'workflow_dispatch') &&
-       contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion))
+      (github.repository == 'OpenIPC/firmware' ||
+       github.event_name == 'workflow_dispatch') &&
+      (github.event_name == 'workflow_dispatch' ||
+       ((github.event.workflow_run.event == 'schedule' ||
+         github.event.workflow_run.event == 'workflow_dispatch') &&
+        contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion)))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master (for the script)

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -25,11 +25,13 @@ jobs:
     # assets actually exist on the release, so a partial release just shows
     # up with fewer platforms in its `platforms` map.
     #
-    # First clause: canonical repo only, since a skipped build still completes
-    # and fires workflow_run on a mirror — see build.yml's preflight.
+    # First clause: on a mirror the nightly's jobs skip, but the run still
+    # completes and fires workflow_run, so gate the cron-originated path on
+    # the canonical repo too — see build.yml's preflight. Dispatch-driven
+    # manifest regeneration is untouched anywhere.
     if: >-
-      (github.repository == 'OpenIPC/firmware' ||
-       github.event_name == 'workflow_dispatch') &&
+      (github.event.workflow_run.event != 'schedule' ||
+       github.repository == 'OpenIPC/firmware') &&
       (github.event_name == 'workflow_dispatch' ||
        ((github.event.workflow_run.event == 'schedule' ||
          github.event.workflow_run.event == 'workflow_dispatch') &&


### PR DESCRIPTION
### The problem

A clone pushed to a **brand-new repository** — a private mirror, an internal re-host — inherits `.github/workflows` along with their cron schedules. From that moment the nightly builds the full ~96-platform matrix every night on that owner's Actions bill, publishing nightlies nobody will ever read.

Forks are already covered: GitHub disables Actions on forks by default and disables scheduled workflows there specifically. A **fresh repository created from a clone is not covered**, and nothing warns the owner — the README doesn't mention CI, and the first sign is the usage page.

I hit this on a private mirror of this repo. One night, unattended:

- **97 jobs, 2,146 billed minutes**, from a single scheduled run
- `Publish releases` failed there, because the mirror had no `nightly` release to write to
- and that is the nasty part: `preflight` decides whether to build by comparing `HEAD` against the sha recorded in the published `nightly` release. With publishing broken, `PREV` stays empty, so `PREV != HEAD` holds forever and **the skip gate can never engage**. Left alone it would have rebuilt the entire matrix every single night — roughly 64k minutes a month — while never publishing anything.

Nothing here is a bug in the pipeline itself; it is a pipeline that belongs to the canonical repo running somewhere it was never meant to run.

### The change

Gate the unattended entry points on `github.repository`, which Actions sets per **running** repository (`owner/repo`), so the comparison is false in any mirror and true upstream:

```yaml
if: github.repository == 'OpenIPC/firmware' || github.event_name == 'workflow_dispatch'
```

Applied to the jobs that start automatically:

| Workflow | Trigger gated |
|---|---|
| `build.yml` | `preflight` — the whole matrix hangs off it via `needs:` |
| `cleanup.yml` | weekly prune cron |
| `gcc-compat.yml` | weekly compat cron |
| `image.yml` | `workflow_run` |
| `manifest.yml` | `workflow_run` |

`image` and `manifest` need it too: a build whose jobs all skip still *completes*, which fires their `workflow_run` trigger.

### What is preserved

- **Upstream behaviour is unchanged.** `github.repository` is `OpenIPC/firmware` for scheduled runs, and for `pull_request` events it is the base repo, so PR builds here still run.
- **`workflow_dispatch` keeps working everywhere**, including in mirrors — an operator who deliberately clicks Run is not blocked. `build-one.yml` is dispatch-only and untouched.
- No change to build logic, matrix contents, or publishing.

Happy to narrow this to `build.yml` alone if you would rather keep the diff minimal, or to switch the literal to a `vars.CANONICAL_REPO` variable if you prefer that over a hardcoded name.
