### PR TITLE
ci: parse-check every shell script that ships in the image

### DIFF
--- a/.github/scripts/test_shell_parse.sh
+++ b/.github/scripts/test_shell_parse.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# Parse-check every shell script that ships inside the firmware image.
+#
+# Before this, the only parse coverage in CI was two lines in shell-tests.yml
+# pinned to sysupgrade. Everything else that lands in the rootfs -- the init
+# scripts, /etc/profile sourced by every login, /init for initramfs boards, the
+# vendor load_* scripts that insert the SoC drivers -- shipped with nothing
+# confirming it even parses. Nothing else covers them: the overlay and each
+# package's install step copy these files in verbatim, so a green build says
+# nothing about their syntax. A typo's first symptom is a service, or a driver
+# load, that silently does not happen on a camera.
+#
+# DISCOVERY is by shebang over the whole overlay and every package files/ dir,
+# not by a list of paths. An earlier draft hand-listed globs (init.d, usr/sbin,
+# files/S??) and silently missed 80 of the 127 scripts -- /init, /etc/rc.local,
+# the mdev and udhcpc helpers, the network if-up hooks, and every
+# osdrv-*/files/script/load_* -- because they did not match the shapes guessed
+# at. Anything with a shell shebang is checked wherever it lives, so a script
+# added in a new shape is covered when it lands.
+#
+# INTERPRETER is busybox ash, because that is what runs on the device, and only
+# that. dash is deliberately NOT used: the shipped busybox is built with
+# CONFIG_ASH_BASH_COMPAT=y (general/package/busybox/busybox.config), so the
+# `function name()` keyword is valid in the field, and four scripts that work on
+# real hardware -- both hi3516cv6xx/hi3519dv500 load_hisilicon, msc313e
+# auto_run.sh, infinity6e zoom.sh -- are rejected by dash. Checking against a
+# stricter shell than the target turns working code red, which is worse than no
+# check at all: it trains people to ignore the job.
+#
+# SCOPE: syntax only. `-n` parses without executing, so a passing file may still
+# be wrong at runtime, and a bashism that ash accepts is by definition not
+# reported here. This is the cheap half of the problem, not a portability audit
+# -- see the note in shell-tests.yml about checkbashisms.
+
+set -u
+
+# CI sets STRICT=1: there, a missing busybox means the check silently did not
+# happen, which should fail loudly rather than pass a green run. Locally it just
+# reports what it could not do and carries on.
+STRICT=${STRICT:-0}
+
+fail=0
+ok()   { echo "ok   $*"; }
+bad()  { echo "FAIL $*"; fail=$((fail + 1)); }
+note() { echo "--   $*"; }
+
+BUSYBOX=$(command -v busybox 2>/dev/null || true)
+
+if [ -z "$BUSYBOX" ]; then
+	if [ "$STRICT" != 0 ]; then
+		echo "FAIL busybox not found and STRICT=$STRICT -- refusing to report a"
+		echo "     pass when nothing was actually parsed."
+		exit 1
+	fi
+	note "busybox not found: nothing to parse against, skipping."
+	note "install busybox-static to run this as the device would."
+	exit 0
+fi
+
+# A busybox built without CONFIG_ASH_BASH_COMPAT rejects `function name()`,
+# which the shipped one accepts. Running that parser here would fail scripts
+# that are correct on hardware, so refuse rather than report false errors.
+if ! "$BUSYBOX" ash -c 'function _probe() { :; }' 2>/dev/null; then
+	echo "FAIL this busybox lacks ASH_BASH_COMPAT, so it rejects the 'function'"
+	echo "     keyword that the shipped busybox accepts. Refusing to apply a"
+	echo "     stricter parser than the device runs."
+	exit 1
+fi
+
+# Everything the overlay drops into the rootfs, plus every file a package
+# installs from its files/ dir. Selection is by shebang below rather than by
+# path, so nothing depends on guessing where scripts live. Symlinks are resolved
+# and the list deduplicated: usr/sbin has five aliases pointing at extutils, and
+# parsing it six times only pads the count.
+candidates() {
+	{
+		find general/overlay \( -type f -o -type l \) 2>/dev/null
+		find general/package -path '*/files/*' \( -type f -o -type l \) 2>/dev/null
+	} | while IFS= read -r p; do
+		[ -f "$p" ] || continue
+		realpath --relative-to=. "$p" 2>/dev/null || echo "$p"
+	done | sort -u
+}
+
+err=$(mktemp)
+trap 'rm -f "$err"' EXIT
+
+checked=0
+skipped=0
+
+while IFS= read -r f; do
+	[ -n "$f" ] && [ -f "$f" ] || continue
+
+	# /etc/profile is sourced by the login shell and carries no shebang; every
+	# other candidate has to declare itself.
+	if [ "$f" = general/overlay/etc/profile ]; then
+		kind=ash
+	else
+		case "$(head -1 "$f" 2>/dev/null)" in
+			'#!'*bash*) kind=bash ;;
+			'#!'*sh*)   kind=ash ;;
+			*)          continue ;;   # not a shell script: config, blob, doc
+		esac
+	fi
+
+	checked=$((checked + 1))
+
+	if [ "$kind" = bash ]; then
+		if bash -n "$f" 2>"$err"; then
+			ok "bash $f"
+		else
+			bad "bash $f"
+			sed 's/^/       /' "$err"
+		fi
+		continue
+	fi
+
+	if "$BUSYBOX" ash -n "$f" 2>"$err"; then
+		ok "ash  $f"
+	else
+		bad "ash  $f"
+		sed 's/^/       /' "$err"
+	fi
+done <<EOF
+$(candidates)
+EOF
+
+echo
+echo "checked $checked shell script(s)"
+
+# A discovery bug that quietly matches nothing would otherwise look identical to
+# a clean run, which is how the previous version of this file hid its blind spot.
+if [ "$checked" -lt 100 ]; then
+	echo "FAIL only $checked script(s) discovered; the tree holds ~127, so"
+	echo "     discovery has regressed. Check the find paths above."
+	exit 1
+fi
+
+if [ "$fail" -ne 0 ]; then
+	echo "$fail check(s) failed"
+	exit 1
+fi
+
+echo "all parsed clean under busybox ash"

--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -33,8 +33,43 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Parse-check under both shells
-        run: |
-          sh -n general/overlay/usr/sbin/sysupgrade
-          dash -n general/overlay/usr/sbin/sysupgrade
+      # The parse-check that used to live here now runs for every shipped script
+      # in the job below, against the busybox ash the device actually uses. This
+      # step was `sh -n` then `dash -n`, which on ubuntu-latest is the same
+      # check twice (/bin/sh is dash) and neither is the target shell.
       - run: bash .github/scripts/test_sysupgrade.sh
+
+  # Only sysupgrade was ever parse-checked; every other script in the image --
+  # the init scripts, /etc/profile, /init on initramfs boards, the vendor load_*
+  # scripts that insert the SoC drivers -- reached cameras without anything
+  # confirming it even parses. Nothing else covers them: the overlay and the
+  # package install steps copy these files in verbatim, so a green build says
+  # nothing about their syntax.
+  #
+  # Checked against busybox ash only, since that is what executes on the device.
+  # dash would be the wrong bar: the shipped busybox sets ASH_BASH_COMPAT, so
+  # `function name()` is valid in the field, and four scripts that run on real
+  # hardware fail under dash. See the header of test_shell_parse.sh.
+  #
+  # Deliberately syntax-only. A bashism audit (checkbashisms) over the same set
+  # is a much larger change -- `local` alone is used throughout -- and is worth
+  # doing separately rather than smuggling into a coverage PR.
+  shipped-shell-parse:
+    name: shipped shell scripts parse
+    if: >-
+      github.repository == 'OpenIPC/firmware' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !github.event.repository.private)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install busybox
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq busybox-static
+      - name: Parse every shipped shell script
+        # STRICT=1 so a busybox that failed to install fails the job instead of
+        # skipping every check and still reporting green.
+        env:
+          STRICT: 1
+        run: bash .github/scripts/test_shell_parse.sh


### PR DESCRIPTION
Follow-up to #2244 / #2265. While reviewing a one-line change to `S95majestic` it became clear that nothing in CI would have caught a syntax error in it — `shell-tests` parse-checks exactly one file, `sysupgrade`.

## The gap

Everything that lands in the rootfs as a shell script — the init scripts, `/etc/profile` that every login sources, `/init` on initramfs boards, the `usr/sbin` helpers, and the vendor `load_*` scripts that insert the SoC drivers — is copied in **verbatim** by the overlay and by the package install steps. Nothing compiles or lints them, so a green build says nothing about whether they parse. A typo's first symptom is a service, or a driver load, that silently doesn't happen on a camera.

## What this adds

A `shipped-shell-parse` job running `.github/scripts/test_shell_parse.sh`, which discovers scripts **by shebang** across the whole overlay and every package `files/` dir, and parses each under **busybox ash**. 128 files are covered.

**Discovery is by shebang, not by path.** The first draft of this PR hand-listed globs (`init.d`, `usr/sbin`, `files/S??`) and missed **80 of the 127** scripts in the tree — `/init`, `/etc/rc.local`, the mdev and udhcpc helpers, the network if-up hooks, and every `osdrv-*/files/script/load_*`. Symlinks are resolved and deduplicated so `extutils` isn't parsed once per `usr/sbin` alias.

**busybox ash is the only interpreter, deliberately.** It's what runs on the device. dash would be the *wrong* bar: the shipped busybox sets `CONFIG_ASH_BASH_COMPAT` (`general/package/busybox/busybox.config:1138`), so `function name()` is valid in the field — and four scripts that work on real hardware are rejected by dash:

```
hisilicon-osdrv-hi3516cv6xx/files/script/load_hisilicon   ash: OK   dash: FAIL
hisilicon-osdrv-hi3519dv500/files/script/load_hisilicon   ash: OK   dash: FAIL
legacy/sigmastar-osdrv-msc313e/files/script/auto_run.sh   ash: OK   dash: FAIL
sigmastar-osdrv-infinity6e/files/script/zoom.sh           ash: OK   dash: FAIL
```

A check stricter than the target turns working code red, which is worse than no check — it teaches people to ignore the job.

## One thing worth reviewer attention

**I deleted two lines from `sysupgrade-verify`.** It ran `sh -n` then `dash -n` on sysupgrade; on `ubuntu-latest` `/bin/sh` *is* dash, so that was the same check twice, and neither was the target shell. The new job covers that file under ash. Both jobs carry the identical repo guard, so they're skipped together and this can't leave sysupgrade unchecked. Happy to restore it if you'd rather this were purely additive.

## Verification

```
$ bash .github/scripts/test_shell_parse.sh
...
checked 128 shell script(s)
all parsed clean under busybox ash
```

A check that cannot fail is worthless, so the failure paths are verified too:

| scenario | expected | actual |
|---|---|---|
| syntax error injected into `general/overlay/init` | fail | `FAIL ash general/overlay/init`, exit 1 |
| `STRICT=1`, busybox absent | fail | exit 1, explicit message |
| busybox without `ASH_BASH_COMPAT` | refuse | exit 1, refuses to apply a stricter parser than the device |
| discovery matches < 100 files | fail | exit 1, "discovery has regressed" |
| clean tree | pass | exit 0 |

`test_sysupgrade.sh` still passes after the job edit.

Three guards exist specifically so this can't silently become a no-op: a missing busybox, a busybox with the wrong config, and a discovery regression each fail loudly rather than reporting green — the last one added because the first draft's blind spot looked identical to a clean run.

## Scope

Syntax only. `-n` parses without executing, so this says nothing about runtime behaviour, and a bashism that ash accepts is by definition not reported. A `checkbashisms` pass would be worth having but is a much larger change — `local` is used throughout — and belongs in its own PR.

One caveat on placement: `shell-tests` is **not** part of the `CI Gate` required status check (that's `build.yml`, gating on `preflight`/`buildroot`/`publish`). So this job is advisory and won't block a merge on its own. Adding it to the required contexts is a branch-protection change and felt like your call.

Verified with busybox 1.35.0; the tree builds 1.36.1. The `ASH_BASH_COMPAT` probe means a version or config mismatch fails loudly rather than silently changing the bar, but I checked against 1.35.0, not the exact shipped build.
