### PR TITLE
qodo-gate: say the initial red clears by itself

### DIFF
--- a/.github/workflows/qodo-gate.yml
+++ b/.github/workflows/qodo-gate.yml
@@ -152,11 +152,25 @@ jobs:
               | select(.body | test(\"Code Review by Qodo\"; \"i\"))
               | .id" | wc -l)
 
+          # Every PR hits this branch once: this run fires at `opened`, before
+          # Qodo has answered. That is not an error state, and the wording
+          # must not read like one — when Qodo's review lands, its comment
+          # re-triggers this gate and the passing run re-runs this failed one,
+          # so the check turns green with no action from anyone (observed
+          # 2-10 minutes on #2273/#2274/#2275, every one via re-run attempt 2).
+          # Only a much longer red deserves a human's attention.
           if [ "$reviewed" -eq 0 ] && [ "$commented" -eq 0 ]; then
-            echo "FAIL: no Qodo review on this PR yet — it reviews new PRs"
-            echo "automatically within a couple of minutes; comment /review to"
-            echo "summon one, then re-run this check once it answers. (Outage?"
-            echo "Apply the skip-qodo-gate label.)"
+            echo "EXPECTED RED: Qodo has not posted its review yet."
+            echo ""
+            echo "This is the normal state right after a PR is opened or updated."
+            echo "No action is needed: when Qodo's review lands (usually within"
+            echo "2-10 minutes), this check re-evaluates and turns green by"
+            echo "itself. You do not need to re-run it."
+            echo ""
+            echo "Still red after ~20 minutes? Then intervene:"
+            echo "  - comment '/review' on the PR to summon Qodo again"
+            echo "  - if Qodo is down, a maintainer can apply the"
+            echo "    'skip-qodo-gate' label, which passes this check"
             exit 1
           fi
           echo "review found: $reviewed review object(s), $commented review comment(s)"


### PR DESCRIPTION
## Problem

Every PR now goes through the same lifecycle, confirmed on all four PRs landed since the `issue_comment` trigger merged:

| PR | red window | how it went green |
|---|---|---|
| #2273 | ~10 min | self-heal, re-run attempt 2 (runner queue ate most of it) |
| #2274 | ~2 min | self-heal, re-run attempt 2 |
| #2275 | ~6 min | self-heal, re-run attempt 2 |
| #2277 | ~8 h | correctly held red — it had findings; green after threads were resolved |

So the *first thing every contributor sees* is a failed required check whose message reads like a terminal error and instructs them to comment `/review` and re-run the check by hand — both of which the gate does itself moments later. Anyone following those instructions would see green arrive and credit the manual steps, learning a superstition on their first PR.

## Fix

The initial failure message now leads with `EXPECTED RED`, states that the check re-evaluates and turns green on its own (usually 2–10 minutes, the observed range), and moves the manual steps behind a "still red after ~20 minutes?" threshold where they belong.

The unresolved-threads message is untouched: in that state action genuinely is required, and #2277 shows the gate holding red for it correctly.

## Evidence

Message-only change inside an `echo` block; no logic touched. Workflow parses. The behaviour it describes is not aspirational — it is the observed record of every PR above, each going green via re-run attempt 2 with no human intervention.

Verification after merge: the next clean PR's failed initial run should show the new wording (this PR's own initial red still shows the old text — the failing run is the one from before the merge, which is exactly the situation the message describes).

## Scope

- [x] No kernel patches, no single-board files, no debugging tooling
- [x] Nothing under `general/overlay/`; no package sources changed
- [x] No code — CI workflow message only, does not enter any image

🤖 Generated with [Claude Code](https://claude.com/claude-code)
