### PR TITLE
libjpeg-openipc: fetch the version it declares, and check what it fetched

### DIFF
--- a/general/package/libjpeg-openipc/libjpeg-openipc.hash
+++ b/general/package/libjpeg-openipc/libjpeg-openipc.hash
@@ -1,0 +1,13 @@
+# There was no hash file here, which is why this package could fetch a tarball
+# whose version did not match the one it declared and nobody noticed. A wrong
+# SOURCE name now fails loudly at download instead of quietly building something
+# else. It also matters that LIBJPEG_OPENIPC_SITE is plain http:// -- with no
+# hash, that download was unverified end to end.
+#
+# Values cross-checked two ways: they are what buildroot records for the same
+# tarball in package/libjpeg/libjpeg.hash, and they are what sha256sum returns
+# for a fresh fetch from www.ijg.org.
+sha256  04705c110cb2469caa79fb71fba3d7bf834914706e9641a4589485c1f832565b  jpegsrc.v9f.tar.gz
+
+# License file, hashed so a silent relicensing upstream is visible too.
+sha256  7c25493a9f64fed34d01445467341bda77bc1cdbeccbe33558659ef173fb9ff2  README

--- a/general/package/libjpeg-openipc/libjpeg-openipc.mk
+++ b/general/package/libjpeg-openipc/libjpeg-openipc.mk
@@ -4,9 +4,18 @@
 #
 ################################################################################
 
-LIBJPEG_OPENIPC_VERSION = 9e
+# 9f, not 9e, because 9f is what this package has actually been building. The
+# SOURCE line below used to interpolate $(LIBJPEG_VERSION) -- buildroot's OWN
+# variable, from package/libjpeg, which is 9f -- rather than this package's.
+# general/external.mk includes every package .mk into one make invocation, so
+# that name resolved to a value this package does not own, and the tree fetched
+# jpegsrc.v9f.tar.gz into a directory called libjpeg-openipc-9e. Correcting the
+# variable while leaving 9e here would have been a silent downgrade of shipped
+# code, so the label is moved to the truth instead. Verified by sha256: what CI
+# downloads matches buildroot's recorded hash for 9f exactly.
+LIBJPEG_OPENIPC_VERSION = 9f
 LIBJPEG_OPENIPC_SITE = http://www.ijg.org/files
-LIBJPEG_OPENIPC_SOURCE = jpegsrc.v$(LIBJPEG_VERSION).tar.gz
+LIBJPEG_OPENIPC_SOURCE = jpegsrc.v$(LIBJPEG_OPENIPC_VERSION).tar.gz
 
 LIBJPEG_OPENIPC_INSTALL_STAGING = YES
 LIBJPEG_OPENIPC_LICENSE = IJG


### PR DESCRIPTION
Found while investigating a red board on #2286. Not caused by it — this has been latent for as long as buildroot has shipped libjpeg 9f.

## The package declared 9e and downloaded 9f

```make
LIBJPEG_OPENIPC_VERSION = 9e
LIBJPEG_OPENIPC_SOURCE  = jpegsrc.v$(LIBJPEG_VERSION).tar.gz   # ← not this package's variable
```

`LIBJPEG_VERSION` belongs to **buildroot's own** `package/libjpeg`, where it is `9f`. `general/external.mk` pulls every package `.mk` into a single make invocation, so the name resolved to a value this package does not own. The tree has been building jpeg **9f** in a directory called `libjpeg-openipc-9e`.

Nothing caught it because there is no hash file: the download was unverified end to end, over plain `http`, so a tarball with the wrong version in its name was indistinguishable from the right one. This is the same global-include hazard already on record from the vendor-ABI work — a `.mk` reading a variable it doesn't own and silently getting another package's value.

## The version goes to 9f, not the other way

This is the part worth reviewing. 9f is what **18 ultimate boards** have actually been shipping — everything that pulls `quirc-openipc`, which selects this package:

```
gk7202v300 gk7205v200 gk7205v300 gk7205v500 hi3516av100 hi3516av200
hi3516cv300 hi3516cv6xx hi3516dv100 hi3516ev200 hi3516ev300 hi3518ev200
hi3518ev300 hi3519dv500 t20 t21 t31 t40      (all _ultimate)
```

Correcting the variable while leaving `9e` in place would have quietly **downgraded** the jpeg library on all of them — a real change wearing a typo fix's clothes. Confirmed by sha256 that what CI downloads is byte-identical to what buildroot records for 9f, so this moves the label to the code, not the code to the label. **No image content changes.**

## The hash file is what stops it recurring

A wrong `SOURCE` name now aborts the download instead of silently building something else, and it closes the unverified-plain-http hole at the same time. Values cross-checked against buildroot's `package/libjpeg/libjpeg.hash` *and* recomputed from a fresh `ijg.org` fetch, then exercised with buildroot's own `support/download/check-hash`:

| input | result |
|---|---|
| correct tarball | OK |
| correct README | OK |
| one appended byte | exit 2, wrong sha256 |
| basename `jpegsrc.v9e.tar.gz` | exit 3, no hash found — **the original bug, now fatal** |

And the leak itself, with `LIBJPEG_VERSION` deliberately poisoned to `9z`:

| recipe | resolves to |
|---|---|
| before | `jpegsrc.v9z.tar.gz` |
| after | `jpegsrc.v9f.tar.gz` |

## Deliberately not fixed here

This package still has **no working download fallback**, which is how it surfaced: `hi3516av100_ultimate` burned the full 7-attempt retry budget (42m52s, run [32178566930](https://github.com/OpenIPC/firmware/actions/runs/32178566930)) when `www.ijg.org` did not answer, then went red. Buildroot's backup mirror is keyed by package name, so it tries `sources.buildroot.net/libjpeg-openipc/` — which does not exist; the file is only under `/libjpeg/`. Verified: `/libjpeg/jpegsrc.v9f.tar.gz` → 200, `/libjpeg-openipc/…` and the flat path → 404.

Correcting the version does not change that. Pointing `SITE` at a mirror would trade upstream provenance for availability, and with a hash now in place that would be *safe* — but it is a separate call worth making deliberately rather than smuggling into a correctness fix.

## Hardware evidence

None. The downloaded bytes are unchanged (sha256-identical to what the 18 boards already build), so any image produced from this branch is identical to one from master — a before/after on a camera could not distinguish them. Flagging explicitly per rule 5.3 rather than leaving it unsaid.