### PR TITLE
build: strip shell comments out of the rootfs, not out of the tree

### DIFF
--- a/.github/scripts/test_strip_shell_comments.sh
+++ b/.github/scripts/test_strip_shell_comments.sh
@@ -1,0 +1,226 @@
+#!/bin/bash
+# Tests for general/scripts/strip-shell-comments.awk, the build-time pass that
+# drops whole-line comments from every shell script before it is flashed.
+#
+# The transform runs on 129 scripts that nobody re-reads after the build, so a
+# wrong edit here is a corrupted rootfs that still builds green: a mangled
+# load_hisilicon is a camera that boots to no video, and the comments are gone
+# from the shipped copy, so the file on the device does not even read like the
+# one in git. Cheap to test, expensive to get wrong.
+#
+# Three constructs look like a comment line and are not, and each is a way to
+# silently change what a script DOES:
+#
+#   heredoc bodies      the `#` is data the script writes out
+#   multi-line strings  VAR="...\n# still the string\n..."
+#   continuations       `foo \` splices the next line on, so a following
+#                       `#...` is an argument, not a comment
+#
+# Part 1 pins each of those with a fixture. Part 2 is the broader claim -- that
+# stripping changes no shipped script's syntax -- checked by parsing all of them
+# before and after with the busybox ash the device runs.
+
+set -u
+
+STRICT=${STRICT:-0}
+
+AWK_SCRIPT=${AWK_SCRIPT:-general/scripts/strip-shell-comments.awk}
+
+fail=0
+ok()   { echo "ok   $*"; }
+bad()  { echo "FAIL $*"; fail=$((fail + 1)); }
+note() { echo "--   $*"; }
+
+[ -f "$AWK_SCRIPT" ] || { echo "FAIL cannot find $AWK_SCRIPT — run me from the repo root"; exit 1; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+strip() { awk -f "$AWK_SCRIPT" "$1"; }
+
+# ---------------------------------------------------------------------------
+# Part 1 — the constructs a naive `/^[[:space:]]*#/d` gets wrong.
+# ---------------------------------------------------------------------------
+
+cat > "$WORK/fixture.sh" <<'FIXTURE'
+#!/bin/sh
+# GONE plain comment
+    # GONE indented comment
+echo one   # LIVE trailing comment rides along with its code line
+cat <<EOF
+# LIVE heredoc body
+EOF
+cat <<-'QUOTED'
+	# LIVE tab-heredoc body
+	QUOTED
+VAR="first
+# LIVE inside a double-quoted string
+last"
+SQ='first
+# LIVE inside a single-quoted string
+last'
+echo two \
+# LIVE spliced onto the continuation above
+echo three
+FIXTURE
+
+strip "$WORK/fixture.sh" > "$WORK/fixture.out"
+
+if grep -q GONE "$WORK/fixture.out"; then
+	bad "a plain comment line survived stripping"
+else
+	ok "plain and indented comment lines are dropped"
+fi
+
+live=$(grep -c LIVE "$WORK/fixture.out")
+if [ "$live" = 6 ]; then
+	ok "heredoc bodies, multi-line strings and continuations are left alone (6/6)"
+else
+	bad "expected 6 LIVE lines to survive, got $live"
+	diff "$WORK/fixture.sh" "$WORK/fixture.out"
+fi
+
+if [ "$(head -1 "$WORK/fixture.out")" = '#!/bin/sh' ]; then
+	ok "the shebang survives"
+else
+	bad "the shebang was stripped — every script would lose its interpreter"
+fi
+
+# A herestring has no terminator line. Mistaking it for a heredoc would make the
+# stripper swallow the entire rest of the file as an unterminated body.
+cat > "$WORK/herestring.sh" <<'HERESTRING'
+#!/bin/bash
+grep x <<<"inline"
+# GONE after a herestring
+echo end
+HERESTRING
+
+strip "$WORK/herestring.sh" > "$WORK/herestring.out"
+if grep -q GONE "$WORK/herestring.out"; then
+	bad "<<< was treated as a heredoc: stripping stopped at the herestring"
+elif grep -q "echo end" "$WORK/herestring.out"; then
+	ok "<<< is read as a herestring, not a heredoc"
+else
+	bad "content after a herestring was lost"
+fi
+
+# Two heredocs opened on one line are consumed in order; getting the order wrong
+# ends the first body at the second's terminator.
+cat > "$WORK/twoheredoc.sh" <<'TWO'
+#!/bin/sh
+cat <<A - <<B
+# LIVE body one
+A
+# LIVE body two
+B
+# GONE trailing comment
+TWO
+
+strip "$WORK/twoheredoc.sh" > "$WORK/twoheredoc.out"
+if [ "$(grep -c LIVE "$WORK/twoheredoc.out")" = 2 ] && ! grep -q GONE "$WORK/twoheredoc.out"; then
+	ok "two heredocs on one line are consumed in order"
+else
+	bad "stacked heredocs on one line were mis-tracked"
+fi
+
+# Running twice must equal running once: the build re-runs post-build hooks on
+# an existing target dir, so a non-idempotent pass would eat code the second time.
+strip "$WORK/fixture.out" > "$WORK/fixture.twice"
+if cmp -s "$WORK/fixture.out" "$WORK/fixture.twice"; then
+	ok "stripping is idempotent"
+else
+	bad "stripping twice differs from stripping once"
+	diff "$WORK/fixture.out" "$WORK/fixture.twice"
+fi
+
+# ---------------------------------------------------------------------------
+# Part 2 — no shipped script changes syntax. This is the claim that matters;
+# Part 1 only explains the ways it could break.
+# ---------------------------------------------------------------------------
+
+BUSYBOX=$(command -v busybox 2>/dev/null || true)
+
+if [ -z "$BUSYBOX" ]; then
+	if [ "$STRICT" != 0 ]; then
+		echo "FAIL busybox not found and STRICT=$STRICT -- refusing to report a"
+		echo "     pass when no shipped script was actually checked."
+		exit 1
+	fi
+	note "busybox not found: skipping the shipped-script sweep."
+	note "install busybox-static to run this as the device would."
+	[ "$fail" -eq 0 ] && echo && echo "Fixture checks passed (sweep skipped)."
+	exit "$([ "$fail" -eq 0 ] && echo 0 || echo 1)"
+fi
+
+# Same bar as test_shell_parse.sh: the shipped busybox sets ASH_BASH_COMPAT, so
+# a busybox without it would reject `function name()` and fail scripts that are
+# correct on hardware.
+if ! "$BUSYBOX" ash -c 'function _probe() { :; }' 2>/dev/null; then
+	echo "FAIL this busybox lacks ASH_BASH_COMPAT, so it rejects the 'function'"
+	echo "     keyword that the shipped busybox accepts."
+	exit 1
+fi
+
+candidates() {
+	{
+		find general/overlay -type f 2>/dev/null
+		find general/package -path '*/files/*' -type f 2>/dev/null
+	} | sort -u
+}
+
+checked=0
+drifted=0
+saved=0
+
+while IFS= read -r f; do
+	[ -n "$f" ] && [ -f "$f" ] || continue
+
+	# Skip binaries before reading a line of them: package files/ dirs carry
+	# blobs, and their NUL bytes make the shebang test below noisy.
+	grep -Iq . "$f" 2>/dev/null || continue
+
+	case "$(head -1 "$f" 2>/dev/null)" in
+		'#!'*sh*) ;;
+		*) [ "$f" = general/overlay/etc/profile ] || continue ;;
+	esac
+
+	strip "$f" > "$WORK/stripped" 2>/dev/null || {
+		bad "awk failed on $f"
+		drifted=$((drifted + 1))
+		continue
+	}
+
+	"$BUSYBOX" ash -n "$f" 2>/dev/null;            before=$?
+	"$BUSYBOX" ash -n "$WORK/stripped" 2>/dev/null; after=$?
+
+	if [ "$before" != "$after" ]; then
+		bad "$f parses differently after stripping (before=$before after=$after)"
+		drifted=$((drifted + 1))
+		continue
+	fi
+
+	if [ "$(head -c2 "$WORK/stripped")" != '#!' ] && [ "$f" != general/overlay/etc/profile ]; then
+		bad "$f lost its shebang"
+		drifted=$((drifted + 1))
+		continue
+	fi
+
+	checked=$((checked + 1))
+	saved=$((saved + $(wc -c < "$f") - $(wc -c < "$WORK/stripped")))
+done <<EOF
+$(candidates)
+EOF
+
+if [ "$checked" -eq 0 ]; then
+	bad "no shipped scripts were found — discovery is broken, not the tree"
+elif [ "$drifted" -eq 0 ]; then
+	ok "$checked shipped scripts parse identically after stripping (${saved} bytes saved)"
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+	echo "All strip-shell-comments checks passed."
+	exit 0
+fi
+echo "$fail check(s) failed."
+exit 1

--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -39,6 +39,17 @@ jobs:
       # check twice (/bin/sh is dash) and neither is the target shell.
       - run: bash .github/scripts/test_sysupgrade.sh
 
+      # The copy in git is not the copy that ships: the build strips whole-line
+      # comments out of it. Run the same suite against that form, so the thing
+      # cameras actually execute is the thing under test. Without this, the
+      # stripper could quietly change behaviour and every check above would
+      # still pass, having tested a file no device ever runs.
+      - name: Re-run against the stripped form that actually ships
+        run: |
+          awk -f general/scripts/strip-shell-comments.awk \
+            general/overlay/usr/sbin/sysupgrade > /tmp/sysupgrade.stripped
+          SRC=/tmp/sysupgrade.stripped bash .github/scripts/test_sysupgrade.sh
+
   # Only sysupgrade was ever parse-checked; every other script in the image --
   # the init scripts, /etc/profile, /init on initramfs boards, the vendor load_*
   # scripts that insert the SoC drivers -- reached cameras without anything
@@ -73,3 +84,11 @@ jobs:
         env:
           STRICT: 1
         run: bash .github/scripts/test_shell_parse.sh
+
+      # The build strips whole-line comments from all of the above before they
+      # are flashed. Parsing only the tree copy would leave that transform --
+      # which rewrites 128 files nobody reads again -- entirely unchecked.
+      - name: Parse them again as the stripper leaves them
+        env:
+          STRICT: 1
+        run: bash .github/scripts/test_strip_shell_comments.sh

--- a/general/scripts/rootfs_script.sh
+++ b/general/scripts/rootfs_script.sh
@@ -58,3 +58,35 @@ if [ -f "${LATE_POST_BUILD_HOOKS}" ]; then
 		fi
 	done < "${LATE_POST_BUILD_HOOKS}"
 fi
+
+# Comments are worth writing and worth keeping in git; they are not worth
+# flashing. sysupgrade alone had grown to 52KB, 57% of it comment, and on
+# 2026-08-18 it pushed hi3519v101_lite 4KB past its 5120KB rootfs cap -- a board
+# that had been sitting at exactly 5120/5120 for some time. Stripping here buys
+# 16KB back on that image and ~24KB across all shipped scripts.
+#
+# Runs LAST, so the late overlays and hooks above are covered too. Discovery is
+# by shebang, matching test_shell_parse.sh -- including its one exception,
+# /etc/profile, which the login shell sources and which carries no shebang.
+STRIPPER="${BR2_EXTERNAL_GENERAL_PATH}/scripts/strip-shell-comments.awk"
+if [ -f "${STRIPPER}" ]; then
+	STRIP_TMP=$(mktemp)
+	# -type f skips the busybox applet symlinks; writing through `cat` rather
+	# than `mv` keeps each file's own mode and inode.
+	find "${TARGET_DIR}" -type f | while IFS= read -r script; do
+		# Weed out binaries before reading a line of one: a rootfs is mostly
+		# ELF, and their NUL bytes make the shebang test below warn per file.
+		grep -Iq . "${script}" 2>/dev/null || continue
+
+		case "$(head -1 "${script}" 2>/dev/null)" in
+			'#!'*sh*) ;;
+			*) [ "${script}" = "${TARGET_DIR}/etc/profile" ] || continue ;;
+		esac
+
+		awk -f "${STRIPPER}" "${script}" > "${STRIP_TMP}" 2>/dev/null || continue
+		# A truncated result means awk gave up half way; keep the original.
+		[ -s "${STRIP_TMP}" ] || continue
+		cat "${STRIP_TMP}" > "${script}"
+	done
+	rm -f "${STRIP_TMP}"
+fi

--- a/general/scripts/rootfs_script.sh
+++ b/general/scripts/rootfs_script.sh
@@ -71,6 +71,7 @@ fi
 STRIPPER="${BR2_EXTERNAL_GENERAL_PATH}/scripts/strip-shell-comments.awk"
 if [ -f "${STRIPPER}" ]; then
 	STRIP_TMP=$(mktemp)
+	STRIP_ERR=$(mktemp)
 	# -type f skips the busybox applet symlinks; writing through `cat` rather
 	# than `mv` keeps each file's own mode and inode.
 	find "${TARGET_DIR}" -type f | while IFS= read -r script; do
@@ -86,7 +87,25 @@ if [ -f "${STRIPPER}" ]; then
 		awk -f "${STRIPPER}" "${script}" > "${STRIP_TMP}" 2>/dev/null || continue
 		# A truncated result means awk gave up half way; keep the original.
 		[ -s "${STRIP_TMP}" ] || continue
-		cat "${STRIP_TMP}" > "${script}"
+
+		# The redirection truncates ${script} before cat writes a byte, so a
+		# failure here -- ENOSPC is the realistic one, on a runner that has just
+		# built a rootfs -- leaves a half-written or empty script in the image.
+		# That is the exact thing this pass must not do: an empty S40network or
+		# load_hisilicon still builds green and bricks the camera quietly. There
+		# is no original left to restore by then, so fail the build instead.
+		if ! cat "${STRIP_TMP}" > "${script}"; then
+			echo "rootfs_script: failed to write stripped ${script}" >&2
+			echo failed > "${STRIP_ERR}"
+			break
+		fi
 	done
-	rm -f "${STRIP_TMP}"
+
+	# `find | while` runs the loop in a subshell, so the failure comes back
+	# through the file rather than through its exit status.
+	if [ -s "${STRIP_ERR}" ]; then
+		rm -f "${STRIP_TMP}" "${STRIP_ERR}"
+		exit 1
+	fi
+	rm -f "${STRIP_TMP}" "${STRIP_ERR}"
 fi

--- a/general/scripts/strip-shell-comments.awk
+++ b/general/scripts/strip-shell-comments.awk
@@ -1,0 +1,115 @@
+# Drop whole-line comments and blank lines from a POSIX shell script.
+#
+# Comments are worth writing and worth keeping in the tree, but every byte of
+# them is also flashed to an 8MB camera. sysupgrade alone reached 52KB, 57% of
+# it comment, and tipped hi3519v101_lite 4KB past its 5120KB rootfs cap on
+# 2026-08-18. Stripping at build time keeps the prose in git and off the flash.
+#
+# Only WHOLE-LINE comments go. A trailing `foo # bar` is left alone: deciding
+# where the code ends needs the same care as the cases below, for a few bytes.
+#
+# Three things look like a comment line and are not, so each is tracked:
+#
+#   heredoc bodies      a `#` there is data the script writes out
+#   multi-line strings  VAR="...\n# still the string\n..."
+#   continuations       `foo \` joins the next line onto this one, so a
+#                       following `#...` is an argument, not a comment
+#
+# Quote state is carried across lines, which is what makes those distinctions
+# possible; a naive `/^[[:space:]]*#/d` gets all three wrong.
+
+# Walk the line, tracking quotes, and return the part of it that is code.
+# Sets `cont` when the line ends in an unescaped backslash.
+function code_of(line,   n, i, ch, prev) {
+	n = length(line)
+	i = 1
+	cont = 0
+	while (i <= n) {
+		ch = substr(line, i, 1)
+
+		if (sq) {                          # '...' — nothing escapes
+			if (ch == "'") sq = 0
+			i++
+			continue
+		}
+		if (dq) {                          # "..." — backslash escapes
+			if (ch == "\\") { i += 2; continue }
+			if (ch == "\"") dq = 0
+			i++
+			continue
+		}
+
+		if (ch == "\\") {
+			if (i == n) { cont = 1; return line }
+			i += 2
+			continue
+		}
+		if (ch == "'")  { sq = 1; i++; continue }
+		if (ch == "\"") { dq = 1; i++; continue }
+		if (ch == "#") {
+			# `#` opens a comment only at the start of a word.
+			prev = (i == 1) ? "" : substr(line, i - 1, 1)
+			if (i == 1 || prev ~ /[ \t;&|()<>]/) return substr(line, 1, i - 1)
+		}
+		i++
+	}
+	return line
+}
+
+# Queue every heredoc opened on this line, in the order the shell reads them.
+function collect_heredocs(code,   pos, seg, at, m, delim) {
+	pos = 1
+	while (1) {
+		seg = substr(code, pos)
+		if (!match(seg, /<<-?[ \t]*("[^"]+"|'[^']+'|[A-Za-z_][A-Za-z0-9_]*)/)) return
+		at = pos + RSTART - 1                 # where the `<<` sits in `code`
+		m = substr(code, at, RLENGTH)
+		pos = at + RLENGTH
+		# `<<<` is a herestring, with no terminator line to wait for. The match
+		# lands on its LAST two `<`, so the tell is the character before it.
+		if (at > 1 && substr(code, at - 1, 1) == "<") continue
+		delim = m
+		sub(/^<<-?[ \t]*/, "", delim)
+		gsub(/^["']|["']$/, "", delim)
+		nd++
+		dstack[nd] = delim
+		dtab[nd] = (substr(m, 3, 1) == "-")   # `<<-` also un-tabs the terminator
+	}
+}
+
+BEGIN { nd = 0; sq = 0; dq = 0; cont = 0; prev_cont = 0 }
+
+{
+	# Inside a heredoc body: verbatim until the terminator.
+	if (nd > 0) {
+		print
+		probe = $0
+		if (dtab[1]) sub(/^\t+/, "", probe)
+		if (probe == dstack[1]) {
+			for (i = 1; i < nd; i++) { dstack[i] = dstack[i + 1]; dtab[i] = dtab[i + 1] }
+			nd--
+		}
+		next
+	}
+
+	# The shebang is the one `#` line that does work.
+	if (NR == 1 && /^#!/) { print; next }
+
+	# Mid-string or mid-continuation, this line is not ours to read.
+	if (sq || dq || prev_cont) {
+		print
+		code = code_of($0)
+		prev_cont = cont
+		collect_heredocs(code)
+		next
+	}
+
+	if (/^[ \t]*$/) next
+
+	code = code_of($0)
+	if (code ~ /^[ \t]*$/) next          # the line was only a comment
+
+	print
+	prev_cont = cont
+	collect_heredocs(code)
+}


### PR DESCRIPTION
## The failure

`hi3519v101_lite` has been red since #2282:

```
- rootfs.squashfs: [5124KB/5120KB]
-- size exceeded by: 4KB
```

It is red on master right now — #2282 and #2283 were both merged while their builds were still running — so tonight's nightly fails without this.

## Why 4KB was enough

The board was not near the edge, it was **on** it. The last green nightly (run [32077538372](https://github.com/OpenIPC/firmware/actions/runs/32077538372)) reported `rootfs.squashfs: [5120KB/5120KB]`, and the size report in that same run records `headroom_kb: 0`. #2282 added 34 lines to `sysupgrade`; that was the entire remaining margin.

`sysupgrade` is why the margin went:

| | |
|---|---|
| size | 52,379 bytes — largest shell script in the image by 2× |
| comments | 29,817 bytes — **57% of the file** |
| growth | 13KB → 52KB since May; +7KB in the five days to 2026-08-18 |
| reach | `general/overlay`, so every board carries all of it |

## What this does

The comments are worth having — several are the only record of why a workaround exists. What is not worth having is *flashing* them. They stay in git and come out in the post-build hook, after the late overlays land so nothing added later is missed.

Measured by rebuilding the last nightly's rootfs with master's `sysupgrade`:

| | bytes | vs 5120KB cap |
|---|---:|---|
| master HEAD, comments intact | 5,246,976 | **4KB over** |
| `sysupgrade` stripped | 5,230,592 | 12KB under |
| all 128 shipped scripts | 5,222,400 | **20KB under** |

24KB back on this board, ~79KB uncompressed across the image. Enough that the next commit does not hit the same wall.

## This is not `sed '/^#/d'`

Three constructs look like a comment line and are not, and each is a way to silently change what a script *does*:

- **heredoc bodies** — the `#` is data the script writes out
- **multi-line strings** — `VAR="...\n# still the string\n..."`
- **continuations** — `foo \` splices the next line on, so a following `#...` is an argument

The pass tracks quote state across lines, which is what makes those distinguishable. Trailing `code # comment` is deliberately left alone: finding where the code ends needs the same care, for a few bytes.

## Verification

This rewrites 128 files nobody reads again, and a bad edit is a rootfs that still builds green — a mangled `load_hisilicon` is a camera that boots to no video. So:

1. **Fixtures** for each construct above, plus `<<<` (a herestring has no terminator, so misreading it swallows the rest of the file) and stacked heredocs on one line. The herestring case caught a real bug in review — the match lands on the *last* two `<`, so the guard has to look at the preceding character.
2. **All 128 shipped scripts** parse identically before and after, under the busybox ash the device runs (ASH_BASH_COMPAT and all), not dash.
3. **`test_sysupgrade.sh`, all 1113 lines, re-run against the stripped `sysupgrade`.** That is the copy cameras execute; testing only the tree copy would leave this transform unchecked by everything above.

The stripper keeps the original if awk fails or truncates, so the worst case is a slightly larger image, not a broken script.

## Not in this PR

A separate change stops CI retrying a size overflow 7 times (50 min, 38.5 of it asleep — which is *why* both PRs merged before their builds reported) and warns when a board is within 32KB of its cap. 14 images on 12 boards are in that band today. Held back until this one lands.