### PR TITLE
wifibroadcast: write noiseLevel where majestic now reads it

### DIFF
--- a/general/package/wifibroadcast-ng/files/wifibroadcast
+++ b/general/package/wifibroadcast-ng/files/wifibroadcast
@@ -179,7 +179,15 @@ video_settings() {
 	cli -s .records.split 1
 	cli -s .records.notime true
 	cli -s .fpv.enabled true
+	# noiseLevel moved onto the channel it configures. 0 is a value here,
+	# not an absence: it turns 3DNR off for latency, so if the key majestic
+	# reads goes unset the ISP default comes back on and nothing says so.
+	# majestic is fetched unpinned from master, so an image can be built
+	# against either side of that rename; an unknown key is ignored, so
+	# writing both is safe. Drop the .fpv line once no supported build
+	# still reads it.
 	cli -s .fpv.noiseLevel 0
+	cli -s .video0.noiseLevel 0
 
 	wifibroadcast cli -s .wireless.mlink 3994
 	wifibroadcast cli -s .wireless.link_control alink


### PR DESCRIPTION
## Problem

majestic is moving its per-channel VENC knobs off the global `fpv` section onto `video0`/`video1`, with no migration. `.fpv.noiseLevel` is one of them, and `video_settings()` in this script is the only place in this tree that sets any of them.

Losing it is not cosmetic. `0` is a value, not an absence: it turns 3DNR off, which is the point of setting it in an FPV profile. Once majestic reads the key from its new location the old one goes unread, the setting reads as "leave the encoder alone", the SigmaStar path returns early, and the ISP default noise reduction comes back on. Nothing in the log says the setting was dropped.

`.fpv.enabled` on the line above is unaffected — it stays where it is, being the switch for the SigmaStar pipeline rather than an encoder setting.

## Hardware tested on

**SSC30KQ** (`ipcinfo --chip-name` → `ssc33x`, sensor `imx335`), running a majestic build that has the rename.

## Evidence

Before — only the old key, exactly what the script writes today:

```
# cli -s .fpv.noiseLevel 0

# grep -n -A2 '^fpv:' /etc/majestic.yaml
136:fpv:
137-  roiRect: []
138-  noiseLevel: 0

# killall -1 majestic
# curl -s /api/v1/config.json   (video0)
  video0.noiseLevel: ABSENT  <-- setting lost, 3DNR left at ISP default
```

After — both keys, as this PR writes them:

```
# cli -s .fpv.noiseLevel 0
# cli -s .video0.noiseLevel 0

# grep -nE 'noiseLevel' /etc/majestic.yaml
38:  noiseLevel: 0
139:  noiseLevel: 0

# awk 'NR>=37 && NR<=39'        # 38 sits under video0
37:   roiRect: []
38:   noiseLevel: 0
39: video1:

# awk 'NR>=137 && NR<=139'      # 139 still under fpv, for older majestic
137: fpv:
138:   roiRect: []
139:   noiseLevel: 0

# killall -1 majestic
# curl -s /api/v1/config.json
  video0.noiseLevel: 0

# fpv path applied with no SDK errors
grep -cE 'Cannot set channel parameters|Cannot set reference|Cannot set intra|Cannot set venc roi'  ->  0
```

## Why both keys

`majestic.mk` fetches `majestic.$(FAMILY).$(VARIANT).master.tar.bz2` — unpinned master — so an image can be built against either side of the rename and there is no version to gate on. majestic ignores a key it does not know, so writing both is correct on both, and this can land before or after the majestic side in either order.

The `.fpv` line can be dropped once no supported build still reads it.

## Checked

`grep` over this repo for all eight moved key names: this is the only occurrence. `sh -n` clean, and the file stays pure ASCII.
