### PR TITLE
gk7102: BR2_TARGET_OPTIMIZATION=-mno-unaligned-access

### DIFF
--- a/br-ext-chip-goke/configs/gk7102_lite_defconfig
+++ b/br-ext-chip-goke/configs/gk7102_lite_defconfig
@@ -3,6 +3,8 @@ BR2_arm=y
 BR2_arm1176jzf_s=y
 BR2_ARM_EABI=y
 
+BR2_TARGET_OPTIMIZATION="-mno-unaligned-access"
+
 # Toolchain
 BR2_TOOLCHAIN_EXTERNAL=y
 BR2_TOOLCHAIN_EXTERNAL_DOWNLOAD=y

--- a/br-ext-chip-goke/configs/gk7102s_lite_defconfig
+++ b/br-ext-chip-goke/configs/gk7102s_lite_defconfig
@@ -3,6 +3,8 @@ BR2_arm=y
 BR2_arm1176jzf_s=y
 BR2_ARM_EABI=y
 
+BR2_TARGET_OPTIMIZATION="-mno-unaligned-access"
+
 # Toolchain
 BR2_TOOLCHAIN_EXTERNAL=y
 BR2_TOOLCHAIN_EXTERNAL_DOWNLOAD=y


### PR DESCRIPTION
## Summary
- Set `BR2_TARGET_OPTIMIZATION=\"-mno-unaligned-access\"` on `gk7102_lite` and `gk7102s_lite` to avoid ARMv6 userspace corruption from unaligned accesses.

## Test plan
- [ ] Rebuild userspace; toolchain wrapper passes `-mno-unaligned-access`
- [ ] SSH + WPA2 stable on GK7102 (validated with rebuilt SDK toolchain)

Part of splitting #2256.

Made with [Cursor](https://cursor.com)