### PR TITLE
sysupgrade: guard the rmdir that actually runs, not the one that does not

### DIFF
--- a/.github/scripts/test_sysupgrade.sh
+++ b/.github/scripts/test_sysupgrade.sh
@@ -944,6 +944,21 @@ awk '/^ramfs_discard\(\)/,/^}/' "$SRC" | grep -qF '^tmpfs $RAM_ROOT tmpfs' \
 grep -qF 'rmdir "/mnt$RAM_ROOT"' "$SRC" \
     && ok "the ramfs phase reclaims the mount point stranded in the old root" \
     || bad "after the pivot nothing removes the old root's RAM_ROOT"
+# ...guarded, because the rootfs SHIPS /ram now. rmdir cannot delete a lower-layer
+# directory, so overlayfs records a whiteout that hides the shipped mount point
+# from every later boot -- which is what a reporter found in /overlay/root after
+# both an upgrade and a factory reset (majestic-webui#120). ramfs_discard got this
+# guard when /ram started shipping; this is the copy on the path that actually
+# runs, since a successful pivot never reaches ramfs_discard.
+grep -qF '[ "1" = "$ram_root_shipped" ] || rmdir "/mnt$RAM_ROOT"' "$SRC" \
+    && ok "the ramfs phase only reclaims a mount point it created (no whiteout)" \
+    || bad "post-pivot rmdir is unguarded; on a rootfs shipping /ram it writes a whiteout"
+# The guard is only worth anything if the value survives the re-exec: the second
+# phase cannot recompute it, because by then $RAM_ROOT names a directory in the
+# NEW root rather than the one being judged.
+awk '/^enter_ramfs\(\)/,/^}/' "$SRC" | grep -qE '^	export .*\bram_root_shipped\b' \
+    && ok "ram_root_shipped is exported into the ramfs phase" \
+    || bad "ram_root_shipped is not exported; the post-pivot guard always reads empty"
 # ...and that "/mnt$RAM_ROOT" only names the right directory if RAM_ROOT is
 # absolute. It is overridable from the environment, and a relative one would
 # also defeat the /proc/mounts check, which records mount points absolutely.

--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -1,6 +1,6 @@
 #!/bin/sh
 # OpenIPC.org | 2025
-scr_version=1.0.60
+scr_version=1.0.61
 
 args="$@"
 LOCK_FILE=/tmp/sysupgrade.lock
@@ -701,6 +701,10 @@ enter_ramfs() {
 	# remote_update: verify_rootfs branches on it for an unmountable rootfs.
 	# lock_owned: die() needs it to know the lock is ours to remove.
 	export remote_update lock_owned
+	# ram_root_shipped: the second phase reclaims the old root's mount point and
+	# needs the same answer ramfs_discard does. It cannot recompute it -- by then
+	# $RAM_ROOT names a directory in the NEW root, not the one being judged.
+	export ram_root_shipped
 	export kernel_version system_version rootfs_version mount_wait abort_wait
 
 	cd "$RAM_ROOT" || { ramfs_unwind; return 1; }
@@ -1126,7 +1130,17 @@ if [ "1" = "$_ramfs_phase" ]; then
 	# ever read again. Take it back now, while there is still a filesystem under
 	# /mnt to take it from: the first flashcp write is a few lines away and the
 	# old root does not survive it (OpenIPC/majestic-webui#120).
-	rmdir "/mnt$RAM_ROOT" 2>/dev/null
+	#
+	# ...but ONLY one we created. The rootfs now ships /ram (see the mount point
+	# in general/overlay/), so on any current image this directory lives in the
+	# read-only lower layer, and rmdir cannot delete one of those -- overlayfs
+	# records a WHITEOUT in the upper layer instead, which HIDES the shipped
+	# mount point from every later boot. ramfs_discard was given this guard when
+	# /ram started shipping; this line is the same rmdir on the path that
+	# actually runs (a successful pivot never reaches ramfs_discard), and it was
+	# missed -- so the whiteout replaced the stray directory it was meant to fix,
+	# on upgrade and on factory reset alike (@usa-, majestic-webui#120).
+	[ "1" = "$ram_root_shipped" ] || rmdir "/mnt$RAM_ROOT" 2>/dev/null
 	flash_and_reboot
 fi
 


### PR DESCRIPTION
`usa-` reports `/overlay/root/ram` is back after an upgrade — and worse than before. It is no longer a stray empty directory but an overlayfs **whiteout**, which *hides* the `/ram` this image now ships:

```
lrwxrwxrwx 1 root root 18 Aug 21 05:27 ram -> (overlay-whiteout)
```

That's the exact hazard b56bad2a7 described, and it shipped anyway — because the guard went on the wrong `rmdir`.

## Two rmdirs, only one guarded

| call site | reached when | state before this PR |
|---|---|---|
| `ramfs_discard()` | the pivot **fails** | guarded by `ram_root_shipped` |
| `_ramfs_phase` block, `rmdir "/mnt$RAM_ROOT"` | the pivot **succeeds** | **unguarded** |

A successful pivot execs, flashes and reboots, so it never reaches `ramfs_discard` at all. The guarded copy is the one that hardly ever runs; the unguarded one runs on every normal upgrade. Since the same commit started shipping `/ram` in the image, that `rmdir` now meets a lower-layer directory it cannot delete, and overlayfs records the whiteout instead.

`ram_root_shipped` wasn't exported either, so even had the guard been there it would have read empty across the pivot's re-exec. Both halves are fixed.

## Reproduced on a camera (current nightly, jffs2 overlay)

```
# rmdir /ram
# ls -la /overlay/ram
lrwxrwxrwx 1 root root 18 /overlay/ram -> (overlay-whiteout)
# ls -ld /ram
ls: /ram: No such file or directory
```

Two things worth recording for anyone cleaning this up by hand:

- **jffs2 renders overlayfs whiteouts as a symlink** to the literal string `(overlay-whiteout)`, not the `0:0` character device the overlayfs docs describe — hence the 18-byte size in the report.
- **Removing the whiteout isn't enough on its own.** `/ram` stays missing from the merged view until `mount -o remount /`, because overlayfs caches the negative dentry.

It reaches factory reset as well as upgrade, which is what the report noticed: `fw-reset.cgi` runs `sysupgrade -s -n -x --web`, and that takes the same pivot.

## Deliberately not self-healing

Cameras already carrying a whiteout are left alone. The pivot still works there — `mkdir` just re-creates the directory in the upper layer each time — and self-healing code on the path where a mistake bricks the camera isn't worth that.

## Tests

Two new harness assertions cover both halves; the existing one only checked that the post-pivot `rmdir` *exists*, which is what let this through. Full suite green.

Reported-by: `usa-`
Ref: OpenIPC/majestic-webui#120

🤖 Generated with [Claude Code](https://claude.com/claude-code)