### PR TITLE
vendor-abi: count a symbol as missing only if nothing defines it

### DIFF
--- a/.github/workflows/vendor-abi.yml
+++ b/.github/workflows/vendor-abi.yml
@@ -5,6 +5,9 @@ on:
       - master
     paths:
       - 'general/package/*-osdrv-*/**'
+      # The auditor sweeps general/package/legacy/*-osdrv-* too, so CI has to
+      # watch it or those packages silently lose the check.
+      - 'general/package/legacy/*-osdrv-*/**'
       - 'general/package/uclibc-compat/**'
       - 'general/package/glibc-compat/**'
       - 'general/scripts/audit-vendor-abi.py'
@@ -46,8 +49,11 @@ jobs:
             # owning package, so those also sweep everything.
             if ! echo "$changed" \
                 | grep -qE '^general/(scripts/audit-vendor-abi\.py|package/(uc|g)libc-compat/)'; then
+              # Keep the legacy/ prefix: the auditor names those packages
+              # "legacy/<name>" and --package resolves the path relative to
+              # general/package, so stripping it would not find them.
               pkgs=$(echo "$changed" \
-                | grep -oE '^general/package/[a-z0-9]+-osdrv-[a-z0-9]+' \
+                | grep -oE '^general/package/(legacy/)?[a-z0-9]+-osdrv-[a-z0-9]+' \
                 | sed 's|^general/package/||' | sort -u)
             fi
           fi

--- a/.github/workflows/vendor-abi.yml
+++ b/.github/workflows/vendor-abi.yml
@@ -1,0 +1,108 @@
+name: vendor-abi
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'general/package/*-osdrv-*/**'
+      - 'general/package/uclibc-compat/**'
+      - 'general/package/glibc-compat/**'
+      - 'general/scripts/audit-vendor-abi.py'
+  # No push trigger, for the same reason shell-tests.yml has none: every commit
+  # on master already ran this on its pull request.
+  workflow_dispatch:
+
+jobs:
+  # Advisory only. hisilicon-osdrv-hi3520dv200 landed in May with a vendor blob
+  # that needed a 32-bit-off_t mmap shim, and nothing in CI noticed -- the gap
+  # was found by hand, months later, on a camera. This job would have printed it
+  # on the pull request. It deliberately does not gate the merge: the audit
+  # downloads a ~100MB toolchain per SoC family from the releases page, so a
+  # rate-limited or reorganised release asset would otherwise block unrelated
+  # work. Read the log, do not trust the checkmark.
+  audit:
+    name: vendor ABI audit (advisory)
+    if: >-
+      github.repository == 'OpenIPC/firmware' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !github.event.repository.private)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need the base commit to diff against, not just the merge head.
+          fetch-depth: 0
+
+      - name: Work out which osdrv packages this PR touches
+        id: changed
+        run: |
+          # workflow_dispatch has no diff to take, so it always sweeps
+          # everything. Empty output means "audit all packages".
+          pkgs=""
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            changed=$(git diff --name-only "$base"...HEAD)
+            # A change to the shims or to the auditor itself has no single
+            # owning package, so those also sweep everything.
+            if ! echo "$changed" \
+                | grep -qE '^general/(scripts/audit-vendor-abi\.py|package/(uc|g)libc-compat/)'; then
+              pkgs=$(echo "$changed" \
+                | grep -oE '^general/package/[a-z0-9]+-osdrv-[a-z0-9]+' \
+                | sed 's|^general/package/||' | sort -u)
+            fi
+          fi
+          {
+            echo "packages<<EOF"
+            echo "$pkgs"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          if [ -n "$pkgs" ]; then
+            echo "Auditing: $pkgs"
+          else
+            echo "Auditing: all osdrv packages (shim or auditor changed)"
+          fi
+
+      - name: Cache downloaded toolchains
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/openipc-audit-toolchains
+          key: audit-toolchains-${{ runner.os }}-v1
+
+      - name: Run the audit
+        run: |
+          set -o pipefail
+          pkgs="${{ steps.changed.outputs.packages }}"
+          rc=0
+          if [ -z "$pkgs" ]; then
+            python3 general/scripts/audit-vendor-abi.py 2>&1 | tee -a audit.log || rc=$?
+          else
+            for p in $pkgs; do
+              python3 general/scripts/audit-vendor-abi.py --package "$p" 2>&1 \
+                | tee -a audit.log || rc=$?
+            done
+          fi
+          echo "audit exit status: $rc (advisory -- not failing the build)"
+
+      - name: Summarise into the job summary
+        if: always()
+        run: |
+          {
+            echo '## Vendor ABI audit (advisory)'
+            echo
+            echo 'Findings below are informational. A missing symbol means a'
+            echo 'vendor .so imports something neither musl nor a sibling'
+            echo 'vendor library in the same package defines.'
+            echo
+            echo '```'
+            # Keep the summary inside GitHub'\''s 1MB budget.
+            head -c 900000 audit.log 2>/dev/null || echo '(no output)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the full log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vendor-abi-audit
+          path: audit.log
+          if-no-files-found: ignore

--- a/general/package/uclibc-compat/src/uclibc-compat.c
+++ b/general/package/uclibc-compat/src/uclibc-compat.c
@@ -189,21 +189,49 @@ static void __uclibc_compat_init(void)
  * __cmsg_nxthdr -- the out-of-line helper behind CMSG_NXTHDR.  glibc and
  * uclibc emit a call to it; musl expands CMSG_NXTHDR entirely inline and so
  * exports nothing.
+ *
+ * glibc's version walks the buffer with raw pointer arithmetic and trusts
+ * the caller to have obtained cmsg from CMSG_FIRSTHDR.  Ancillary data
+ * ultimately comes from the kernel via recvmsg(), so this one validates the
+ * cursor against the control buffer first and does every bounds test in
+ * size_t offsets: computing `cmsg + CMSG_ALIGN(cmsg_len)` and only then
+ * checking it would already be undefined behaviour for a corrupt length.
  */
 __attribute__((visibility("default")))
 struct cmsghdr *__cmsg_nxthdr(struct msghdr *mhdr, struct cmsghdr *cmsg)
 {
-	if ((size_t)cmsg->cmsg_len < sizeof(struct cmsghdr))
+	if (!mhdr || !cmsg || !mhdr->msg_control)
 		return NULL;
 
-	unsigned char *next = (unsigned char *)cmsg + CMSG_ALIGN(cmsg->cmsg_len);
-	unsigned char *end = (unsigned char *)mhdr->msg_control + mhdr->msg_controllen;
+	unsigned char *base = (unsigned char *)mhdr->msg_control;
+	size_t buflen = mhdr->msg_controllen;
+	unsigned char *cur = (unsigned char *)cmsg;
 
-	if (next + sizeof(struct cmsghdr) > end || next < (unsigned char *)cmsg)
+	/* The cursor itself has to lie inside the control buffer. */
+	if (cur < base || (size_t)(cur - base) > buflen)
 		return NULL;
 
-	struct cmsghdr *nxt = (struct cmsghdr *)next;
-	if (next + CMSG_ALIGN(nxt->cmsg_len) > end)
+	size_t offset = (size_t)(cur - base);
+	size_t remaining = buflen - offset;
+	if (remaining < sizeof(struct cmsghdr))
+		return NULL;
+
+	size_t len = cmsg->cmsg_len;
+	if (len < sizeof(struct cmsghdr) || len > remaining)
+		return NULL;
+
+	/* CMSG_ALIGN can round up past the end, so compare before advancing. */
+	size_t step = CMSG_ALIGN(len);
+	if (step < len || step > remaining)
+		return NULL;
+
+	remaining -= step;
+	if (remaining < sizeof(struct cmsghdr))
+		return NULL;
+
+	struct cmsghdr *nxt = (struct cmsghdr *)(cur + step);
+	size_t nxt_len = nxt->cmsg_len;
+	if (nxt_len < sizeof(struct cmsghdr) || nxt_len > remaining)
 		return NULL;
 
 	return nxt;
@@ -225,21 +253,31 @@ struct cmsghdr *__cmsg_nxthdr(struct msghdr *mhdr, struct cmsghdr *cmsg)
  * is the library failing to load at all.  __pthread_unwind_next is only
  * reached once cancellation is already unwinding, so it terminates the
  * thread the way the caller expects rather than returning.
+ *
+ * The buffer is opaque to us, so it is taken as void * -- except where the
+ * headers already declare these (glibc), which would make a differing
+ * signature a hard error rather than a warning.
  */
+#ifdef __GLIBC__
+typedef __pthread_unwind_buf_t *uclibc_compat_cancel_buf;
+#else
+typedef void *uclibc_compat_cancel_buf;
+#endif
+
 __attribute__((visibility("default")))
-void __pthread_register_cancel(void *buf)
+void __pthread_register_cancel(uclibc_compat_cancel_buf buf)
 {
 	(void)buf;
 }
 
 __attribute__((visibility("default")))
-void __pthread_unregister_cancel(void *buf)
+void __pthread_unregister_cancel(uclibc_compat_cancel_buf buf)
 {
 	(void)buf;
 }
 
 __attribute__((visibility("default"), noreturn))
-void __pthread_unwind_next(void *buf)
+void __pthread_unwind_next(uclibc_compat_cancel_buf buf)
 {
 	(void)buf;
 	pthread_exit(PTHREAD_CANCELED);

--- a/general/package/uclibc-compat/src/uclibc-compat.c
+++ b/general/package/uclibc-compat/src/uclibc-compat.c
@@ -20,11 +20,13 @@
 
 #define _GNU_SOURCE
 #include <errno.h>
+#include <pthread.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/socket.h>
 #include <unistd.h>
 
 /* ======================================================================
@@ -105,6 +107,143 @@ static const unsigned short int __uclibc_ctype_b_data[384] = {
 
 __attribute__((visibility("default")))
 const unsigned short int *__ctype_b = &__uclibc_ctype_b_data[128];
+
+/*
+ * __ctype_tolower -- uclibc's tolower() lookup table, indexed the same way
+ * as __ctype_b: the exported pointer aims at element 128 of a 384-entry
+ * table so the valid index range is [-128, 255].
+ *
+ * The element type is int16_t, NOT the int32_t that glibc uses.  This is
+ * not a guess: the consuming code in ingenic-osdrv-t20 libalog.so scales
+ * the index by 2 and reads with a signed halfword load --
+ *
+ *     lw   $3, -0x7fbc($gp)   ; &__ctype_tolower
+ *     lw   $3, 0x0($3)        ; the pointer itself
+ *     sll  $2, $2, 0x1        ; index * 2  -> 2-byte elements
+ *     lh   $2, 0x0($2)        ; signed halfword
+ *
+ * Using glibc's 4-byte layout here would silently return garbage for every
+ * tolower() the vendor libraries perform.  Note that a glibc-built blob
+ * (e.g. rockchip-osdrv-rv11xx) would want the int32_t layout instead, so
+ * this table is only correct for the uclibc-built platforms it targets.
+ */
+static const int16_t __uclibc_ctype_tolower_data[384] = {
+	 -128,  -127,  -126,  -125,  -124,  -123,  -122,  -121,  -120,  -119,  -118,  -117,
+	 -116,  -115,  -114,  -113,  -112,  -111,  -110,  -109,  -108,  -107,  -106,  -105,
+	 -104,  -103,  -102,  -101,  -100,   -99,   -98,   -97,   -96,   -95,   -94,   -93,
+	  -92,   -91,   -90,   -89,   -88,   -87,   -86,   -85,   -84,   -83,   -82,   -81,
+	  -80,   -79,   -78,   -77,   -76,   -75,   -74,   -73,   -72,   -71,   -70,   -69,
+	  -68,   -67,   -66,   -65,   -64,   -63,   -62,   -61,   -60,   -59,   -58,   -57,
+	  -56,   -55,   -54,   -53,   -52,   -51,   -50,   -49,   -48,   -47,   -46,   -45,
+	  -44,   -43,   -42,   -41,   -40,   -39,   -38,   -37,   -36,   -35,   -34,   -33,
+	  -32,   -31,   -30,   -29,   -28,   -27,   -26,   -25,   -24,   -23,   -22,   -21,
+	  -20,   -19,   -18,   -17,   -16,   -15,   -14,   -13,   -12,   -11,   -10,    -9,
+	   -8,    -7,    -6,    -5,    -4,    -3,    -2,    -1,     0,     1,     2,     3,
+	    4,     5,     6,     7,     8,     9,    10,    11,    12,    13,    14,    15,
+	   16,    17,    18,    19,    20,    21,    22,    23,    24,    25,    26,    27,
+	   28,    29,    30,    31,    32,    33,    34,    35,    36,    37,    38,    39,
+	   40,    41,    42,    43,    44,    45,    46,    47,    48,    49,    50,    51,
+	   52,    53,    54,    55,    56,    57,    58,    59,    60,    61,    62,    63,
+	/* 'A'-'Z' (65-90) fold to 'a'-'z' (97-122); everything else is identity */
+	   64,    97,    98,    99,   100,   101,   102,   103,   104,   105,   106,   107,
+	  108,   109,   110,   111,   112,   113,   114,   115,   116,   117,   118,   119,
+	  120,   121,   122,    91,    92,    93,    94,    95,    96,    97,    98,    99,
+	  100,   101,   102,   103,   104,   105,   106,   107,   108,   109,   110,   111,
+	  112,   113,   114,   115,   116,   117,   118,   119,   120,   121,   122,   123,
+	  124,   125,   126,   127,   128,   129,   130,   131,   132,   133,   134,   135,
+	  136,   137,   138,   139,   140,   141,   142,   143,   144,   145,   146,   147,
+	  148,   149,   150,   151,   152,   153,   154,   155,   156,   157,   158,   159,
+	  160,   161,   162,   163,   164,   165,   166,   167,   168,   169,   170,   171,
+	  172,   173,   174,   175,   176,   177,   178,   179,   180,   181,   182,   183,
+	  184,   185,   186,   187,   188,   189,   190,   191,   192,   193,   194,   195,
+	  196,   197,   198,   199,   200,   201,   202,   203,   204,   205,   206,   207,
+	  208,   209,   210,   211,   212,   213,   214,   215,   216,   217,   218,   219,
+	  220,   221,   222,   223,   224,   225,   226,   227,   228,   229,   230,   231,
+	  232,   233,   234,   235,   236,   237,   238,   239,   240,   241,   242,   243,
+	  244,   245,   246,   247,   248,   249,   250,   251,   252,   253,   254,   255,
+};
+
+__attribute__((visibility("default")))
+const int16_t *__ctype_tolower = &__uclibc_ctype_tolower_data[128];
+
+/*
+ * __stdin -- uclibc implements the stdin macro as a FILE* variable named
+ * __stdin, so vendor binaries import the variable rather than musl's
+ * `extern FILE *const stdin`.  musl's stdin is not a constant expression,
+ * so the aliasing has to happen in a constructor.
+ *
+ * This is only safe as long as the vendor code treats the FILE* as opaque
+ * (passing it to fgets/fread/fileno).  Code that reaches inside the FILE
+ * struct would still break: uclibc's and musl's layouts differ.
+ */
+__attribute__((visibility("default")))
+FILE *__stdin = NULL;
+
+__attribute__((constructor))
+static void __uclibc_compat_init(void)
+{
+	__stdin = stdin;
+}
+
+/*
+ * __cmsg_nxthdr -- the out-of-line helper behind CMSG_NXTHDR.  glibc and
+ * uclibc emit a call to it; musl expands CMSG_NXTHDR entirely inline and so
+ * exports nothing.
+ */
+__attribute__((visibility("default")))
+struct cmsghdr *__cmsg_nxthdr(struct msghdr *mhdr, struct cmsghdr *cmsg)
+{
+	if ((size_t)cmsg->cmsg_len < sizeof(struct cmsghdr))
+		return NULL;
+
+	unsigned char *next = (unsigned char *)cmsg + CMSG_ALIGN(cmsg->cmsg_len);
+	unsigned char *end = (unsigned char *)mhdr->msg_control + mhdr->msg_controllen;
+
+	if (next + sizeof(struct cmsghdr) > end || next < (unsigned char *)cmsg)
+		return NULL;
+
+	struct cmsghdr *nxt = (struct cmsghdr *)next;
+	if (next + CMSG_ALIGN(nxt->cmsg_len) > end)
+		return NULL;
+
+	return nxt;
+}
+
+/*
+ * pthread cancellation cleanup ABI -- glibc/uclibc compile
+ * pthread_cleanup_push()/pop() into calls to these three helpers, which
+ * maintain a per-thread stack of cleanup buffers consulted only while a
+ * cancellation is actually unwinding.  musl implements cleanup handlers
+ * with a different, entirely internal mechanism and exports nothing here.
+ *
+ * LIMITATION: register/unregister are no-ops, which is exactly correct for
+ * the overwhelmingly common path where the thread is never cancelled --
+ * push/pop then have no observable effect.  If a thread IS cancelled, the
+ * handlers pushed this way do not run, so a vendor library that relies on
+ * pthread_cancel to release a lock or free a buffer will leak it.  No
+ * OpenIPC platform is known to cancel a vendor thread, and the alternative
+ * is the library failing to load at all.  __pthread_unwind_next is only
+ * reached once cancellation is already unwinding, so it terminates the
+ * thread the way the caller expects rather than returning.
+ */
+__attribute__((visibility("default")))
+void __pthread_register_cancel(void *buf)
+{
+	(void)buf;
+}
+
+__attribute__((visibility("default")))
+void __pthread_unregister_cancel(void *buf)
+{
+	(void)buf;
+}
+
+__attribute__((visibility("default"), noreturn))
+void __pthread_unwind_next(void *buf)
+{
+	(void)buf;
+	pthread_exit(PTHREAD_CANCELED);
+}
 
 /* __assert -- uclibc: __assert(msg, file, line), no func parameter */
 __attribute__((visibility("default")))

--- a/general/scripts/audit-vendor-abi.py
+++ b/general/scripts/audit-vendor-abi.py
@@ -15,8 +15,14 @@ modern musl libc.
 This tool performs two definitive checks (no guessing):
 
   1. SYMBOL CHECK: extracts every imported symbol from vendor .so files and
-     checks whether the actual musl libc.so exports it.  Any symbol the
-     vendor needs but musl doesn't provide will fail at dlopen/startup.
+     checks whether anything in the process image defines it.  A symbol only
+     counts as missing when neither musl NOR a sibling .so shipped in the same
+     package provides it -- HiSilicon and Goke packages ship libsecurec.so,
+     which defines the C11 Annex K family (memcpy_s, snprintf_s, ...) that the
+     other vendor libraries import via DT_NEEDED.  Symbols owned by the
+     compiler runtime (libgcc's __aeabi_*/__divdi3, libstdc++'s __cxa_*) are
+     reported separately: they resolve from whichever executable loads the
+     library, so they are not a libc gap either.
 
   2. STRUCT PROBE: compiles a small C program with the platform's musl
      cross-compiler and runs it under qemu to get exact sizeof/offsetof
@@ -59,6 +65,7 @@ EXIT CODES
 import argparse
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -75,6 +82,8 @@ class BinaryInfo:
     path: str           # absolute path
     rel_path: str       # relative to package dir
     imports: list       # [(binding, symbol), ...]
+    exports: set        # symbols this .so DEFINES (resolvable by siblings)
+    soname: str         # DT_SONAME, or the file basename if unset
     needed: list        # NEEDED entries from .dynamic
     version_reqs: list  # GLIBC_2.x etc version tags
 
@@ -89,6 +98,11 @@ class PackageResult:
     missing_symbols: dict = field(default_factory=lambda: defaultdict(list))
     # maps symbol -> [binary_rel_paths]
     struct_mismatches: list = field(default_factory=list)
+    # symbol -> sorted list of sibling SONAMEs in this package that define it
+    sibling_resolved: dict = field(default_factory=dict)
+    # symbols provided by the compiler runtime the consumer links (libgcc,
+    # libstdc++), not by libc -- never a shim's job
+    toolchain_symbols: dict = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -145,7 +159,45 @@ LINKER_INTERNALS = {
     "__gmon_start__", "_Jv_RegisterClasses",
     "__deregister_frame_info", "__register_frame_info",
     "_ITM_deregisterTMCloneTable", "_ITM_registerTMCloneTable",
+    "__GNU_EH_FRAME_HDR", "_gp_disp", "__gnu_local_gp",
 }
+
+# Symbols supplied by the compiler runtime rather than by libc.  A vendor .so
+# importing these is not a musl problem: libgcc / libgcc_eh / libstdc++ get
+# linked into whichever executable loads the library.  Reporting them as
+# "missing from musl" is what inflated the counts in issue #1992 -- e.g.
+# rockchip-osdrv-rv11xx imports 15 C++ ABI symbols that libstdc++ provides.
+TOOLCHAIN_RUNTIME_PREFIXES = (
+    "__aeabi_",      # ARM EABI helpers (libgcc)
+    "__cxa_",        # C++ ABI (libstdc++)
+    "_Unwind_",      # unwinder (libgcc_eh)
+    "__gxx_",        # C++ personality routine (libstdc++)
+)
+
+TOOLCHAIN_RUNTIME_SYMBOLS = {
+    # libgcc integer/float helpers
+    "__divdi3", "__udivdi3", "__moddi3", "__umoddi3", "__divdc3",
+    "__floatdisf", "__floatdidf", "__fixdfdi", "__fixunsdfdi",
+    "__popcountsi2", "__popcountdi2", "__clzsi2", "__ctzsi2",
+    # libgcc_eh frame registration
+    "__register_frame_info_bases", "__deregister_frame_info_bases",
+    "__register_frame_info_header_bases",
+    # libstdc++
+    "__dynamic_cast",
+}
+
+
+def is_toolchain_runtime_symbol(sym: str) -> bool:
+    """True if the compiler runtime (libgcc/libstdc++) provides this symbol.
+
+    Note __aeabi_d2iz is deliberately NOT special-cased away here: older
+    Buildroot ARM toolchains have been seen not to emit it, which is why
+    uclibc-compat carries an implementation.  It is still a libgcc symbol,
+    so it is bucketed with the rest and simply not counted as a musl gap.
+    """
+    if sym in TOOLCHAIN_RUNTIME_SYMBOLS:
+        return True
+    return any(sym.startswith(p) for p in TOOLCHAIN_RUNTIME_PREFIXES)
 
 
 # ---------------------------------------------------------------------------
@@ -189,19 +241,24 @@ def parse_binary(path: str, pkg_dir: str) -> BinaryInfo | None:
 
     rel_path = os.path.relpath(path, pkg_dir)
 
-    # Dynamic section for NEEDED
+    # Dynamic section for NEEDED / SONAME
     dyn_out = run_readelf(["-d"], path)
     needed = re.findall(r"NEEDED.*\[(.+?)\]", dyn_out)
+    m_soname = re.search(r"SONAME.*\[(.+?)\]", dyn_out)
+    soname = m_soname.group(1) if m_soname else os.path.basename(path)
 
-    # Dynamic symbols -- undefined imports
+    # Dynamic symbols -- undefined imports and defined exports
     dynsym_out = run_readelf(["--dyn-syms"], path)
     imports = []
+    exports = set()
     for line in dynsym_out.splitlines():
         parts = line.split()
-        if len(parts) >= 8 and parts[6] == "UND" and parts[7]:
-            binding = parts[4]
+        if len(parts) >= 8 and parts[7]:
             sym = parts[7].split("@")[0]
-            imports.append((binding, sym))
+            if parts[6] == "UND":
+                imports.append((parts[4], sym))
+            else:
+                exports.add(sym)
 
     # GNU version requirements
     ver_out = run_readelf(["-V"], path)
@@ -211,7 +268,8 @@ def parse_binary(path: str, pkg_dir: str) -> BinaryInfo | None:
 
     return BinaryInfo(
         path=path, rel_path=rel_path,
-        imports=imports, needed=needed, version_reqs=version_reqs,
+        imports=imports, exports=exports, soname=soname,
+        needed=needed, version_reqs=version_reqs,
     )
 
 
@@ -484,6 +542,17 @@ def audit_package(pkg_name: str, pkg_dir: str, musl_exports: set[str],
     result.source_libc = detect_source_libc(result.binaries)
     result.arch = detect_arch(result.binaries[0].path)
 
+    # A symbol is only "missing" if nothing in the process image defines it.
+    # musl is one provider; the sibling .so shipped alongside in the same
+    # package are another.  HiSilicon and Goke packages ship libsecurec.so,
+    # which defines the whole C11 Annex K family (memcpy_s, snprintf_s, ...)
+    # that the other vendor libraries import via DT_NEEDED.  Checking musl
+    # alone reports those as missing and overstates the real gap.
+    sibling_providers = defaultdict(set)
+    for binfo in result.binaries:
+        for sym in binfo.exports:
+            sibling_providers[sym].add(binfo.soname)
+
     # Phase 1: Missing symbols (skip vendor-internal and linker symbols)
     for binfo in result.binaries:
         for binding, sym in binfo.imports:
@@ -492,6 +561,24 @@ def audit_package(pkg_name: str, pkg_dir: str, musl_exports: set[str],
             if is_vendor_symbol(sym):
                 continue
             if binding == "WEAK" and sym in LINKER_INTERNALS:
+                continue
+            if sym in LINKER_INTERNALS:
+                continue
+            if is_toolchain_runtime_symbol(sym):
+                result.toolchain_symbols.setdefault(sym, []).append(binfo.rel_path)
+                continue
+            providers = sibling_providers.get(sym)
+            if providers:
+                # Defined by a sibling in this package.  Flag the case where
+                # the importer does not name that sibling in its own DT_NEEDED
+                # -- it then depends on the provider being pulled into the
+                # process by someone else, which is fragile but not broken.
+                direct = providers & set(binfo.needed)
+                result.sibling_resolved.setdefault(
+                    sym, {"providers": sorted(providers), "indirect": []},
+                )
+                if not direct:
+                    result.sibling_resolved[sym]["indirect"].append(binfo.rel_path)
                 continue
             result.missing_symbols[sym].append(binfo.rel_path)
 
@@ -603,6 +690,32 @@ def print_report(result: PackageResult, quiet: bool) -> None:
             for sym, bins in sorted(other_missing.items()):
                 print(f"    {sym}")
             print()
+
+    # Resolved by a sibling in the same package -- reported so the audit is
+    # not silently dropping them, but these are not a gap to shim.
+    if result.sibling_resolved and not quiet:
+        indirect = {s: d for s, d in result.sibling_resolved.items() if d["indirect"]}
+        print(f"  RESOLVED BY SIBLING VENDOR LIBS "
+              f"({len(result.sibling_resolved)} symbols) -- not a musl gap:")
+        for sym, d in sorted(result.sibling_resolved.items()):
+            print(f"    {sym}  <- {', '.join(d['providers'])}")
+        print()
+        if indirect:
+            print(f"  ...of which {len(indirect)} are imported by a binary that "
+                  f"does not list the provider in its own DT_NEEDED:")
+            for sym, d in sorted(indirect.items()):
+                for b in sorted(set(d["indirect"])):
+                    print(f"    {sym}  <- needed by {b}")
+            print()
+
+    # Compiler-runtime symbols -- provided by libgcc/libstdc++ in whichever
+    # executable loads the library, never by libc.
+    if result.toolchain_symbols and not quiet:
+        print(f"  COMPILER RUNTIME ({len(result.toolchain_symbols)} symbols) -- "
+              f"provided by libgcc/libstdc++, not libc:")
+        for sym in sorted(result.toolchain_symbols):
+            print(f"    {sym}")
+        print()
 
     # Struct mismatches
     if result.struct_mismatches:
@@ -754,39 +867,60 @@ def download_toolchain(soc_vendor: str, soc_family: str, prefix: str) -> Path | 
     tarball_path = TOOLCHAIN_CACHE_DIR / tarball_name
     extract_dir = TOOLCHAIN_CACHE_DIR / f"{soc_vendor}-{soc_family}"
 
-    # Already extracted?
+    # Already extracted?  Only a directory published by the atomic rename
+    # below counts: a half-extracted tree would otherwise be trusted forever.
     if extract_dir.is_dir():
         return extract_dir
 
-    # Already downloaded?
+    # Already downloaded?  Download into a .part file and rename only on
+    # success, so an interrupted run (CI timeout, ^C) cannot leave a truncated
+    # tarball that every later run happily tries to extract.  This matters most
+    # under the CI cache, where one poisoned entry would persist across runs.
     if not tarball_path.exists():
         url = f"{TOOLCHAIN_URL_BASE}/{tarball_name}"
         print(f"  Downloading toolchain: {url}")
+        part_path = tarball_path.with_name(tarball_name + ".part")
         try:
             r = subprocess.run(
-                ["wget", "-q", "-O", str(tarball_path), url],
-                timeout=300,
+                ["wget", "-q", "-O", str(part_path), url],
+                timeout=900,
             )
             if r.returncode != 0:
-                tarball_path.unlink(missing_ok=True)
+                part_path.unlink(missing_ok=True)
                 print(f"  ERROR: download failed", file=sys.stderr)
                 return None
+            part_path.replace(tarball_path)
         except (subprocess.TimeoutExpired, FileNotFoundError):
-            tarball_path.unlink(missing_ok=True)
+            part_path.unlink(missing_ok=True)
             print(f"  ERROR: download failed (timeout or wget not found)", file=sys.stderr)
             return None
 
-    # Extract
+    # Extract into a scratch directory and publish it with a single rename, for
+    # the same reason: a failed tar must not leave a partial tree behind under
+    # the name the "already extracted?" check above trusts.
     print(f"  Extracting toolchain to {extract_dir}")
-    extract_dir.mkdir(parents=True, exist_ok=True)
-    r = subprocess.run(
-        ["tar", "xzf", str(tarball_path), "-C", str(extract_dir), "--strip-components=1"],
-        capture_output=True, timeout=120,
-    )
+    staging_dir = extract_dir.with_name(extract_dir.name + ".partial")
+    shutil.rmtree(staging_dir, ignore_errors=True)
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        r = subprocess.run(
+            ["tar", "xzf", str(tarball_path), "-C", str(staging_dir),
+             "--strip-components=1"],
+            capture_output=True, timeout=300,
+        )
+    except subprocess.TimeoutExpired:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        print(f"  ERROR: extraction timed out", file=sys.stderr)
+        return None
     if r.returncode != 0:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        # A truncated tarball is the usual cause, and keeping it would make the
+        # failure permanent, so drop it and let the next run fetch it again.
+        tarball_path.unlink(missing_ok=True)
         print(f"  ERROR: extraction failed: {r.stderr.decode()}", file=sys.stderr)
         return None
 
+    staging_dir.replace(extract_dir)
     return extract_dir
 
 

--- a/general/scripts/audit-vendor-abi.py
+++ b/general/scripts/audit-vendor-abi.py
@@ -223,12 +223,34 @@ def is_elf(path: str) -> bool:
         return False
 
 
+def is_exportable(bind: str, vis: str) -> bool:
+    """True if a defined .dynsym entry can actually satisfy another DSO.
+
+    Being defined is not enough.  A LOCAL binding is not visible outside the
+    object and HIDDEN/INTERNAL visibility is not visible to the dynamic
+    linker at all, so neither can resolve a sibling's import.  Counting one
+    as a provider would let a genuinely missing symbol be reported as
+    sibling-resolved.
+
+    In this tree the entries this actually removes are benign -- across the
+    vendor .so sampled, the 366 non-exportable .dynsym entries are 243 LOCAL
+    section symbols (.init, .jcr) and 123 instances of readelf's own header
+    row, which otherwise parses as a symbol literally named "Name".  No
+    HIDDEN entry was observed, and no symbol changed classification when this
+    filter was added.  It is here so that a vendor drop which does carry one
+    cannot quietly mask a real gap.
+    """
+    return bind in ("GLOBAL", "WEAK") and vis in ("DEFAULT", "PROTECTED")
+
+
 def get_musl_exports(libc_path: str) -> set[str]:
     """Get all symbols exported by musl libc.so."""
     out = run_readelf(["--dyn-syms"], libc_path)
     exports = set()
     for line in out.splitlines():
         parts = line.split()
+        if len(parts) >= 8 and not is_exportable(parts[4], parts[5]):
+            continue
         if len(parts) >= 8 and parts[6] != "UND" and parts[7]:
             exports.add(parts[7].split("@")[0])
     return exports
@@ -257,7 +279,7 @@ def parse_binary(path: str, pkg_dir: str) -> BinaryInfo | None:
             sym = parts[7].split("@")[0]
             if parts[6] == "UND":
                 imports.append((parts[4], sym))
-            else:
+            elif is_exportable(parts[4], parts[5]):
                 exports.add(sym)
 
     # GNU version requirements


### PR DESCRIPTION
Closes #1992.

## Problem

#1992 audited 492 vendor `.so` across 15 packages and produced a per-package
shim roadmap. Re-checking it against master, the structural half still holds —
`off_t` 4 vs 8, `struct stat` 88 vs 152, `struct timespec` 8 vs 16 are static
ABI facts, and every flagged blob is byte-identical (all osdrv packages carry
checked-in binaries with empty `VERSION`/`SITE`; nothing was bumped). The
`stat`-family importers are all still there.

The symbol half was wrong, and wrong in the direction that creates work.
`audit-vendor-abi.py` resolved every undefined symbol against the platform musl
`libc.so` and nothing else. But vendor packages do not ship one library each:
the HiSilicon and Goke trees ship `libsecurec.so` next to `libmpi.so`, and it
defines the entire C11 Annex K family (`memcpy_s`, `snprintf_s`, `strncpy_s`,
…) that the others import through `DT_NEEDED`. Those were counted as missing.
So were `__aeabi_*`, `__divdi3` and `__cxa_*`, which come from libgcc and
libstdc++ in whichever executable loads the library.

Measured against the tree, the genuine gap is much smaller than the issue
records:

| Package | #1992 says | Actually missing |
|---|---|---|
| hisilicon-osdrv-hi3516ev200 | 11 | **3** |
| goke-osdrv-gk7205v200 | 8 | **3** |
| goke-osdrv-gk7205v500 | 8 | **0** |
| hisilicon-osdrv-hi3516cv200 | 7 | **0** |

The surviving HiSilicon/Goke residue is three uclibc-isms — `__ctype_b`,
`__fgetc_unlocked`, `_stdlib_mb_cur_max` — and majestic already defines all
three itself, so the on-camera risk is limited to non-majestic consumers of the
vendor libraries. Fullhan and Ingenic gaps are real and are what this PR shims.

## What this changes

**1. The auditor counts a symbol as missing only if nothing defines it.**
Resolution now runs against musl plus the exports of every sibling `.so` in the
package, with compiler-runtime symbols bucketed separately. Symbols resolved by
a sibling are still printed rather than silently dropped, including the ones
whose importer does not name the provider in its own `DT_NEEDED` —
hi3520dv200's `libmpi.so` reaches `jpeg_*` that way, which is fragile rather
than broken, and worth seeing.

**2. `uclibc-compat` gains the Fullhan/Ingenic symbols.** `__stdin`,
`__cmsg_nxthdr`, `__ctype_tolower` and the three `__pthread_*_cancel` cleanup
helpers. This is SDK-side only — no package gains a dependency, no rootfs
changes.

`__ctype_tolower` is `int16_t` here, **not** the `int32_t` glibc uses. That is
not a guess; it is read out of the consuming code in
`ingenic-osdrv-t20/files/lib/libalog.so`:

```
lw   $3, -0x7fbc($gp)   ; &__ctype_tolower
lw   $3, 0x0($3)        ; the pointer itself
sll  $2, $2, 0x1        ; index * 2  -> 2-byte elements
lh   $2, 0x0($2)        ; signed halfword load
```

Shipping glibc's layout would have silently corrupted every `tolower()` the
vendor code performs.

**3. The toolchain downloader stages and renames.** It used to create the
extraction directory *before* extracting and then trust any existing directory
forever, so a single interrupted run poisoned the cache permanently. The new
CI job caches that directory across runs, so this had to be fixed first.

**4. An advisory CI job.** hi3520dv200 landed in May with a blob needing a
32-bit-`off_t` mmap shim and nothing noticed; it was found by hand on a camera
months later. This job would have printed it on the PR. It reports into the
step summary and never gates the merge — the audit pulls a ~100MB toolchain per
SoC family, and a rate-limited release asset must not block unrelated work.

## Hardware tested on

None, and none is needed: nothing here changes what runs on a camera. The
auditor is a host-side script, and the shim additions are compiled into the SDK
tarball, not installed into any rootfs. The `__ctype_tolower` layout — the one
change where being wrong would matter on a device — was settled by
disassembling the vendor consumer rather than by testing.

## Evidence

The false positive, before — `libbcd.so` imports `memcpy_s`, and the provider
ships in the same package and is named in its `DT_NEEDED`:

```
$ readelf -dW general/package/hisilicon-osdrv-hi3516ev200/files/lib/libbcd.so | grep NEEDED
 0x00000001 (NEEDED) Shared library: [libdl.so.0]
 0x00000001 (NEEDED) Shared library: [libsecurec.so]
 0x00000001 (NEEDED) Shared library: [libc.so.0]
 0x00000001 (NEEDED) Shared library: [ld-uClibc.so.0]

$ readelf -sW --dyn-syms general/package/hisilicon-osdrv-hi3516ev200/files/lib/libsecurec.so | grep -E ' memcpy_s| memset_s| snprintf_s'
    38: 000018d8   124 FUNC    GLOBAL DEFAULT    8 snprintf_s
    47: 000066d8   304 FUNC    GLOBAL DEFAULT    8 memcpy_s
    49: 0000b068   128 FUNC    GLOBAL DEFAULT    8 memset_s
```

After, on `hisilicon-osdrv-hi3519dv500` — one of three packages added since the
audit and never covered by it. 324 symbols correctly attributed to siblings,
the C++ ABI bucketed away, no phantom libc gap:

```
Package: hisilicon-osdrv-hi3519dv500
  Binaries: 41 .so files

  RESOLVED BY SIBLING VENDOR LIBS (324 symbols) -- not a musl gap:
    audio_dnvqe_create  <- libdnvqe.so
    ...
  COMPILER RUNTIME (3 symbols) -- provided by libgcc/libstdc++, not libc:
    __cxa_guard_acquire
    __cxa_guard_release
    __cxa_pure_virtual
```

The indirect-dependency case it now surfaces on hi3520dv200:

```
  RESOLVED BY SIBLING VENDOR LIBS (9 symbols) -- not a musl gap:
    jpeg_read_header  <- libjpeg.so, libjpeg6b.so
  ...of which 9 are imported by a binary that does not list the provider in its own DT_NEEDED:
    jpeg_read_header  <- needed by files/lib/libmpi.so
```

Struct detection is unaffected:

```
  STRUCT LAYOUT MISMATCHES (glibc vs musl):
    struct stat  (used by: __xstat)
      sizeof(struct stat): glibc=88  musl=152
    off_t  (used by: mmap)
      sizeof(off_t): glibc=4  musl=8
```

Shim builds clean and exports all six on both ARM and aarch64 musl, with the
table width confirmed at 384 × 2 bytes:

```
$ arm-openipc-linux-musleabi-gcc -shared -Wall -O2 -fPIC -o libuclibc-compat.so uclibc-compat.c
$ readelf -sW --syms libuclibc-compat.so | grep ctype_tolower_data
    37: 00000cc8   768 OBJECT  LOCAL  DEFAULT   11 __uclibc_ctype_tolower_data
```

## What this does not close

Worth stating plainly, since #1992's checklist implies otherwise:

- The `struct stat` / `off_t` roadmap items are **not** fixed here and cannot be
  fixed by a shipped `.so`. Overriding `stat`/`mmap` process-wide would break
  musl's own callers; it has to happen in the executable via the static shim,
  per-consumer. hi3516cv100 and hi3520dv200 already do this.
- `__ctype_tolower` is exported with the uclibc layout, so a glibc-built blob
  (`rockchip-osdrv-rv11xx`) linking this shim would want the `int32_t` variant
  instead. Noted at the definition; no such consumer exists today.
- The MIPS build of the shim was not compiled locally (no MIPS musl toolchain
  to hand). It is arch-independent C and builds on ARM and aarch64.
- Newly surfaced and *not* addressed here, since they are outside the agreed
  scope: `strtouq` (novatek), `pthread_rwlockattr_setkind_np` (grainmedia),
  `__expf_finite`/`__log_finite` (infinity6e), the LFS64 aliases and
  `gnu_dev_major`/`minor` (rv11xx), `backtrace` (infinity6c).

## Scope

- [x] No kernel patches under `general/package/all-patches/linux/`
- [x] No files specific to a single retail camera model
- [x] No probing or bring-up tooling
- [x] Nothing under `general/overlay/` or in a shared `load_<vendor>` script hardcodes a value specific to my board
- [x] Package sources come from an OpenIPC repository, and any version bump keeps at least the specificity of the pin it replaces
- [x] No `LD_PRELOAD`, and no binaries that cannot be rebuilt from source
- [ ] New code is selected by a defconfig, so CI actually builds it — the shim additions reach CI through the SDK bundling step on any board whose osdrv package exists, not through a defconfig symbol

🤖 Generated with [Claude Code](https://claude.com/claude-code)
