### PR TITLE
libjpeg-openipc: give it a mirror that actually has the tarball

### DIFF
--- a/general/package/libjpeg-openipc/libjpeg-openipc.mk
+++ b/general/package/libjpeg-openipc/libjpeg-openipc.mk
@@ -17,6 +17,23 @@ LIBJPEG_OPENIPC_VERSION = 9f
 LIBJPEG_OPENIPC_SITE = http://www.ijg.org/files
 LIBJPEG_OPENIPC_SOURCE = jpegsrc.v$(LIBJPEG_OPENIPC_VERSION).tar.gz
 
+# www.ijg.org is one small host, and until this line the package had no second
+# place to look: buildroot builds the BR2_BACKUP_SITE URL as
+# <backup>/$(PKG)_DL_SUBDIR/<file>, DL_SUBDIR defaults to the package name, and
+# sources.buildroot.net has no libjpeg-openipc/ directory -- only libjpeg/,
+# named after the upstream package this one is a fork of. Both fallbacks
+# therefore 404'd, so a single ijg.org outage was fatal: hi3516av100_ultimate
+# burned all seven build attempts on it, 42m52s, on 2026-08-18.
+#
+# Pointing DL_SUBDIR at the directory that does hold this exact tarball gives
+# the mirror back. Same idiom buildroot uses for its own forks and split
+# packages -- LINUX_HEADERS_DL_SUBDIR = linux, HOST_LIBIBERTY_DL_SUBDIR =
+# binutils. It also shares output/dl/libjpeg/ with buildroot's libjpeg, which is
+# correct: it is the same tarball under the same name, and the .hash beside this
+# file is checked either way (HASH_FILES is keyed on the package, not on
+# DL_SUBDIR), so a mirror serving anything else still fails the download.
+LIBJPEG_OPENIPC_DL_SUBDIR = libjpeg
+
 LIBJPEG_OPENIPC_INSTALL_STAGING = YES
 LIBJPEG_OPENIPC_LICENSE = IJG
 LIBJPEG_OPENIPC_LICENSE_FILES = README


### PR DESCRIPTION
Closes the loose end left open in #2287.

## The fallback existed — it just pointed nowhere

`www.ijg.org` is one small host, and this package had no second place to look. A single outage there was fatal: `hi3516av100_ultimate` spent all seven build attempts and **42m52s** on it on 2026-08-18 before going red.

Buildroot *does* have a backup site. It builds the URL as:

```
<BR2_BACKUP_SITE>/$(PKG)_DL_SUBDIR/<file>
```

`DL_SUBDIR` defaults to the package name, and `sources.buildroot.net` has no `libjpeg-openipc/` directory — it has `libjpeg/`, named for the upstream package this one forks. So both candidates 404'd, exactly as the CI log shows:

```
https://sources.buildroot.net/libjpeg-openipc/jpegsrc.v9f.tar.gz  ->  404
https://sources.buildroot.net/jpegsrc.v9f.tar.gz                  ->  404
https://sources.buildroot.net/libjpeg/jpegsrc.v9f.tar.gz          ->  200   ← the file is right here
```

## One line, and it is buildroot's own idiom

`LIBJPEG_OPENIPC_DL_SUBDIR = libjpeg` — the same thing buildroot does for its own splits and forks: `LINUX_HEADERS_DL_SUBDIR = linux`, `HOST_LIBIBERTY_DL_SUBDIR = binutils`, `APPARMOR_DL_SUBDIR = libapparmor`.

**Upstream stays the primary**, so provenance doesn't move — this only restores the second attempt. That was the open question in #2287 ("pointing SITE at a mirror would trade provenance for availability"); `DL_SUBDIR` sidesteps the trade entirely, which is why it's the better answer than the one I floated there.

Sharing `output/dl/libjpeg/` with buildroot's `libjpeg` is correct rather than incidental: same tarball, same filename, and the `.hash` added in #2287 is checked either way — `HASH_FILES` is keyed on the package directory, not on `DL_SUBDIR`. A mirror serving anything else still fails the download.

## Verification

Drove buildroot's own `support/download/dl-wrapper` with the primary site pointed at a dead port — i.e. reproducing 2026-08-18:

| `DL_SUBDIR` | result |
|---|---|
| `libjpeg-openipc` (before) | **exit 1, 0 files** — the build dies |
| `libjpeg` (after) | **exit 0, 1 file**, `jpegsrc.v9f.tar.gz: OK (sha256: 04705c…)` |

The hash line is buildroot's own `check-hash` confirming the mirror served the same bytes as upstream.

## One-off cost

The dl cache keys on the same directory, so the first build after this lands re-downloads the tarball once into `output/dl/libjpeg/` instead of finding it under the old name. After that it caches as before.

## Hardware evidence

None, and not applicable: this changes where a source tarball may be fetched from, not its contents — the sha256 is unchanged and enforced. Any image built from this branch is identical to one built from master.