### PR TITLE
overlay: guard the TZ export so a missing /etc/TZ does not pin UTC

### DIFF
--- a/general/overlay/etc/init.d/rcS
+++ b/general/overlay/etc/init.d/rcS
@@ -1,7 +1,9 @@
 #!/bin/sh
 export SENSOR=$(fw_printenv -n sensor)
 export UPGRADE=$(fw_printenv -n upgrade)
-export TZ=$(cat /etc/TZ)
+# Guarded: an empty TZ pins UTC on musl and skips the /etc/localtime fallback
+# that an unset TZ would use, so a missing /etc/TZ must leave TZ alone.
+[ -r /etc/TZ ] && export TZ=$(cat /etc/TZ)
 
 for i in /etc/init.d/S??*; do
 	[ ! -f "$i" ] && continue

--- a/general/overlay/etc/profile
+++ b/general/overlay/etc/profile
@@ -3,7 +3,9 @@ export EDITOR="/bin/vi"
 export HOME="/root"
 export SENSOR=$(fw_printenv -n sensor)
 export UPGRADE=$(fw_printenv -n upgrade)
-export TZ=$(cat /etc/TZ)
+# Guarded: an empty TZ pins UTC on musl and skips the /etc/localtime fallback
+# that an unset TZ would use, so a missing /etc/TZ must leave TZ alone.
+[ -r /etc/TZ ] && export TZ=$(cat /etc/TZ)
 
 echo_c() {
 	echo -ne "\e[1;$1m$2\e[0m"


### PR DESCRIPTION
Follow-up to #2244, which added a `[ -r /etc/TZ ]` guard to `S95majestic`. The same guard belongs on the two places that set `TZ` for everything else.

## Why

`rcS:4` and `profile:6` both do:

```sh
export TZ=$(cat /etc/TZ)
```

If `/etc/TZ` is missing, the substitution yields nothing and they export an **empty** `TZ`. That is strictly worse than not exporting at all, because musl distinguishes the two cases:

```c
s = getenv("TZ");
if (!s) s = "/etc/localtime";
if (!*s) s = __utc;          /* musl src/time/__tz.c:134-136 */
```

An *unset* `TZ` falls back to `/etc/localtime`; an *empty* `TZ` pins UTC and skips that fallback. So the unguarded form actively suppresses the fallback it should be deferring to — on a unit where someone has installed tzdata and an `/etc/localtime`, deleting `/etc/TZ` silently forces UTC instead of using it.

## Scope

No behaviour change when `/etc/TZ` is present, which is the shipped default (`GMT0`). This only affects the missing-file path. `rcS` and `profile` have no `set -e`, and the guard sits mid-file in both, so the `&&` returning non-zero can't leak into an exit status.

Boards on uClibc (`gm8135`, `gm8136`, `msc313e`) read `/etc/TZ` natively and are unaffected either way; the guard is inert there.

## Verification

Parse-checked under both shells:

```
$ for f in general/overlay/etc/init.d/rcS general/overlay/etc/profile; do sh -n $f && dash -n $f; done   # clean
```

Behaviour of the guarded vs unguarded form when the file is absent:

```
$ dash -c '[ -r /tmp/NOPE ] && export TZ=$(cat /tmp/NOPE 2>/dev/null); echo "set=${TZ+yes} val=[${TZ-<unset>}]"'
set= val=[<unset>]        # guarded: musl will consult /etc/localtime

$ dash -c 'export TZ=$(cat /tmp/NOPE 2>/dev/null); echo "set=${TZ+yes} val=[${TZ-<unset>}]"'
set=yes val=[]            # current: musl pins UTC
```

And with the file present the value still lands intact, including the commas and slash in a DST rule:

```
$ dash -c '[ -r /tmp/TZ ] && export TZ=$(cat /tmp/TZ); echo "[$TZ]"'
[CET-1CEST,M3.5.0,M10.5.0/3]
```

(That last one also confirms the unquoted `$(...)` is safe here: `export VAR=word` parses as an assignment, so no field splitting — the existing style is fine and I left it alone.)

Not verified on hardware — this is a missing-file path that the shipped image never hits, since `/etc/TZ` is part of the overlay. The musl semantics are read from `src/time/__tz.c` directly rather than recalled.

## Note on coverage

`shell-tests` currently parse-checks only `sysupgrade`. Extending `sysupgrade-verify` to cover `rcS`, `profile` and the `S9*` init scripts would be cheap and would have caught nothing here, but is worth doing on its own; happy to send that separately rather than widen this PR.
