### PR TITLE
hisilicon-opensdk: bump ff20187b → 2d637e35 (V4 mic tone on cold boot, osal timer teardown)

### DIFF
--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = ff20187b
+HISILICON_OPENSDK_VERSION = 2d637e35
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Bumps `hisilicon-opensdk` `ff20187b` → `2d637e35` so the V4 microphone fix reaches nightlies.

## What it picks up

```
2d637e3 osal: wait for the timer callback before freeing the timer (#211)
f69ecc9 kernel/hi3516cv200: recognize the gc2023_mipi sensor type (#207)
849f066 acodec: retune the ADC when a clock change invalidates it (#209)
```

**acodec** — the analog mic on every V4 part comes up with an audible tone after a cold boot: 609 Hz at a 16 kHz sample rate plus five harmonics, up to 20 dB over the noise floor, lasting until something restarts the streamer. The codec's ADC tuning is only valid for the codec clock that was running when it was made, and enabling an audio input reprograms that clock — so the tuning that was correct a moment earlier is stale, and nothing recalibrated. The driver now watches the hardware validity bit and retunes. Reported as OpenIPC/majestic#285.

Affects `gk7205v200`, `gk7205v300`, `gk7202v300`, `gk7605v100` and `hi3516ev200`/`ev300` — reproduced on gk7205v200 and hi3516ev300, and the rest share the same build target.

**osal** — timer teardown could free a timer whose callback was still running, or which had re-armed itself: `del_timer()` does not wait, and destroy `kfree()`s straight after. Reaches every module using osal timers — `vi`, `vpss`, `chnl`, `pm`, `rtc`, `ir`, `vdec`, `dis` across V2, V3 and V4.

**sensor** — gc2023_mipi recognised on hi3516cv200, pairing with #2248 which just landed here.

## Verification

Built `gk7205v200_lite` from this exact hash (tarball fetched from GitHub, no local override): 33 modules build clean, and both fixes are present in the resulting `open_acodec.ko` and `open_osal.ko`.

Flashed onto a lab gk7205v200:

- full 36-module stack boots, video serving
- 10 × `load_goke -a` teardown/reload cycles — 36 modules back every time
- 8 × SIGHUP pipeline rebuilds
- zero oops, zero warnings throughout
- cold-boot mic capture: 41 LSB rms with the comb before, 5 LSB and no coherent tone after

Camera restored to stock afterwards and re-verified.

Upstream CI on openhisilicon was 35/35 green on `2d637e35`, including `Build SDK` and `QEMU boot` for every supported chip.
