### PR TITLE
qodo-gate: re-evaluate when Qodo posts its review comment

### DIFF
--- a/.github/workflows/qodo-gate.yml
+++ b/.github/workflows/qodo-gate.yml
@@ -62,9 +62,28 @@ permissions:
 jobs:
   qodo-gate:
     runs-on: ubuntu-latest
-    # issue_comment fires for plain issues too, which have no PR to gate.
-    # Every other trigger here is PR-only, so this is the whole guard.
-    if: github.event_name != 'issue_comment' || github.event.issue.pull_request
+    # Narrow the issue_comment trigger to the single comment that can change
+    # this gate's verdict: Qodo's review. Without all three clauses the job is
+    # an API-heavy workflow holding `actions: write` that any commenter could
+    # run at will, on any PR, as often as they liked — CI noise, and needless
+    # rate-limit exposure on a REQUIRED check.
+    #
+    #   issue.pull_request  — issue_comment fires for plain issues too, and
+    #                         those have no PR to gate.
+    #   comment author      — only the bot's own comment is evidence of review.
+    #                         A human typing /review still works: Qodo answers,
+    #                         and that answer is what triggers this.
+    #   comment body        — the bot also posts "Qodo is busy working" and
+    #                         "PR Summary by Qodo", neither of which means the
+    #                         diff was reviewed. Matching the review header
+    #                         keeps this to one run per review.
+    #
+    # Every other trigger here is PR-only and needs no guard.
+    if: >-
+      github.event_name != 'issue_comment' ||
+      (github.event.issue.pull_request &&
+       startsWith(github.event.comment.user.login, 'qodo-free-for-open-source-projects') &&
+       contains(github.event.comment.body, 'Code Review by Qodo'))
     steps:
       - name: Require a Qodo review with all its threads resolved
         env:

--- a/.github/workflows/qodo-gate.yml
+++ b/.github/workflows/qodo-gate.yml
@@ -45,6 +45,14 @@ on:
     types: [submitted]
   pull_request_review_comment:
     types: [created, deleted]
+  # A clean PR's only proof of review is an ISSUE comment, and without this
+  # trigger nothing re-evaluates the gate when it arrives: the run fired at
+  # `opened` fails (Qodo has not answered yet), the comment lands a minute or
+  # two later, and the check stays red until an unrelated push happens to
+  # re-trigger it. That is precisely how #2269 went green — a follow-up commit,
+  # not the review — which hid the gap on the PR that introduced it.
+  issue_comment:
+    types: [created, edited]
 
 permissions:
   contents: read
@@ -54,11 +62,16 @@ permissions:
 jobs:
   qodo-gate:
     runs-on: ubuntu-latest
+    # issue_comment fires for plain issues too, which have no PR to gate.
+    # Every other trigger here is PR-only, so this is the whole guard.
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request
     steps:
       - name: Require a Qodo review with all its threads resolved
         env:
           GH_TOKEN: ${{ github.token }}
-          PR: ${{ github.event.pull_request.number }}
+          # issue_comment carries `issue`, not `pull_request` — for a PR
+          # comment the issue number IS the PR number.
+          PR: ${{ github.event.pull_request.number || github.event.issue.number }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
         run: |
@@ -185,10 +198,21 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
+          # Empty on issue_comment, which carries no head sha — resolved from
+          # the PR below. This is the trigger that matters most for the sweep:
+          # it is the one that turns a clean PR's earlier red run green.
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR: ${{ github.event.pull_request.number || github.event.issue.number }}
           THIS_RUN: ${{ github.run_id }}
         run: |
           set -u
+          if [ -z "$HEAD_SHA" ]; then
+            if ! HEAD_SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid \
+                --jq .headRefOid); then
+              echo "sweep skipped: could not resolve head sha for PR $PR"
+              exit 0
+            fi
+          fi
           # The listing is guarded too, not just the reruns: with an unguarded
           # pipeline a transient list failure would be the step's exit code —
           # exactly the PASS-into-FAIL this step promises not to produce.


### PR DESCRIPTION
## Problem

Found by Qodo's own review of #2269 — a correct finding against the fix in that PR.

#2269 taught the gate to accept an issue comment headed `Code Review by Qodo` as proof of review, since that is the only proof a zero-finding PR ever produces. It did not give the workflow a reason to *look again* when that comment arrives.

So the gap only moved:

1. PR opens → `qodo-gate` runs → Qodo has not answered yet → **fail** (correct)
2. Qodo posts `Code Review by Qodo` a minute or two later — as an issue comment
3. `issue_comment` was not a trigger, so **nothing re-evaluates the gate**
4. The required check stays red until an unrelated push

The irony is that #2269 could not have caught this itself: it went green because I pushed a second commit, which re-triggered the gate at a point where the comment already existed. A `synchronize` event masked a missing `issue_comment` event.

## Fix

Adds the `issue_comment` trigger, plus the plumbing that payload requires:

- **A job guard.** `issue_comment` also fires for plain issues, which have no PR to gate. Every other trigger here is PR-only, so `github.event_name != 'issue_comment' || github.event.issue.pull_request` is the whole condition.
- **PR number from `github.event.issue.number`.** `issue_comment` carries `issue`, not `pull_request`; for a comment on a PR the issue number *is* the PR number.
- **Head sha resolved at runtime in the sweep step.** It read `github.event.pull_request.head.sha`, which `issue_comment` does not carry. Now looked up from the PR when empty, and still best-effort — a failed lookup skips the sweep rather than turning a PASS into a FAIL.

The sweep matters most on exactly this trigger: it is the one that clears a clean PR's earlier red run off the head commit, which branch protection's rollup would otherwise keep counting.

## Evidence

Review configuration only; nothing enters an image.

- Root cause is reproducible by inspection: `on:` had no `issue_comment`, while the detection logic added in #2269 depends on a comment.
- Workflow parses; triggers are `pull_request`, `pull_request_review`, `pull_request_review_comment`, `issue_comment`; both steps resolve `PR` from either payload shape.
- **This PR cannot test the path it fixes, and its own gate will stay red.** I initially expected it to self-heal; it will not. GitHub runs `issue_comment`-triggered workflows from the **default branch**, not from the PR head — so the new trigger is inert until this merges. Observed directly here: Qodo posted `PR Summary by Qodo` (an issue comment) at `16:01:26Z` and no `qodo-gate` run appeared for it; the only run is the `pull_request` one that failed at open. The same is true of the `pull_request_review` triggers, which is why those runs sat queued forever on #2268 while only `pull_request` runs completed.

  So merging this needs the same manual nudge #2269 needed — a push, or the `skip-qodo-gate` label. That is the bootstrap problem in a sentence: **the fix for "the gate cannot self-heal" cannot itself self-heal.**

  **Real verification is the first clean PR opened after this merges:** its `qodo-gate` should go red at open and turn green on its own once Qodo comments, with no push. If it stays red, this fix is wrong.

Also confirmed while verifying #2269's merge: the `.pr_agent.toml` loader fix works. A `/review` on master's config produced a normal review with **no** `failed to apply 'local' repo settings` comment, so the custom standards are live for the first time.

## Scope

- [x] No kernel patches, no single-board files, no debugging tooling
- [x] Nothing under `general/overlay/`; no package sources changed
- [x] No code — CI workflow only, does not enter any image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

