### PR TITLE
qodo: unbreak the config loader, and stop the gate blocking clean PRs

### DIFF
--- a/.github/workflows/qodo-gate.yml
+++ b/.github/workflows/qodo-gate.yml
@@ -83,9 +83,20 @@ jobs:
             exit 0
           fi
 
-          # Any review by the bot counts — the first pass reviews the whole
-          # diff, and its later in-place updates edit the same review object,
-          # so one review object existing == the PR has been Qodo-reviewed.
+          # Qodo signals a finished review in one of two ways, and a clean PR
+          # only ever produces the second:
+          #
+          #   1. a review OBJECT — created when it has inline comments to hang
+          #      on the diff. Its later in-place updates edit the same object,
+          #      so one existing == the PR has been reviewed.
+          #   2. an issue COMMENT headed "Code Review by Qodo" — which is ALL
+          #      a zero-finding PR gets. Verified on #2269: "Bugs (0), Rule
+          #      violations (0), Requirement gaps (0)", and no review object
+          #      at all.
+          #
+          # Counting only (1) therefore blocks every clean PR forever — the
+          # gate can never go green precisely when there is nothing to fix.
+          #
           # Paginated: a busy PR accumulates well over 100 review objects
           # (every inline reply wraps itself in one), and the bot's first
           # review is the OLDEST — exactly what a last-100 window loses
@@ -96,13 +107,27 @@ jobs:
             --paginate --jq ".[]
               | select(.user.login | startswith(\"$BOT\"))
               | .id" | wc -l)
-          if [ "$reviewed" -eq 0 ]; then
+
+          # Match the review header specifically, NOT merely "a comment by the
+          # bot". Qodo also posts "Qodo is busy working" (a placeholder before
+          # it has read anything), "PR Summary by Qodo" (/describe output, not
+          # a review), and "failed to apply 'local' repo settings" (an error).
+          # Treating any of those as a review would let the gate pass on a PR
+          # the agent never actually reviewed.
+          commented=$(gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$PR/comments" \
+            --paginate --jq ".[]
+              | select(.user.login | startswith(\"$BOT\"))
+              | select(.body | test(\"Code Review by Qodo\"; \"i\"))
+              | .id" | wc -l)
+
+          if [ "$reviewed" -eq 0 ] && [ "$commented" -eq 0 ]; then
             echo "FAIL: no Qodo review on this PR yet — it reviews new PRs"
             echo "automatically within a couple of minutes; comment /review to"
             echo "summon one, then re-run this check once it answers. (Outage?"
             echo "Apply the skip-qodo-gate label.)"
             exit 1
           fi
+          echo "review found: $reviewed review object(s), $commented review comment(s)"
 
           # Unresolved Qodo threads, paginated (a long-lived PR can exceed one
           # 100-thread page; a truncated read must never produce a false pass).

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -5,6 +5,21 @@
 #   pr_compliance_checklist.yaml - binary hard gates
 #
 # Reference: https://docs.qodo.ai/install-and-configure/configuration-overview/configuration-file
+#
+# CAUTION - do not name the dynamic linker's library-injection environment
+# variable in this file, in any case, and not inside a longer word either.
+# PR-Agent parses this file with a hardened Dynaconf loader that rejects the
+# directives capable of executing code or reading arbitrary files, and that
+# variable's name ends in one of them. Matching is on the bare token, so the
+# full variable name trips it even though it is only prose in a guideline.
+#
+# The failure mode is silent in the worst way: the agent posts "failed to apply
+# 'local' repo settings / Forbidden directive", then reviews the PR with its
+# stock prompt - so every guideline below is ignored while the review still
+# looks normal. That is exactly what happened on #2268, which added this file.
+#
+# Write such rules in best_practices.md instead. It is plain markdown, is under
+# no such restriction, and already states this one in full in section 4.1.
 
 [github_app]
 pr_commands = [
@@ -59,9 +74,11 @@ Prioritise, in order:
    majestic streamer belong to majestic's maintainers. Redirecting a contributor is a
    normal, useful review outcome; say which repo and why.
 
-5. Monkey-patching in place of a fix. LD_PRELOAD shims are not acceptable anywhere in the
-   OpenIPC tree, in firmware or in builder. Neither is a kernel module that rewrites a
-   vendor blob's memory at runtime, nor a generated facade library checked in as a binary.
+5. Monkey-patching in place of a fix. Dynamic-linker injection shims - a library forced
+   ahead of the real one through the linker's LD_* environment knob, spelled out in
+   best_practices.md section 4.1 - are not acceptable anywhere in the OpenIPC tree, in
+   firmware or in builder. Neither is a kernel module that rewrites a vendor blob's memory
+   at runtime, nor a generated facade library checked in as a binary.
    Each of these is bound to one exact build of one blob and fails silently at the next
    vendor drop.
 
@@ -89,6 +106,7 @@ Do not raise a finding for pre-existing code that the diff merely moves or reind
 Note especially: a device-specific value added to general/overlay/ or to a shared
 load_<vendor> script fails the blast-radius gate even when it is correct for the board the
 contributor tested, because it changes the default for cameras already in the field. And
-LD_PRELOAD has no sanctioned use in this tree - a majestic bug that appears to need one is
-a majestic issue, not a firmware change.
+dynamic-linker injection shims (best_practices.md section 4.1) have no sanctioned use in
+this tree - a majestic bug that appears to need one is a majestic issue, not a firmware
+change.
 """


### PR DESCRIPTION
## Problem

Since #2268 merged, Qodo has been rejecting `.pr_agent.toml` on every PR ([example](https://github.com/OpenIPC/firmware/pull/2268#issuecomment-5307889661)):

> ❌ **PR-Agent failed to apply 'local' repo settings**
> **Error message:** `Forbidden directive: preload`

PR-Agent parses the repo-local config with a hardened Dynaconf loader that rejects directives capable of executing code or reading arbitrary files. It matches on the bare token — and the dynamic linker's library-injection environment variable, which two of the guidelines named as something contributors must *not* use, ends in one of those tokens. It tripped the check while being nothing but prose inside a string.

The irony is that the rule banning the thing is what broke the config.

**This failure mode is nastier than a wrong rule.** The agent does not fall back to a partial config — it drops the local settings entirely and reviews with its stock prompt. So every guideline added in #2268 has been inactive since it merged, while the reviews still looked perfectly normal. Nothing on the PR indicates the standards were skipped except that one comment.

## Fix

Both guidelines now describe the mechanism and point at `best_practices.md` section 4.1, which states the rule in full and is not affected:

```diff
-5. Monkey-patching in place of a fix. LD_PRELOAD shims are not acceptable anywhere in the
-   OpenIPC tree, in firmware or in builder.
+5. Monkey-patching in place of a fix. Dynamic-linker injection shims - a library forced
+   ahead of the real one through the linker's LD_* environment knob, spelled out in
+   best_practices.md section 4.1 - are not acceptable anywhere in the OpenIPC tree, in
+   firmware or in builder.
```

`best_practices.md` and `pr_compliance_checklist.yaml` are untouched and keep the literal variable name — they are not parsed by that loader. The rule itself is unchanged in substance, and the agent still reaches the full wording through the standards file.

A header comment records the constraint for whoever edits this next. It is worded so that it does not name the variable either — I checked the raw file has zero occurrences of any rejected token, comments included, since I could not confirm whether the scan ignores comments.

## Evidence

No hardware involved; this is review configuration.

- Reproduced: the bot comment above, on the PR that introduced the file.
- Mechanism confirmed against PR-Agent's documented secure loader, which rejects "includes, preloads, custom loaders, and other directives that could execute code or read arbitrary files".
- `.pr_agent.toml` parses under `tomllib`, and the guidelines still carry the rule (`'injection shims'` and the section 4.1 cross-reference both present).
- Raw-file scan for every rejected token returns zero matches.

**This PR cannot test itself, and the failure comment on it is expected.** PR-Agent reads the repo-local config from the **default branch**, not from the PR head — sensible, since otherwise a PR could inject config for its own review. Two observations pin this down:

- On #2268 the error did not appear while the PR was open; it appeared **4 seconds after merge** (merged `14:20:10Z`, comment `14:20:14Z`). Before the merge `master` had no `.pr_agent.toml`, so there was nothing to reject.
- On this PR the same error appears again, because `master` still carries the old file. The fix on this branch is invisible to the loader.

Note also that the bot renders an **empty** "Configuration content" block, consistent with rejecting the file before it can echo anything.

So the fix cannot be proven from here; it is verified by inspection (zero occurrences of any rejected token in the raw file, comments included). **The real check is the first PR opened after this merges:** if it draws a normal Qodo review with no "failed to apply 'local' repo settings" comment, the config is live. If the comment persists, the token match is broader than assumed and the remaining guidelines need the same treatment.

## Second fix: qodo-gate blocked every clean PR

Found while trying to merge this PR — its own gate failed, and would have failed forever.

The gate looked only for a **review object** by the bot. Qodo creates one when it has inline comments to attach to the diff, so any PR it finds something in has one. That is why it passed on #2268 and on every OpenIPC/devourer PR I checked — all of them had findings.

A clean PR gets no review object at all. Qodo reported `Bugs (0), Rule violations (0), Requirement gaps (0)` on this PR as a plain issue comment and created nothing else, so the gate reported "no Qodo review on this PR yet" and could never go green. **The check blocked hardest exactly when there was nothing to fix.**

It now accepts either signal: a review object, or an issue comment headed `Code Review by Qodo`. The header is matched specifically rather than "any comment by the bot", because Qodo also posts `Qodo is busy working` (a placeholder written before it has read anything), `PR Summary by Qodo` (`/describe` output), and the `failed to apply 'local' repo settings` error. Counting those would pass a PR the agent never reviewed.

Verified against the live API before pushing:

| PR | review objects | review comments | verdict |
|---|---|---|---|
| #2269 (clean) | 0 | 1 | PASS — was FAIL |
| #2268 (had findings) | 1 | 1 | PASS — unchanged |

All three noise comments are correctly rejected. Thread resolution is unaffected: a zero-finding PR opens no threads, so the unresolved count is 0 and it falls through to PASS.

Unlike the config fix, this one **is** testable here — `pull_request` workflows run from the merge commit, so this PR's own `qodo-gate` used the fixed file and passed with `review found: 0 review object(s), 1 review comment(s)`.

## Scope

- [x] No kernel patches, no single-board files, no debugging tooling
- [x] Nothing under `general/overlay/`; no package sources changed
- [x] No code — review configuration only, does not enter any image

🤖 Generated with [Claude Code](https://claude.com/claude-code)


