### PR TITLE
ci: make every defconfig either built or explained

### DIFF
--- a/.github/scripts/ci-matrix.py
+++ b/.github/scripts/ci-matrix.py
@@ -83,7 +83,7 @@ ALL_BOARDS = [
     # via gk7205v200's BR2_OPENIPC_SOC_ALIASES (manifest @alias).
     "gk7202v300_lite", "gk7205v200_lite", "gk7205v300_lite", "gk7605v100_lite",
     # Goke [GK7205V500]
-    "gk7205v500_lite",
+    "gk7201v200_lite", "gk7205v500_lite", "gk7205v510_lite",
     # Allwinner
     "v851s_lite",
     # Fullhan
@@ -106,7 +106,64 @@ ALL_BOARDS = [
     "hi3516cv300_ultimate", "hi3516ev200_ultimate", "hi3516ev300_ultimate",
     "hi3518ev300_ultimate", "hi3516av200_ultimate",
     "gk7202v300_ultimate", "gk7205v200_ultimate", "gk7205v300_ultimate",
+    "gk7205v500_ultimate",
 ]
+
+# Defconfigs that exist and are deliberately NOT built, each with the reason.
+#
+# ALL_BOARDS is hand-maintained, and --self-test used to check it in one
+# direction only: every name here must have a defconfig. Nothing checked the
+# reverse, so a defconfig added to a family that was already in the matrix ---
+# gk7205v500_ultimate and gk7205v510_lite, say, both landed after their family
+# --- was simply never built, and nothing said so. UNBUILT_FAMILIES catches a
+# whole family falling out; it cannot see one board inside a family that builds.
+#
+# So the contract is now total: every defconfig is either built, or in a family
+# named in UNBUILT_FAMILIES, or named here with a reason. Silence is no longer
+# an option, which is the actual fix --- the list below is just today's answer.
+UNBUILT_BOARDS = {
+    # Firmware-identical to a board that IS built, and served from it via
+    # BR2_OPENIPC_SOC_ALIASES (manifest @alias). Building them would ship two
+    # bit-identical images under different names. These two were already
+    # explained in prose beside ALL_BOARDS; now they are checked.
+    "gk7205v210_lite": "alias of gk7205v200_lite",
+    "xm550_lite": "alias of xm530_lite",
+
+    # Variants outside the lite/ultimate/neo set the matrix is built around.
+    # Per the firmware-vs-builder split, the extra variants are OpenIPC/builder's
+    # to publish, and this repo builds the standard ones.
+    "gk7205v200_original": "variant 'original', not a standard matrix variant",
+    "hi3516ev300_dev": "variant 'dev', not a standard matrix variant",
+    "hi3516ev300_glibc": "variant 'glibc', not a standard matrix variant",
+    "t31glibc_lite": "glibc toolchain variant of t31_lite",
+
+    # Not firmware images at all: no BR2_OPENIPC_VARIANT, so nothing the repack
+    # step or the manifest knows how to name.
+    "hi3519dv500_toolchain": "toolchain config, produces no firmware image",
+    "s2l22m_lite": "no variant set; Ambarella S2L has no board directory",
+    "s2l33m_lite": "no variant set; Ambarella S2L has no board directory",
+
+    # These are real boards, and this is a COST decision rather than a technical
+    # one, so it is the entry most worth arguing with. Every one of them sets
+    # BR2_TOOLCHAIN_BUILDROOT_MUSL instead of BR2_TOOLCHAIN_EXTERNAL: it
+    # compiles a GCC and a musl from source before it starts on the firmware,
+    # tens of minutes each, against ~6 for a board that downloads its toolchain.
+    # Adding all seven would cost more runner time than a large part of the rest
+    # of the matrix, on every PR that touches a shared path.
+    #
+    # It is the same trade the SMOKE_BOARDS comment above makes deliberately,
+    # and it is one edit to reverse: move a name from here into ALL_BOARDS and
+    # it builds. Note what this does NOT say --- none of these has ever been
+    # built by CI, so "not built" is a statement about cost, not evidence that
+    # they work.
+    "fh8852v210_lite": "internal toolchain: builds gcc+musl from source",
+    "fh8856v100_lite": "internal toolchain: builds gcc+musl from source",
+    "fh8856v200_lite": "internal toolchain: builds gcc+musl from source",
+    "fh8856v210_lite": "internal toolchain: builds gcc+musl from source",
+    "fh8858v200_lite": "internal toolchain: builds gcc+musl from source",
+    "fh8858v210_lite": "internal toolchain: builds gcc+musl from source",
+    "hi3518ev201_lite": "internal toolchain: builds gcc+musl from source",
+}
 
 # Workflows that cannot change what a firmware image contains. Matched on the
 # whole filename, never as a prefix: a workflow this list has never heard of is
@@ -566,6 +623,30 @@ def self_test():
                 f"{vendor_dir}/board/{family}/ backs no board in ALL_BOARDS; add it "
                 f"to UNBUILT_FAMILIES if that is deliberate")
 
+    # 2b. And the same contract one level down, per defconfig. Check 2 works on
+    #     board DIRECTORIES, so it only ever noticed a whole family leaving the
+    #     matrix; a board added to a family that was already built was invisible
+    #     to it. Nineteen defconfigs had accumulated that way.
+    for board in sorted(tree.boards):
+        if board in tree.built or board in UNBUILT_BOARDS:
+            continue
+        info = tree.boards[board]
+        if (info["vendor_dir"], info["family"]) in UNBUILT_FAMILIES:
+            continue
+        problems.append(
+            f"{board} has a defconfig but nothing builds it; add it to ALL_BOARDS, "
+            f"or to UNBUILT_BOARDS with the reason if that is deliberate")
+    # The reverse, so the list cannot rot into a set of names that explain
+    # nothing: an entry that got deleted, renamed, or quietly promoted.
+    for board, reason in sorted(UNBUILT_BOARDS.items()):
+        if board not in tree.boards:
+            problems.append(f"{board} is in UNBUILT_BOARDS but has no defconfig; drop it")
+        elif board in tree.built:
+            problems.append(
+                f"{board} is in UNBUILT_BOARDS but ALL_BOARDS builds it; drop it")
+        elif not reason.strip():
+            problems.append(f"{board} is in UNBUILT_BOARDS with no reason given")
+
     # 3. Same contract for packages. This is the check that catches a defconfig
     #    or a _DEPENDENCIES edit quietly taking a package out of the matrix.
     for path in sorted(glob.glob(f"{REPO_ROOT}/general/package/*/")):
@@ -648,7 +729,7 @@ def self_test():
         (["general/package/sigmastar-osdrv-sensors/Config.in"],
          24, "reached via Config.in select"),
         # Shared packages narrow too, just barely.
-        (["general/package/majestic/majestic.mk"], 86, "majestic is nearly everywhere"),
+        (["general/package/majestic/majestic.mk"], 87, "majestic is nearly everywhere"),
         # Board configs and kernel configs.
         (["br-ext-chip-goke/configs/gk7205v200_lite_defconfig"], 1, "one defconfig"),
         (["br-ext-chip-hisilicon/board/hi3516ev200/hi3516ev300.generic.config"],
@@ -710,7 +791,7 @@ def self_test():
         (["LICENSES/vendor.txt"], full, "LICENSES/ is not the licence file"),
         (["READMEgenerator.c"], full, "README prefix is not a readme"),
         (["general/package/majestic/README.md"],
-         86, "markdown inside a package is that package"),
+         87, "markdown inside a package is that package"),
         (["br-ext-chip-hisilicon/board/hi3516ev200/NOTES.md"],
          8, "markdown inside a board dir is that family"),
         (["general/scripts/pr_compliance_checklist.yaml"],


### PR DESCRIPTION
Found while working on #2287. `--self-test` checked `ALL_BOARDS` in one direction only — every name in it must have a defconfig — and nothing checked the reverse.

`UNBUILT_FAMILIES` doesn't close it either: it works on board *directories*, so it only notices a whole family leaving the matrix. A defconfig added to a family that still builds was invisible. **Nineteen had accumulated that way**, including `gk7205v500_ultimate` and `gk7205v510_lite` — both added along with their boards and never built since.

## The fix is the contract, not the list

Every defconfig is now either in `ALL_BOARDS`, or in a family named in `UNBUILT_FAMILIES`, or in the new `UNBUILT_BOARDS` **with a reason**. Silence stops being an option.

The reverse is checked too, so the list can't rot: an entry that is now built, has lost its defconfig, or carries an empty reason all fail the self-test.

## Three were plain omissions and now build

Matrix goes 96 → 99:

```
gk7201v200_lite   gk7205v500_ultimate   gk7205v510_lite
```

## The rest are deliberate — reasons checked, not assumed

| boards | reason |
|---|---|
| `gk7205v210_lite`, `xm550_lite` | firmware-identical to a built board, served via `BR2_OPENIPC_SOC_ALIASES`. Already true and already written in prose beside `ALL_BOARDS` — now machine-checked |
| `gk7205v200_original`, `hi3516ev300_dev`, `hi3516ev300_glibc`, `t31glibc_lite` | variants outside the lite/ultimate/neo set, which is builder's to publish |
| `hi3519dv500_toolchain`, `s2l22m_lite`, `s2l33m_lite` | no `BR2_OPENIPC_VARIANT` at all; produce nothing the repack step could name |

## The seven worth arguing with

`fh8852v210`, `fh8856v100/v200/v210`, `fh8858v200/v210`, `hi3518ev201` are **real boards**, and the reason they stay out is **cost, not correctness**.

Every one sets `BR2_TOOLCHAIN_BUILDROOT_MUSL` instead of `BR2_TOOLCHAIN_EXTERNAL` — it compiles a GCC and a musl *from source* before it starts on the firmware. Tens of minutes each, against ~6 for a board that downloads its toolchain. Adding all seven would cost more runner time than a large part of the rest of the matrix, on every PR that touches a shared path.

That is the same trade the `SMOKE_BOARDS` comment already makes deliberately, and it is **one edit to reverse** — move a name from `UNBUILT_BOARDS` into `ALL_BOARDS` and it builds. If you'd rather pay for them, say so and I'll move them.

What this explicitly does *not* say: that they work. None has ever been built here. "Not built" is now a statement about cost — which is precisely what the old silence obscured.

## Verification

| check | result |
|---|---|
| defconfig nobody added to `ALL_BOARDS` | self-test exits 1, names the board |
| …then added | exits 0 |
| `UNBUILT_BOARDS` entry that IS built | flagged, "drop it" |
| `UNBUILT_BOARDS` entry with no defconfig | flagged, "drop it" |
| `UNBUILT_BOARDS` entry with an empty reason | flagged |
| narrowing unchanged | goke osdrv edit still resolves to 7 boards |
| the three new boards | present in a full-matrix run |

This PR edits `ci-matrix.py`, which deliberately widens to the full matrix, so CI builds all 99 here — including the three additions. That is the real test of whether they build; if any doesn't, it moves to `UNBUILT_BOARDS` with the failure as its reason rather than being quietly dropped.

## Hardware evidence

None, and not applicable: this changes which boards CI builds and a self-test. No file in the diff is copied into a rootfs, and no image content changes.