### PR TITLE
sysupgrade: stop the ramfs pivot leaving debris in the overlay

### DIFF
--- a/.github/scripts/test_sysupgrade.sh
+++ b/.github/scripts/test_sysupgrade.sh
@@ -950,6 +950,13 @@ grep -qF 'rmdir "/mnt$RAM_ROOT"' "$SRC" \
 grep -qE '^case "\$RAM_ROOT" in /\*\)' "$SRC" \
     && ok "a relative RAM_ROOT override is normalised to an absolute path" \
     || bad "RAM_ROOT is used as \"/mnt\$RAM_ROOT\" and matched against /proc/mounts; it must be absolute"
+# That rmdir runs AFTER the pivot, where the applet symlinks are the only tools
+# there are. `busybox --list` is a build option, so on a camera without it the
+# hardcoded fallback list is the whole toolbox -- an applet missing from it is
+# simply "not found", and a cleanup that fails is one that silently did nothing.
+awk '/^enter_ramfs\(\)/,/^}/' "$SRC" | awk '/for applet in sh ash/,/done/' | grep -qw 'rmdir' \
+    && ok "the fallback applet list stages rmdir for the ramfs phase" \
+    || bad "the ramfs phase runs rmdir, but a busybox without --list would not have that applet"
 awk '/^enter_ramfs\(\)/,/^}/' "$SRC" | grep -q 'export remote_update' \
     && ok "remote_update survives the re-exec (verify_rootfs branches on it)" \
     || bad "remote_update is not exported; an unmountable rootfs behaves differently in phase 2"

--- a/.github/scripts/test_sysupgrade.sh
+++ b/.github/scripts/test_sysupgrade.sh
@@ -797,6 +797,24 @@ else
     bad "--no_ramfs -> expected no pivot but a normal flash, log='$(cat "$SB/tmp/flash.log")'"
 fi
 
+# A pivot that did not happen must still hand the old root back as it found it.
+# The shipped rootfs has no /ram, so the directory enter_ramfs makes lands in the
+# overlay's upper layer and stays there: every upgrade since the pivot landed
+# left a stray /overlay/root/ram behind (OpenIPC/majestic-webui#120).
+#
+# rmdir is stubbed rather than left real because this sandbox fakes `mount` --
+# nothing was ever mounted on $SB/ram, so it still holds the staged busybox tree
+# and a real rmdir would rightly refuse to remove it.
+stub rmdir 'echo "rmdir $*" >> "$FLASH_LOG"; exit 0'
+reset_env
+run -z --kernel="$K" --rootfs="$R"
+if grep -q "^rmdir .*/ram$" "$SB/tmp/flash.log"; then
+    ok "a pivot that failed reclaims its ramfs mount point"
+else
+    bad "failed pivot left RAM_ROOT behind, log='$(cat "$SB/tmp/flash.log")'"
+fi
+rm -f "$SB/bin/rmdir"
+
 # ---------------------------------------------------------------------------
 echo
 echo "=== Part 2: invariants in $SRC ==="
@@ -887,6 +905,45 @@ guarded=$(awk '/^enter_ramfs\(\)/,/^}/' "$SRC" | awk '/mount -o move \/dev/,0' |
 [ "$guarded" -ge 1 ] && [ "$bare" -le "$guarded" ] \
     && ok "no unguarded return between the mount moves and the pivot" \
     || bad "$bare return(s) after the moves but only $guarded unwind(s)"
+# A shell redirection CREATES its target. Between the /dev move and the pivot the
+# name /dev/null resolves inside the OLD root, which has no such node -- devtmpfs
+# supplied it, and devtmpfs has just been moved away. So `2>/dev/null` there does
+# not discard the error, it writes a regular file named `null` into that root.
+# The root is an overlay, so the file lands in the upper layer and outlives the
+# upgrade: cameras on four SoCs came back from a clean flash carrying a 0600
+# /overlay/root/dev/null (OpenIPC/majestic-webui#120).
+window=$(awk '/^enter_ramfs\(\)/,/^}/' "$SRC" | awk '/mount -o move \/dev/,/pivot_root/')
+printf '%s\n' "$window" | grep -q '>/dev/null' \
+    && bad "enter_ramfs names /dev/null after moving /dev away -- that CREATES the file" \
+    || ok "nothing between the /dev move and the pivot names /dev/null"
+printf '%s\n' "$window" | grep -q '2>&3' \
+    && ok "the window between the /dev move and the pivot redirects to fd 3" \
+    || bad "post-move redirections must name a descriptor, not a path"
+# ramfs_unwind is reached from inside that same window -- putting /dev back is
+# what it exists for -- so it cannot name /dev/null either.
+awk '/^ramfs_unwind\(\)/,/^}/' "$SRC" | grep -q '>/dev/null' \
+    && bad "ramfs_unwind names /dev/null while /dev may still be moved away" \
+    || ok "ramfs_unwind never names /dev/null in a redirection"
+# ...and the descriptor only means anything if it was opened while /dev was still
+# the devtmpfs, i.e. at the top level, before enter_ramfs can run.
+grep -qE '^[^[:space:]].*exec 3>' "$SRC" \
+    && ok "fd 3 is opened at the top level, while /dev is still the devtmpfs" \
+    || bad "fd 3 must be opened before enter_ramfs starts relocating /dev"
+# The mount point is the other half of the same leak: the shipped rootfs has no
+# /ram, so `mkdir -p "$RAM_ROOT"` writes a directory into the overlay's upper
+# layer, and nothing used to take it back out.
+awk '/^ramfs_discard\(\)/,/^}/' "$SRC" | grep -q 'rmdir' \
+    && ok "ramfs_discard reclaims the mount point enter_ramfs created" \
+    || bad "nothing removes RAM_ROOT; the overlay gains an empty /ram per upgrade"
+awk '/^ramfs_discard\(\)/,/^}/' "$SRC" | grep -q 'rm -rf' \
+    && bad "ramfs_discard must not recursively delete a root the flash may still run from" \
+    || ok "ramfs_discard removes an empty directory only (rmdir, never rm -rf)"
+awk '/^ramfs_discard\(\)/,/^}/' "$SRC" | grep -qF '^tmpfs $RAM_ROOT tmpfs' \
+    && ok "ramfs_discard only detaches a tmpfs of its own" \
+    || bad "RAM_ROOT is overridable; an unconditional umount could detach real storage"
+grep -qF 'rmdir "/mnt$RAM_ROOT"' "$SRC" \
+    && ok "the ramfs phase reclaims the mount point stranded in the old root" \
+    || bad "after the pivot nothing removes the old root's RAM_ROOT"
 awk '/^enter_ramfs\(\)/,/^}/' "$SRC" | grep -q 'export remote_update' \
     && ok "remote_update survives the re-exec (verify_rootfs branches on it)" \
     || bad "remote_update is not exported; an unmountable rootfs behaves differently in phase 2"

--- a/.github/scripts/test_sysupgrade.sh
+++ b/.github/scripts/test_sysupgrade.sh
@@ -944,6 +944,12 @@ awk '/^ramfs_discard\(\)/,/^}/' "$SRC" | grep -qF '^tmpfs $RAM_ROOT tmpfs' \
 grep -qF 'rmdir "/mnt$RAM_ROOT"' "$SRC" \
     && ok "the ramfs phase reclaims the mount point stranded in the old root" \
     || bad "after the pivot nothing removes the old root's RAM_ROOT"
+# ...and that "/mnt$RAM_ROOT" only names the right directory if RAM_ROOT is
+# absolute. It is overridable from the environment, and a relative one would
+# also defeat the /proc/mounts check, which records mount points absolutely.
+grep -qE '^case "\$RAM_ROOT" in /\*\)' "$SRC" \
+    && ok "a relative RAM_ROOT override is normalised to an absolute path" \
+    || bad "RAM_ROOT is used as \"/mnt\$RAM_ROOT\" and matched against /proc/mounts; it must be absolute"
 awk '/^enter_ramfs\(\)/,/^}/' "$SRC" | grep -q 'export remote_update' \
     && ok "remote_update survives the re-exec (verify_rootfs branches on it)" \
     || bad "remote_update is not exported; an unmountable rootfs behaves differently in phase 2"

--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -621,8 +621,8 @@ enter_ramfs() {
 	done
 	# --list is a build option; fall back to what the flash phase actually uses.
 	for applet in sh ash awk basename cat cut dd flash_eraseall flashcp grep \
-		head ln losetup ls mkdir mount od printf reboot rm sed sleep sync \
-		tail timeout umount xxd; do
+		head ln losetup ls mkdir mount od printf reboot rm rmdir sed sleep \
+		sync tail timeout umount xxd; do
 		[ -e "$RAM_ROOT/bin/$applet" ] || ln -sf busybox "$RAM_ROOT/bin/$applet" 2>/dev/null
 	done
 	# If the essentials are not there, the ramfs is worse than useless: better to

--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -8,6 +8,13 @@ LOCK_FILE=/tmp/sysupgrade.lock
 # under /tmp: /tmp is moved into it, and a mount cannot be relocated under
 # itself. See enter_ramfs.
 RAM_ROOT=${RAM_ROOT:-/ram}
+# Absolute, always. Two things downstream assume it: /proc/mounts records mount
+# points absolutely, so the "is this tmpfs ours" check would never match a
+# relative path; and the second phase reaches this same directory through the
+# old root as "/mnt$RAM_ROOT", which a missing leading slash turns into
+# "/mntram". Both would fail quietly, so normalise an override rather than
+# trusting whoever set it.
+case "$RAM_ROOT" in /*) ;; *) RAM_ROOT="/$RAM_ROOT" ;; esac
 # A writable descriptor on the real /dev/null, opened once while /dev is still
 # certainly the devtmpfs.
 #

--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -1,6 +1,6 @@
 #!/bin/sh
 # OpenIPC.org | 2025
-scr_version=1.0.57
+scr_version=1.0.58
 
 args="$@"
 LOCK_FILE=/tmp/sysupgrade.lock
@@ -8,6 +8,23 @@ LOCK_FILE=/tmp/sysupgrade.lock
 # under /tmp: /tmp is moved into it, and a mount cannot be relocated under
 # itself. See enter_ramfs.
 RAM_ROOT=${RAM_ROOT:-/ram}
+# A writable descriptor on the real /dev/null, opened once while /dev is still
+# certainly the devtmpfs.
+#
+# enter_ramfs moves /dev out of the old root and then keeps running there for a
+# few more commands. A shell redirection CREATES its target, so a plain
+# `2>/dev/null` in that window discards nothing — it writes a regular file named
+# `null` into the old root's now-empty /dev. That root is an overlay, so the file
+# lands in the upper layer and outlives the upgrade: cameras came back from a
+# perfectly good flash carrying a 0600 /overlay/root/dev/null which shadows the
+# character device on every boot until /init moves devtmpfs back over it
+# (OpenIPC/majestic-webui#120). Reported on four SoCs at once, and absent from
+# every camera old enough to predate the ramfs pivot.
+#
+# A descriptor names the inode, not the path, so it keeps working across the
+# mount move, the pivot and the exec. Guarded and given a fallback because `exec`
+# is a special builtin: a redirection it cannot satisfy takes the script down.
+if [ -c /dev/null ]; then exec 3>/dev/null; else exec 3>&2; fi
 # Seconds the rootfs verify-mount may take before it is treated as unmountable.
 mount_wait=${mount_wait:-45}
 # Seconds the operator gets to Ctrl-C out of a run that will force a reboot.
@@ -448,6 +465,28 @@ restore_resources() {
 	return 0
 }
 
+# Give the old root back its mount point.
+#
+# The shipped rootfs has no /ram, so the `mkdir -p "$RAM_ROOT"` in enter_ramfs
+# writes a new directory into the overlay's upper layer — and nothing ever took
+# it out again, so every upgrade that used the pivot left an empty
+# /overlay/root/ram behind for good (OpenIPC/majestic-webui#120).
+#
+# rmdir, never `rm -rf`: if the tmpfs is somehow still attached — a lazy umount
+# that has not completed, a staged root the flash is still executing from —
+# rmdir fails harmlessly where a recursive delete would pull the floor out from
+# under the flash. An empty directory is all there is to remove.
+ramfs_discard() {
+	# Only ever detach a tmpfs of our own. RAM_ROOT is overridable from the
+	# environment (the test harness relies on that), so an unconditional umount
+	# would happily detach real storage if it were pointed at some — the same
+	# care the stale-mount check in enter_ramfs takes, for the same reason.
+	if grep -q "^tmpfs $RAM_ROOT tmpfs" /proc/mounts 2>&3; then
+		umount "$RAM_ROOT" 2>&3
+	fi
+	rmdir "$RAM_ROOT" 2>&3
+}
+
 # Everything from the first flash write onwards runs on borrowed time.
 #
 # flashcp rewrites the MTD partition that backs the mounted squashfs rootfs, and
@@ -478,17 +517,26 @@ restore_resources() {
 # the RUNNING camera with no device nodes at all -- worse than the bug the pivot
 # fixes. Moves that never happened fail harmlessly, so this is safe to call from
 # any failure point after the first one.
+#
+# Every redirection from here to the end of the function goes to fd 3 rather
+# than to /dev/null by name: this runs precisely when /dev may already have been
+# moved away, which is when writing to that name creates a file instead of
+# discarding output. See the note beside the `exec 3>` at the top.
 ramfs_unwind() {
-	cd / 2>/dev/null
-	mount -o move "$RAM_ROOT/tmp" /tmp 2>/dev/null
-	mount -o move "$RAM_ROOT/proc" /proc 2>/dev/null
-	mount -o move "$RAM_ROOT/dev" /dev 2>/dev/null
-	mount -o move "$RAM_ROOT/sys" /sys 2>/dev/null
+	cd / 2>&3
+	mount -o move "$RAM_ROOT/tmp" /tmp 2>&3
+	mount -o move "$RAM_ROOT/proc" /proc 2>&3
+	mount -o move "$RAM_ROOT/dev" /dev 2>&3
+	mount -o move "$RAM_ROOT/sys" /sys 2>&3
 	# Lazy as a fallback: /sys carries submounts (debugfs, configfs) and a
 	# move-back that does not take leaves the tmpfs busy. Observed on an ssc30kq,
 	# where the plain umount left /ram mounted -- harmless on its own, but a
 	# retry would stack a second tmpfs on top of it.
-	umount "$RAM_ROOT" 2>/dev/null || umount -l "$RAM_ROOT" 2>/dev/null
+	umount "$RAM_ROOT" 2>&3 || umount -l "$RAM_ROOT" 2>&3
+	# The mount point itself is left for the caller to reclaim: every path that
+	# runs this one ends in `return 1` out of enter_ramfs, and that is where
+	# ramfs_discard lives, so removing it here as well would just be a second
+	# owner for the same directory.
 
 	# Restoring is attempted, not guaranteed, so check it rather than assume it.
 	# Handing the in-place path an environment without /dev or /proc is the very
@@ -500,7 +548,7 @@ ramfs_unwind() {
 	# Deliberately not reboot_system(): -x must not be honoured here, and there
 	# is no state left worth tidying.
 	if [ ! -c /dev/null ] || [ ! -r /proc/mounts ] ||
-		! grep -q " /tmp " /proc/mounts 2>/dev/null; then
+		! grep -q " /tmp " /proc/mounts 2>&3; then
 		echo_c 31 "\nCould not restore /dev, /proc or /tmp after a failed pivot."
 		echo_c 31 "Rebooting instead of flashing in a broken environment."
 		echo_c 31 "Nothing was written; the camera comes back on its current firmware."
@@ -581,10 +629,15 @@ enter_ramfs() {
 	# Carry over the mounts the flash still needs: /dev for the MTD nodes, /proc
 	# for get_device and sysrq, /tmp for the unpacked images. Moving rather than
 	# binding leaves nothing pointing back into the old root.
-	mount -o move /dev "$RAM_ROOT/dev" 2>/dev/null || { ramfs_unwind; return 1; }
-	mount -o move /proc "$RAM_ROOT/proc" 2>/dev/null || { ramfs_unwind; return 1; }
-	mount -o move /tmp "$RAM_ROOT/tmp" 2>/dev/null || { ramfs_unwind; return 1; }
-	mount -o move /sys "$RAM_ROOT/sys" 2>/dev/null
+	#
+	# /dev goes first and takes the devtmpfs with it, so from here until the pivot
+	# the name /dev/null resolves inside the old root, where there is no such node
+	# — every redirection below therefore goes to fd 3 instead. See the `exec 3>`
+	# at the top of the script.
+	mount -o move /dev "$RAM_ROOT/dev" 2>&3 || { ramfs_unwind; return 1; }
+	mount -o move /proc "$RAM_ROOT/proc" 2>&3 || { ramfs_unwind; return 1; }
+	mount -o move /tmp "$RAM_ROOT/tmp" 2>&3 || { ramfs_unwind; return 1; }
+	mount -o move /sys "$RAM_ROOT/sys" 2>&3
 
 	# State the second phase cannot recompute once the old root is behind it.
 	# NOT _ramfs_phase: that one is set only after the pivot has actually
@@ -603,7 +656,7 @@ enter_ramfs() {
 	cd "$RAM_ROOT" || { ramfs_unwind; return 1; }
 	# After this the old root is at ./mnt and still mounted — deliberately: the
 	# MTD partitions are addressed through /dev, not through it.
-	if ! pivot_root . mnt 2>/dev/null; then
+	if ! pivot_root . mnt 2>&3; then
 		ramfs_unwind
 		return 1
 	fi
@@ -1017,6 +1070,13 @@ done
 # the writes; flash_and_reboot never returns.
 if [ "1" = "$_ramfs_phase" ]; then
 	echo_c 34 "Flashing from RAM (pid $$)"
+	# pivot_root detached the tmpfs from the old root's $RAM_ROOT and parked that
+	# root at /mnt, so what is left there is the bare mount point enter_ramfs
+	# created — an empty directory in the overlay's upper layer that nothing will
+	# ever read again. Take it back now, while there is still a filesystem under
+	# /mnt to take it from: the first flashcp write is a few lines away and the
+	# old root does not survive it (OpenIPC/majestic-webui#120).
+	rmdir "/mnt$RAM_ROOT" 2>/dev/null
 	flash_and_reboot
 fi
 
@@ -1081,5 +1141,13 @@ echo_c 37 "\nProtected: flashing continues even if this terminal disconnects."
 # On success this never comes back — the rest runs in the re-exec'd process
 # inside the ramfs. A camera that cannot give us one still has to upgrade, so a
 # failure here falls through and flashes in place exactly as before.
-enter_ramfs
+if ! enter_ramfs; then
+	# The pivot did not take, so the in-place flash below needs none of what was
+	# staged for it. enter_ramfs bails out from a dozen places and cannot tidy up
+	# from inside each one, so the single path that means "no pivot" does it:
+	# otherwise a camera that merely FAILED to move into RAM was still left with
+	# the mount point, and on the earliest bail-outs with a tmpfs on it too.
+	# ramfs_unwind may already have done both, in which case this is a no-op.
+	ramfs_discard
+fi
 flash_and_reboot


### PR DESCRIPTION
Reported by @usa- in OpenIPC/majestic-webui#120: cameras upgraded since the ramfs pivot landed come back carrying two entries nothing put there on purpose, on four SoCs at once.

```
/overlay/root/dev/null
/overlay/root/ram/
```

His guess in the report was right — *"something is writing to `/dev/null` (like `2>/dev/null`) while it has not yet been created or is no longer available."*

## `/dev/null`

A shell redirection **creates** its target. `enter_ramfs` moves `/dev` — the devtmpfs that supplied the node — out of the old root, and then keeps running there for four more commands. Every `2>/dev/null` in that window therefore discards nothing; it writes a regular file named `null` into a directory the shipped rootfs leaves empty. That root is an overlay, so the file lands in the upper layer and outlives the upgrade.

The mode is the fingerprint. Root's umask on the camera is `0077`, and the artifact is `0600` — exactly what `open(O_CREAT, 0666)` yields:

```
# ls -l /overlay/root/dev/null
-rw-------    1 root     root             0 Aug 16 09:59 /overlay/root/dev/null
```

`/rom/dev` ships no `null` node at all, so there is nothing for overlayfs to have copied up — the file is new.

Holding a descriptor open on the real node survives the mount move, the pivot and the exec, because a descriptor names the inode rather than the path. Reproduced **both ways on real hardware with no flash writes**, by moving `/dev` aside and putting it back:

| inside the window | result |
|---|---|
| `2>/dev/null` (old) | creates `-rw-------` regular file |
| `2>&3` (new) | creates nothing, still discards |

## `/ram`

The mount point itself. The rootfs ships no `/ram`, so `mkdir -p "$RAM_ROOT"` writes it into the upper layer, and nothing ever removed it — not after a successful pivot, not after a failed one, and not after the early bail-outs, which leave a tmpfs mounted on it as well.

Reclaimed on each path now. After the pivot the old root sits at `/mnt` with the tmpfs already detached, so the second phase takes it back before the first `flashcp` write destroys the filesystem it lives on; the single `enter_ramfs` call site covers every bail-out. `rmdir`, never `rm -rf` — if the tmpfs is somehow still attached, refusing is the right answer.

## Impact

Neither artifact is dangerous *today*: `/init` moves devtmpfs back over `/dev` early enough that nothing has been observed writing through the file. But it is a silent write to flash on every upgrade, and a trap for anyone who later adds a redirection to `/init` between its own `pivot_root` and its `mount -o move /rom/dev /dev`.

## Verification

End to end on the lab hi3516av300, with the patched script and the artifacts cleared first:

```
2.6.08.15 -> 2.6.08.16, clean reboot
/overlay/root/dev/   empty
/overlay/root/ram    No such file or directory
```

`test_sysupgrade.sh` gains one behavioural check (a failed pivot reclaims its mount point) and seven source invariants covering the redirect window, `ramfs_unwind`, where fd 3 is opened, and `rmdir`-not-`rm -rf`. Both halves fail the suite when reverted:

```
FAIL failed pivot left RAM_ROOT behind
FAIL enter_ramfs names /dev/null after moving /dev away -- that CREATES the file
```

`scr_version` is bumped to 1.0.58 so `self_update` actually delivers this — it compares versions, so reusing 1.0.57 would never install on a running camera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)