### PR TITLE
ci: keep inherited workflows from billing non-canonical repos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -545,7 +545,14 @@ jobs:
   ci-gate:
     name: CI Gate
     needs: [preflight, buildroot, publish]
-    if: always()
+    # always() so the gate still reports when a needed job fails -- but not on a
+    # run whose preflight the guard above deliberately skipped, where it would
+    # read preflight=skipped and turn a saved build into a red run. Upstream the
+    # added disjunct is true, so this reduces to always().
+    if: >-
+      always() && (github.repository == 'OpenIPC/firmware' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !github.event.repository.private))
     runs-on: ubuntu-latest
     steps:
       - name: Require preflight + firmware matrix to succeed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,24 @@ on:
 jobs:
   preflight:
     name: Preflight
+    # Guard rail for clones of this repo. A clone pushed to a new repository
+    # (a private mirror, an internal re-host) inherits this file along with
+    # its cron, and the full platform matrix — ~2000 runner-minutes a pass —
+    # then runs on that owner's Actions bill: nightly via the schedule, and
+    # again on every internal PR they open. Forks are partially covered
+    # (GitHub disables scheduled workflows there), a fresh repository is not.
+    #
+    # The line is drawn where the minutes stop being free:
+    #   - canonical repo: everything runs, unchanged
+    #   - workflow_dispatch: an operator explicitly asked; runs anywhere
+    #   - pull_request on a PUBLIC repo: free minutes (contributor PRs here
+    #     run in this repo's context; within-fork PRs are public by
+    #     construction) — runs
+    #   - anything unattended or billed on a non-canonical repo — skips
+    if: >-
+      github.repository == 'OpenIPC/firmware' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !github.event.repository.private)
     runs-on: ubuntu-latest
     outputs:
       should_build: ${{ steps.gate.outputs.should_build }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -15,6 +15,9 @@ concurrency:
 jobs:
   prune:
     name: Prune old nightly releases
+    # Canonical repo only on the weekly cron — see build.yml's preflight.
+    # Dispatch runs are unaffected.
+    if: github.event_name != 'schedule' || github.repository == 'OpenIPC/firmware'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/gcc-compat.yml
+++ b/.github/workflows/gcc-compat.yml
@@ -15,6 +15,12 @@ on:
 jobs:
   gcc-compat:
     name: GCC ${{matrix.gcc}}
+    # Same guard rail as build.yml's preflight: run where the minutes are
+    # free or explicitly asked for, skip unattended/billed mirror runs.
+    if: >-
+      github.repository == 'OpenIPC/firmware' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !github.event.repository.private)
     runs-on: ubuntu-latest
     container:
       image: gcc:${{matrix.gcc}}

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -24,11 +24,18 @@ jobs:
     # A flaky board doesn't deny image assembly for the platforms that did
     # upload a firmware tgz — firmware_url returns empty for missing ones and
     # create() skips them.
+    #
+    # First clause: on a mirror the nightly's jobs skip, but the run still
+    # completes and fires workflow_run, so gate the cron-originated path on
+    # the canonical repo too — see build.yml's preflight. Dispatch-driven
+    # reassembly is untouched anywhere.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      ((github.event.workflow_run.event == 'schedule' ||
-        github.event.workflow_run.event == 'workflow_dispatch') &&
-       contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion))
+      (github.event.workflow_run.event != 'schedule' ||
+       github.repository == 'OpenIPC/firmware') &&
+      (github.event_name == 'workflow_dispatch' ||
+       ((github.event.workflow_run.event == 'schedule' ||
+         github.event.workflow_run.event == 'workflow_dispatch') &&
+        contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion)))
     env:
       SIGMASTAR: ssc30kd ssc30kq ssc325 ssc333 ssc335 ssc335de ssc337 ssc337de ssc338q ssc377 ssc377d ssc377de ssc377qe ssc378de ssc378qe
       INGENIC: t10 t10l t20 t20l t20x t21n t23n t30a t30a1 t30l t30n t30x t31a t31al t31l t31lc t31n t31x

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -24,11 +24,18 @@ jobs:
     # platforms that did upload artifacts. enrich_manifest.py reads whatever
     # assets actually exist on the release, so a partial release just shows
     # up with fewer platforms in its `platforms` map.
+    #
+    # First clause: on a mirror the nightly's jobs skip, but the run still
+    # completes and fires workflow_run, so gate the cron-originated path on
+    # the canonical repo too — see build.yml's preflight. Dispatch-driven
+    # manifest regeneration is untouched anywhere.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      ((github.event.workflow_run.event == 'schedule' ||
-        github.event.workflow_run.event == 'workflow_dispatch') &&
-       contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion))
+      (github.event.workflow_run.event != 'schedule' ||
+       github.repository == 'OpenIPC/firmware') &&
+      (github.event_name == 'workflow_dispatch' ||
+       ((github.event.workflow_run.event == 'schedule' ||
+         github.event.workflow_run.event == 'workflow_dispatch') &&
+        contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion)))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master (for the script)

--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -9,8 +9,16 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Same guard build.yml and gcc-compat.yml carry. These two jobs are cheap, but
+  # they are the last billed entry point a clone inherits: on a private mirror
+  # every master sync push and every internal PR runs them on that owner's bill.
+  # Upstream the first disjunct is true, so the condition is a tautology here.
   load-hisilicon-parsing:
     name: load_hisilicon os_mem_size derivation
+    if: >-
+      github.repository == 'OpenIPC/firmware' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !github.event.repository.private)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,6 +26,10 @@ jobs:
 
   sysupgrade-verify:
     name: sysupgrade rootfs verification
+    if: >-
+      github.repository == 'OpenIPC/firmware' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !github.event.repository.private)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Supersedes #2254 (closed) — same goal, final logic.

### Problem

Push a clone of this repo to a new repository (private mirror / internal re-host) and `.github/workflows` comes along with its cron. The full ~96-platform matrix then runs **on that owner's Actions bill** — nightly, unattended, publishing nightlies nobody reads. Forks are only partially protected: GitHub disables *scheduled* workflows on forks, but a fresh repository gets no protection and no warning.

Measured on one private mirror, from a single night: **97 jobs, 2,146 billed minutes**. And it never converges: the mirror's `Publish releases` fails (no `nightly` release exists there), so `preflight`'s sha skip-gate never engages and the full matrix rebuilds **every** night — ~64k minutes/month for nothing.

### The rule this implements

**Unattended runs happen only on the canonical repo.** Anywhere else a workflow runs only if someone explicitly asked for it (`workflow_dispatch`), or if it is both free and attended (`pull_request` on a public repo).

```yaml
if: >-
  github.repository == 'OpenIPC/firmware' ||
  github.event_name == 'workflow_dispatch' ||
  (github.event_name == 'pull_request' && !github.event.repository.private)
```

This is deliberately stricter than "gate it where the minutes stop being free". A public re-host's minutes *are* free, and its cron is still skipped: a re-host quietly publishing `nightly` and `latest` releases under its own name is a worse outcome than wasted minutes, so the unattended path is cut there too. Only the canonical repo runs on a schedule.

| event | where | result |
|---|---|---|
| `schedule` | OpenIPC/firmware | runs (unchanged) |
| `pull_request` | OpenIPC/firmware | runs (unchanged — contributor PRs execute in this repo's context) |
| `push: master` | OpenIPC/firmware | runs (unchanged) |
| `workflow_dispatch` | anywhere | runs (an operator explicitly asked; `build-one.yml` untouched) |
| `pull_request` | public fork / re-host | runs (free and attended; forks of a public repo are public by construction) |
| `schedule` | public re-host | **skips** (deliberate — see above) |
| `schedule` | private mirror | **skips** |
| `pull_request` | private mirror | **skips** (the only place PR CI costs a third party money) |
| `push: master` | any mirror | **skips** |

### Coverage

`build.yml` and `gcc-compat.yml` carry the guard on their entry jobs. `image.yml` / `manifest.yml` gate their cron-originated `workflow_run` path the same way — a nightly whose jobs all skipped still completes and fires `workflow_run`. `cleanup.yml` carries it on its weekly cron. `shell-tests.yml` carries it too: it triggers on `pull_request` and `push: [master]`, which made it the last billed entry point a clone inherits. `toolchain`, `uboot` and `build-one` are dispatch-only and need nothing.

`ci-gate` carries the guard as well, keeping `always()`. Without that, skipping `preflight` did not skip the gate: it ran anyway, read `preflight=skipped` and exited 1, so a guarded run came out **red** rather than skipped — a red nightly every day and a red required check on every internal PR. Guarding the job rather than teaching the gate script to tolerate `preflight=skipped` keeps the gate strict upstream, which is the one place it has to be.

A guarded run now skips whole, start to finish, and reports nothing.

### Upstream impact

None. On `OpenIPC/firmware` the first disjunct is true, so every added condition is a tautology and each job's `if` reduces to what it was before this PR — `ci-gate`'s reduces to plain `always()`.
