### PR TITLE
ci: carry the publish hardening back from builder

### DIFF
--- a/.github/scripts/ci-matrix.py
+++ b/.github/scripts/ci-matrix.py
@@ -21,7 +21,8 @@ and nothing selects uclibc-compat (hisilicon-osdrv-hi3516cv100.mk depends on
 it), so dropping either kind would resolve a real package to zero boards.
 
 Usage:
-    ci-matrix.py               # read GitHub Actions env, write $GITHUB_OUTPUT
+    ci-matrix.py               # read GitHub Actions env; append to $GITHUB_OUTPUT
+                               # when it is set, otherwise print the same lines
     ci-matrix.py --stdin       # read a file list on stdin, print the decision
     ci-matrix.py --self-test   # check this file still agrees with the tree
 """
@@ -809,9 +810,24 @@ def main():
     for board in decision["rows"]:
         print(f"  {board}", file=sys.stderr)
 
-    print(f"matrix={json.dumps(decision['matrix'], separators=(',', ':'))}")
-    print(f"needs-build={str(decision['needs_build']).lower()}")
-    print(f"reason={decision['reason']}")
+    lines = [
+        f"matrix={json.dumps(decision['matrix'], separators=(',', ':'))}",
+        f"needs-build={str(decision['needs_build']).lower()}",
+        f"reason={decision['reason']}",
+    ]
+    # Write $GITHUB_OUTPUT here rather than having the workflow redirect stdout
+    # into it. Under a redirect every print() in this file is one keystroke away
+    # from corrupting the step outputs, and a crash between the first line and
+    # the last leaves a half-written file that Actions still reads. Diagnostics
+    # go to stderr precisely so that cannot happen -- which is a rule that has
+    # to hold forever to stay safe, instead of a property of the code.
+    # Falls back to stdout so a local run still shows what it decided.
+    destination = None if args.stdin else os.environ.get("GITHUB_OUTPUT")
+    if destination:
+        with open(destination, "a") as handle:
+            handle.write("\n".join(lines) + "\n")
+    else:
+        print("\n".join(lines))
     return 0
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         name: Pick the affected boards
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python3 .github/scripts/ci-matrix.py >> ${GITHUB_OUTPUT}
+        run: python3 .github/scripts/ci-matrix.py
 
   preflight:
     name: Preflight
@@ -313,7 +313,15 @@ jobs:
     permissions:
       contents: write
     steps:
+      # continue-on-error only so that a matrix where every board failed --
+      # and therefore uploaded no fw-* artifact at all -- does not hard-fail
+      # here before the gate can report why. Collect below turns that back
+      # into a failure for every other case; without it, a broken download
+      # produced an empty dist/, the count guard skipped publishing, and the
+      # nightly went green having published nothing. Found by review on
+      # OpenIPC/builder#121, whose publish job this one seeded.
       - name: Download build artifacts
+        id: download
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
@@ -325,10 +333,29 @@ jobs:
         id: collect
         run: |
           mkdir -p dist
-          count=$(find dist -type f | wc -l)
+          # tr because wc pads its output on some platforms (BSD does, the
+          # GNU coreutils on the runner does not) and a padded "     0" would
+          # read as non-empty to the `!= '0'` guard below.
+          count=$(find dist -type f | wc -l | tr -d '[:space:]')
           echo "Collected ${count} asset(s):"
           ls -la dist || true
           echo "count=${count}" >> "$GITHUB_OUTPUT"
+
+          # A matrix that went green must have produced artifacts. Zero assets
+          # after that means the download failed, not that there was nothing
+          # to publish.
+          if [ "${{ needs.buildroot.result }}" = "success" ]; then
+            if [ "${{ steps.download.outcome }}" != "success" ]; then
+              echo "::error::artifact download failed after a fully successful matrix"
+              exit 1
+            fi
+            if [ "${count}" -eq 0 ]; then
+              echo "::error::no artifacts collected although every board built"
+              exit 1
+            fi
+          elif [ "${count}" -eq 0 ]; then
+            echo "::notice::matrix failed and produced nothing; no release to write"
+          fi
 
       # Drive the release writes ourselves instead of softprops/action-gh-release.
       # That action uploads assets CONCURRENTLY with no throttle/retry knob, so
@@ -419,16 +446,25 @@ jobs:
             "$BUILD_ID" "${#DATED[@]}" "$HEAD_SHA" "$BUILT_AT" > dist/_manifest.json
           gh_retry gh release upload "$BUILD_ID" dist/_manifest.json --clobber
 
-          # --- rolling nightly: move tag + body to this build, refresh images ---
-          ensure_release nightly
-          gh_retry gh release edit nightly --notes "$NOTES"
-          gh_retry gh api -X PATCH "repos/${GH_REPO}/git/refs/tags/nightly" -f sha="$HEAD_SHA" -F force=true
-          upload_paced nightly "${IMAGES[@]}"
+          # nightly and latest only ever move when there is firmware to move
+          # them to. dist/ can be sidecars and no images -- one board that
+          # produced a size report and no .tgz is enough -- and pointing the
+          # two tags flashers pull from at a build with no images behind them
+          # is worse than leaving them on yesterday's.
+          if [ "${#IMAGES[@]}" -eq 0 ]; then
+            echo "::warning::no images in this build; leaving nightly and latest where they are"
+          else
+            # --- rolling nightly: move tag + body to this build, refresh images ---
+            ensure_release nightly
+            gh_retry gh release edit nightly --notes "$NOTES"
+            gh_retry gh api -X PATCH "repos/${GH_REPO}/git/refs/tags/nightly" -f sha="$HEAD_SHA" -F force=true
+            upload_paced nightly "${IMAGES[@]}"
 
-          # --- latest: legacy alias ---
-          ensure_release latest
-          gh_retry gh api -X PATCH "repos/${GH_REPO}/git/refs/tags/latest" -f sha="$HEAD_SHA" -F force=true
-          upload_paced latest "${IMAGES[@]}"
+            # --- latest: legacy alias ---
+            ensure_release latest
+            gh_retry gh api -X PATCH "repos/${GH_REPO}/git/refs/tags/latest" -f sha="$HEAD_SHA" -F force=true
+            upload_paced latest "${IMAGES[@]}"
+          fi
 
   # Single umbrella status check that reflects the whole build matrix, so the
   # branch-protection required-checks list does not need one hardcoded


### PR DESCRIPTION
Review on OpenIPC/builder#121 found two holes in its publish job. That job was seeded from this one — and both holes are still here, where they matter more: this nightly is the one `sysupgrade` users flash from daily.

## 1. A failed artifact download published nothing and stayed green

The download runs with `continue-on-error: true`, so a transient failure produced an empty `dist/`, the count guard skipped publishing, the job succeeded, and `CI Gate` accepts `publish=success`.

The flag **stays** — it is load-bearing for exactly one case: a matrix where every board failed uploads no `fw-*` artifact at all, and a hard download failure there would mask the real reason. `Collect assets` now turns it back into a failure everywhere else:

| matrix | download | assets | outcome |
|---|---|---|---|
| success | failed | — | **error** (was: green) |
| success | ok | 0 | **error** (was: green) |
| failure | — | 0 | tolerated; gate fails on the matrix result |
| success | ok | >0 | publishes |

## 2. `nightly`/`latest` could be force-moved to a build with no firmware behind them

The tag moves were unconditional once *any* asset existed — and `dist/` can hold sidecars and no images (one board producing a `sizes.*.json` and no `.tgz` is enough). Both tags now move only when `IMAGES` is non-empty; otherwise they stay on yesterday's build, with a warning.

Also normalised the count through `tr`. On the runner's GNU coreutils `wc` does not pad — that's BSD behaviour, so this wasn't exploitable here — but the guard shouldn't depend on which `wc` is in front of it.

## 3. `ci-matrix.py` owns `$GITHUB_OUTPUT`

Same docstring inaccuracy flagged on builder: it claimed to write `$GITHUB_OUTPUT` while printing to stdout and relying on the workflow to redirect. Under a redirect every `print()` is one keystroke away from corrupting the step outputs, and a mid-run crash leaves a half-written file Actions still reads. The script now appends to `$GITHUB_OUTPUT` itself when set, prints when not, and `--stdin` never touches the file.

## Testing

None of the publish path can run on a pull request, so: all four collect states and all four output paths verified offline (the two previously-green failure states now fail), YAML parses, `--self-test` green. This PR touches `ci-matrix.py`, so it correctly runs the full 96-board matrix — and tonight's 22:30 UTC nightly is the first live pass over the new publish logic if this merges before then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
