### PR TITLE
ci: stop retrying a build that cannot succeed, and say when one nearly failed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,9 +220,17 @@ jobs:
           attempt=1
           buildlog=$(mktemp)
           for sleep_for in $backoffs ""; do
+            # `set +e` around the pipeline, not because the default shell needs
+            # it -- runner logs show `bash -e {0}`, errexit without pipefail, so
+            # this pipeline reports tee's zero and never trips errexit -- but
+            # because that is one `defaults: run: shell: bash` away from being
+            # untrue. Under pipefail a failing make would abort the step right
+            # here, and the whole retry budget below would silently stop
+            # existing. PIPESTATUS[0] is make's own status either way.
+            set +e
             make BOARD=${{matrix.platform}} 2>&1 | tee "${buildlog}"
-            # tee's status is not make's; ask for the one that matters.
             rc=${PIPESTATUS[0]}
+            set -e
             if [ "${rc}" -eq 0 ]; then break; fi
 
             # CHECK_SIZE in the Makefile prints this, and only this, when an
@@ -244,9 +252,14 @@ jobs:
           # Fitting with almost nothing to spare is the state this guard exists
           # for, and it looks exactly like fitting comfortably in a green run.
           # Promote the Makefile's line to an annotation so it outlives the log.
+          # `|| true` because finding nothing here is the good outcome, and a
+          # grep that matches nothing exits 1. Harmless under the current
+          # `bash -e {0}` (the pipeline takes the while loop's zero), fatal the
+          # day anything turns pipefail on -- every comfortably-sized board
+          # would fail its build for having nothing to warn about.
           grep -- '-- headroom warning:' "${buildlog}" | while IFS= read -r line; do
             echo "::warning::${{matrix.platform}}: ${line#-- headroom warning: }"
-          done
+          done || true
           rm -f "${buildlog}"
 
           TIME=$(date -d @${SECONDS} +%M:%S)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,10 +207,31 @@ jobs:
           # the GitHub releases CDN / toolchain mirror flakes that took down
           # hi3516av100_ultimate on 2026-05-20 (run 26196546684) — 502s
           # storming for >10 min outlasted the previous 30/60/120/300 budget.
+          #
+          # Those backoffs are a bet that the failure is a flake. An image that
+          # does not fit its partition is not one: it will not fit on the sixth
+          # try either. hi3519v101_lite spent 50 minutes proving that on
+          # 2026-08-18 (run 32138368965 — 4KB over a 5120KB cap), 38.5 of them
+          # asleep, and the verdict landed at 14:39 for a PR that had been
+          # merged at 13:14. The budget did not only waste an hour of runner
+          # time, it pushed the answer past the point where anyone was still
+          # looking at it. Deterministic failures stop on the first attempt.
           backoffs="30 60 120 300 600 1200"
           attempt=1
+          buildlog=$(mktemp)
           for sleep_for in $backoffs ""; do
-            make BOARD=${{matrix.platform}} && break
+            make BOARD=${{matrix.platform}} 2>&1 | tee "${buildlog}"
+            # tee's status is not make's; ask for the one that matters.
+            rc=${PIPESTATUS[0]}
+            if [ "${rc}" -eq 0 ]; then break; fi
+
+            # CHECK_SIZE in the Makefile prints this, and only this, when an
+            # image is larger than the partition it has to live in.
+            if grep -q -- '-- size exceeded by:' "${buildlog}"; then
+              echo "::error::${{matrix.platform}}: $(grep -m1 -o -- '-- size exceeded by:.*' "${buildlog}") — the image does not fit its partition, which retrying cannot change"
+              exit 1
+            fi
+
             if [ -z "$sleep_for" ]; then
               echo "::error::build failed after ${attempt} attempts"
               exit 1
@@ -219,6 +240,14 @@ jobs:
             sleep "$sleep_for"
             attempt=$((attempt + 1))
           done
+
+          # Fitting with almost nothing to spare is the state this guard exists
+          # for, and it looks exactly like fitting comfortably in a green run.
+          # Promote the Makefile's line to an annotation so it outlives the log.
+          grep -- '-- headroom warning:' "${buildlog}" | while IFS= read -r line; do
+            echo "::warning::${{matrix.platform}}: ${line#-- headroom warning: }"
+          done
+          rm -f "${buildlog}"
 
           TIME=$(date -d @${SECONDS} +%M:%S)
           echo TIME=${TIME} >> ${GITHUB_ENV}

--- a/Makefile
+++ b/Makefile
@@ -231,12 +231,20 @@ define PREPARE_REPACK
 	$(call REPACK_FIRMWARE,$(1),$(3),$(5))
 endef
 
+# The headroom line exists because "fits" and "only just fits" read the same in
+# a green build. hi3519v101_lite sat at exactly 5120KB of a 5120KB cap for weeks
+# -- reported, passing, and one 34-line edit from the overflow it hit on
+# 2026-08-18. 32KB is the threshold because what tips these boards is a change
+# to the shared overlay, which is single-digit KB at a time; a board under that
+# is a couple of ordinary commits from red, and a board over it is not.
 define CHECK_SIZE
 	$(eval FILE_SIZE = $(shell expr $(shell stat -c %s $(TARGET)/images/$(1) || echo 0) / 1024))
 	if test $(FILE_SIZE) -eq 0; then exit 1; fi
 	echo - $(1): [$(FILE_SIZE)KB/$(2)KB]
 	if test $(FILE_SIZE) -gt $(2); then \
 		echo -- size exceeded by: $(shell expr $(FILE_SIZE) - $(2))KB; exit 1; fi
+	if test $(shell expr $(2) - $(FILE_SIZE)) -lt 32; then \
+		echo -- headroom warning: $(1) has $(shell expr $(2) - $(FILE_SIZE))KB left of $(2)KB; fi
 endef
 
 define REPACK_FIRMWARE


### PR DESCRIPTION
Follow-up to #2284, which fixed the overflow. This fixes the two things that let it get merged in the first place.

## 1. A retry budget spent on a failure that cannot un-fail

The build step retries 7 times with `30/60/120/300/600/1200` backoff. That is the right shape for the CDN flake it was written for, and the wrong shape for an image that is too big for its partition — which fails identically every time.

`hi3519v101_lite` took that path on 2026-08-18 ([run 32138368965](https://github.com/OpenIPC/firmware/actions/runs/32138368965)): 4KB over a 5120KB cap, seven attempts, **50 minutes wall clock, 38.5 of them asleep**.

The runner hour is the smaller cost. Look at the timing:

| | |
|---|---|
| 13:14 | #2282 merged |
| 13:26 | #2283 merged |
| **14:39** | the build job finally reports the overflow |

`CI Gate` is a required status check, but `enforce_admins` is off, so both merges went in over a gate that was still *pending* — pending because the retry budget was still running down. The retry loop turned a deterministic failure into a late one, and a late one is one nobody waits for.

So: grep the build output for the one line `CHECK_SIZE` prints on an overflow, and fail on the first attempt when it is there. Everything else keeps the full budget, unchanged. `make` is now piped through `tee`, so `PIPESTATUS[0]` decides rather than tee's always-zero exit.

## 2. "Fits" and "only just fits" look identical in a green build

This is the reason the first half was needed. `hi3519v101_lite` did not drift into the overflow — it had been sitting at *exactly* 5120KB of 5120KB, green, for weeks. The size report in the last green nightly literally records `headroom_kb: 0`, and nothing surfaced it.

`CHECK_SIZE` now prints a headroom line under 32KB free, and the workflow promotes it to a job annotation. 32KB because what tips these boards is a shared-overlay edit of a few KB at a time — a board under that is a couple of ordinary commits from red.

Against the last green nightly before #2284 ([run 32077538372](https://github.com/OpenIPC/firmware/actions/runs/32077538372)) that is **14 images on 12 boards** — the point being that this is a cluster, not one unlucky board:

| left | board | image | | left | board | image |
|---:|---|---|---|---:|---|---|
| 0KB | hi3519v101_lite | rootfs | | 1KB | hi3516ev300_lite | uImage |
| 1KB | hi3516ev300_ultimate | uImage | | 12KB | gk7205v300_lite | rootfs |
| 20KB | gk7205v200_lite | rootfs | | 23KB | ssc30kq_lite | uImage |
| 24KB | ssc30kd_lite | uImage | | 24KB | ssc30kd_ultimate | uImage |
| 24KB | ssc30kq_ultimate | uImage | | 24KB | ssc338q_lite | uImage |
| 24KB | ssc338q_ultimate | uImage | | 27KB | v851s_lite | uImage |
| 28KB | gk7605v100_lite | rootfs | | 28KB | hi3516av300_neo | uImage |

#2284 has since bought all of them back a few KB — `hi3519v101_lite` goes to roughly 20KB free — so the next nightly will read differently. Every board on that list is still inside the band this warns about.

## Verification

A stubbed `make` driven through all four paths:

| input | behaviour |
|---|---|
| size overflow | stops after **1** attempt, annotates the overflow, exits 1 |
| transient failure | still burns all 7 attempts, exits 1 |
| success near the cap | annotates the headroom, exits 0 |
| comfortable success | silent, exits 0 |

And `CHECK_SIZE` itself against real files at 5108KB, 4000KB and 5124KB against a 5120KB cap: warns, silent, and fails respectively — the overflow path exits before the warning, so an over-cap image reports the overflow and not a headroom note.

## Hardware evidence

None, and none is applicable: this changes CI plumbing and a build-time size check. No file in this diff reaches a camera. Flagging it explicitly so the omission is a stated judgement rather than an oversight — see rule 5.3 in `best_practices.md`.