### PR TITLE
xmdp: bound the Version copy so a scan reply can't smash the stack (#2293)

### DIFF
--- a/general/package/xmdp/src/xmdp.c
+++ b/general/package/xmdp/src/xmdp.c
@@ -20,8 +20,6 @@
 // send broadcast packets periodically
 #define TIMEOUT 5 // seconds
 
-#define MIN(x, y) ((x) < (y) ? (x) : (y))
-
 static int scansec = 0;
 
 const char brpkt[] =
@@ -201,28 +199,28 @@ int scan() {
     }
     enum ConnectStatus netip_conn = netip_connect(host_ip, netip_port);
 
+    // Both Version and BuildDate come straight from an unauthenticated UDP
+    // reply, so every write into this fixed buffer is bounded — issue #2293.
     char verstr[128] = {0};
     if (strlen(version)) {
-      int n_dot = 0, i = 0;
+      int n_dot = 0;
+      size_t len = 0;
       while (*version) {
         if (*version == '.') {
           n_dot++;
           if (n_dot == 4)
             break;
-        } else if (n_dot == 3) {
-          verstr[i++] = *version;
+        } else if (n_dot == 3 && len < sizeof(verstr) - 1) {
+          verstr[len++] = *version;
         }
         version++;
       }
+      verstr[len] = '\0';
 
-      if (strlen(builddt) == 19 && builddt[10] == ' ') {
-        const char *end = builddt + 10;
-        strcat(verstr + strlen(verstr), " (");
-        snprintf(verstr + strlen(verstr),
-                 MIN(sizeof(verstr) - strlen(verstr), end - builddt + 1), "%s",
-                 builddt);
-        strcat(verstr + strlen(verstr), ")");
-      }
+      // Append the date portion "YYYY-MM-DD" of BuildDate. snprintf caps the
+      // write at the space left, so a full verstr can't be pushed past the end.
+      if (strlen(builddt) == 19 && builddt[10] == ' ')
+        snprintf(verstr + len, sizeof(verstr) - len, " (%.10s)", builddt);
     }
 
     printf("%s%s\t%s\t%s %s, %s", color(netip_conn), host_ip, mac,


### PR DESCRIPTION
## Summary

Fixes #2293 — a remote, unauthenticated stack buffer overflow in `xmdp`.

`scan()` broadcasts a NETIP/DVRIP probe on UDP/34569 and parses whatever
comes back as JSON. The socket is not `connect()`-ed, so `recvfrom()`
accepts a reply from any host. The 4th dot-separated field of
`NetWork.NetCommon.Version` is copied into a fixed 128-byte stack buffer
`verstr` one byte at a time, and the destination index was never bounded:

```c
} else if (n_dot == 3) {
  verstr[i++] = *version;   // i never checked against sizeof(verstr)
}
```

A `Version` with three dots followed by a >127-byte tail walks off the end
of `verstr` and corrupts `scan()`'s stack frame (CWE-121). Any host that
can reach UDP/34569 while an operator runs the scanner can trigger it with
one unsolicited unicast reply — no auth, no race.

## Fix

Bound the destination index against `sizeof(verstr) - 1`, preserving the
NUL the `{0}` initializer guarantees. The following BuildDate append
already uses `snprintf` with remaining-space arithmetic, which stays
correct once the buffer is kept NUL-terminated.

## Verification

- Reproduced the crash from the reporter's PoC against this exact source.
- AddressSanitizer pinpoints the OOB `WRITE of size 1` at the `verstr[i++]`
  line before the fix; after the fix the loop writes exactly 127 bytes and
  exits cleanly (buffer NUL-terminated, no overflow).
- `xmdp` still compiles clean (`-Os -Wall -Wpedantic`, no new warnings).

Only 3 defconfigs select `BR2_PACKAGE_XMDP` (hi3520dv200_lite,
hi3536cv100_lite, hi3536dv100_lite); `ci-matrix.py` narrows the build to
those boards.

## Test plan

- [x] PoC no longer crashes the scanner
- [x] AddressSanitizer clean after fix
- [x] xmdp builds without warnings
