### PR TITLE
majestic-webui: do not fail the build when the WebUI drops a file

### DIFF
--- a/general/package/majestic-webui/majestic-webui.mk
+++ b/general/package/majestic-webui/majestic-webui.mk
@@ -30,18 +30,26 @@ define MAJESTIC_WEBUI_INSTALL
 	cp -r $(@D)/www $(TARGET_DIR)/var
 endef
 
+# -f throughout: which files the WebUI ships is decided in another repo, so a
+# fixup that hard-fails on a missing one turns any deletion there into a broken
+# build here -- for every platform at once, and only visible on the next PR,
+# because master has no push trigger. j/locale_fpv.cgi and p/header_fpv.cgi went
+# in OpenIPC/majestic-webui#141; fpv-wfb.cgi and p/fpv_common.cgi still ship, and
+# are still unwanted in a standard build.
 define MAJESTIC_WEBUI_STANDARD_FIXUP
-	rm $(TARGET_DIR)/var/www/cgi-bin/fpv-wfb.cgi
-	rm $(TARGET_DIR)/var/www/cgi-bin/j/locale_fpv.cgi
-	rm $(TARGET_DIR)/var/www/cgi-bin/p/header_fpv.cgi
-	rm $(TARGET_DIR)/var/www/cgi-bin/p/fpv_common.cgi
+	rm -f $(TARGET_DIR)/var/www/cgi-bin/fpv-wfb.cgi
+	rm -f $(TARGET_DIR)/var/www/cgi-bin/j/locale_fpv.cgi
+	rm -f $(TARGET_DIR)/var/www/cgi-bin/p/header_fpv.cgi
+	rm -f $(TARGET_DIR)/var/www/cgi-bin/p/fpv_common.cgi
 endef
 
+# The two variant overrides this used to install are gone upstream: header_fpv
+# was never included by any page and locale_fpv was never read, so an FPV build
+# already renders the standard header and labels. Moving them is not just
+# unnecessary now, it fails -- mv errors on a missing source even with -f.
 define MAJESTIC_WEBUI_FPV_FIXUP
-	mv -f $(TARGET_DIR)/var/www/cgi-bin/j/locale_fpv.cgi $(TARGET_DIR)/var/www/cgi-bin/j/locale.cgi
-	mv -f $(TARGET_DIR)/var/www/cgi-bin/p/header_fpv.cgi $(TARGET_DIR)/var/www/cgi-bin/p/header.cgi
-	rm $(TARGET_DIR)/usr/sbin/telegram
-	rm $(TARGET_DIR)/usr/sbin/openwall
+	rm -f $(TARGET_DIR)/usr/sbin/telegram
+	rm -f $(TARGET_DIR)/usr/sbin/openwall
 endef
 
 define MAJESTIC_WEBUI_INSTALL_TARGET_CMDS


### PR DESCRIPTION
**Every firmware build is currently failing, on every platform**, in the majestic-webui install step:

```
rm .../var/www/cgi-bin/j/locale_fpv.cgi
rm: cannot remove '...': No such file or directory
make[1]: *** [package/pkg-generic.mk:374] Error 1
build failed after 7 attempts
```

`j/locale_fpv.cgi` and `p/header_fpv.cgi` were removed upstream in OpenIPC/majestic-webui#141, but the fixups here still delete them unconditionally, and the FPV variant still `mv`s them into place.

### Why it surfaced only now

master has no push trigger, so nothing rebuilt when the WebUI change landed, and the stale dist asset still contained the files. The first rebuild of that asset published a dist without them — and from that point **every pull request fails all ~96 platform jobs**, about 40 minutes in.

Which files the WebUI ships is decided in another repository. A fixup that hard-fails on a missing one turns any deletion there into a repo-wide build outage here, discovered by whoever opens the next PR.

### The change

- `-f` throughout. `fpv-wfb.cgi` and `p/fpv_common.cgi` **do** still ship and are still unwanted in a standard build, so those lines stay; the two that no longer exist are harmless to keep as `-f` in case an older dist is ever built against.
- Drop the two `mv` lines from the FPV fixup. Those overrides are gone upstream — `header_fpv` was never included by any page and `locale_fpv` was never read, so an FPV build already renders the standard header and labels. Moving them is not merely unnecessary now, it **fails**: `mv` errors on a missing source even with `-f`.

### Found how

While waiting on #2263. Its 96 platform jobs all failed, and the first batch of 20 died simultaneously at 43 minutes, which looked like runner exhaustion. It was not — pulling the in-progress job log showed the `rm`, and the same failure will hit any PR opened right now.

#2263 is unaffected in substance: its own checks (`Preflight`, `sysupgrade rootfs verification`, `load_hisilicon os_mem_size derivation`) all passed. It needs rebasing on this once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)