### PR TITLE
sysupgrade: quiesce the overlay before erasing the medium under it

### DIFF
--- a/.github/scripts/test_sysupgrade.sh
+++ b/.github/scripts/test_sysupgrade.sh
@@ -87,8 +87,18 @@ printf '#!/bin/sh\necho "S95majestic $1" >> "$FLASH_LOG"\nexit 0\n' \
 # where they should be, so the fallback cases exercise the fallback rather than
 # the emergency "cannot restore, reboot" path. Deliberately no line for $SB/ram:
 # a stale ramfs is the exception, not the default.
-printf 'tmpfs %s/tmp tmpfs rw,relatime 0 0\nproc %s/proc proc rw,relatime 0 0\n' \
-    "$SB" "$SB" > "$SB/proc/mounts"
+#
+# The jffs2 line is what quiesce_overlay looks itself up in: it maps the
+# rootfs_data partition get_device() reports to the mount point to remount
+# read-only. set_mounts drops it for the "overlay is not mounted at all" case
+# (NAND/UBI, or a root that never mounted one).
+set_mounts() {
+    printf 'tmpfs %s/tmp tmpfs rw,relatime 0 0\nproc %s/proc proc rw,relatime 0 0\n' \
+        "$SB" "$SB" > "$SB/proc/mounts"
+    [ "no-overlay" = "${1:-}" ] \
+        || printf '/dev/mtdblock4 /overlay jffs2 rw,relatime 0 0\n' >> "$SB/proc/mounts"
+}
+set_mounts
 
 set_mtd() { cat > "$SB/proc/mtd"; }
 
@@ -171,6 +181,10 @@ target=${!#}
 # wedges before the code under test is even reached.
 for a in "$@"; do
     case "$a" in
+        # quiesce_overlay remounts the jffs2 read-only before the erase. Log it
+        # so a test can assert both that it happened and that it happened FIRST;
+        # STUB_REMOUNT_RC injects a kernel that refuses.
+        *remount*) echo "remount $*" >> "$FLASH_LOG"; exit "${STUB_REMOUNT_RC:-0}" ;;
         move|tmpfs|--move|-M) exit 0 ;;
     esac
 done
@@ -256,11 +270,17 @@ run() {
         STUB_IMG_SOC="${STUB_IMG_SOC:-ssc338q}" \
         STUB_IMG_VERSION="${STUB_IMG_VERSION:-2026.07.11}" \
         STUB_FLASHCP_FAIL="${STUB_FLASHCP_FAIL:-0}" \
+        STUB_REMOUNT_RC="${STUB_REMOUNT_RC:-0}" \
         sh "$SB/sysupgrade" "$@" 2>&1)
     RC=$?
 }
 flashed()      { grep -q "flashcp .*$1" "$SB/tmp/flash.log"; }
 erased()       { grep -q "flash_eraseall .*$1" "$SB/tmp/flash.log"; }
+remounted_ro() { grep -q "remount .*remount,ro .*$1" "$SB/tmp/flash.log"; }
+# Line number of a phrase in the flash log, for ordering assertions: quiesce
+# before erase is the whole point, and a remount that lands afterwards is a
+# remount of a partition that has already been deleted.
+logged_at()    { grep -n -- "$1" "$SB/tmp/flash.log" | head -1 | cut -d: -f1; }
 nothing_wrote() { ! grep -q "flashcp" "$SB/tmp/flash.log"; }
 # The busybox stub logs a bare "reboot" line, so whether the run rebooted is
 # directly observable -- which is the whole question issue #2231 turns on.
@@ -270,7 +290,8 @@ at() { printf '%s\n' "$OUT" | grep -n -- "$1" | head -1 | cut -d: -f1; }
 
 reset_env() {
     unset STUB_MOUNT STUB_VENDOR STUB_SOC STUB_IMG_SOC STUB_IMG_VERSION MOUNT_WAIT
-    unset STUB_FLASHCP_FAIL STUB_PIVOT_RC
+    unset STUB_FLASHCP_FAIL STUB_PIVOT_RC STUB_REMOUNT_RC
+    set_mounts
     rm -rf "$SB/ram"
     rm -f "$SB"/tmp/*.ssc338q "$SB"/tmp/firmware.bin.* "$SB"/tmp/*.tgz "$SB"/tmp/*.md5sum
     make_uimage "$SB/tmp/uImage.ssc338q" ssc338q
@@ -618,6 +639,44 @@ if erased /dev/mtd4 && rebooted; then
 else
     bad "-x + --wipe_overlay -> expected erase and reboot, rc=$RC log='$(cat "$SB/tmp/flash.log")'"
 fi
+# ...and because it is live, the kernel has to be taken off it first. jffs2's GC
+# thread writes the same medium flash_eraseall is erasing, and both notice: the
+# thread walks a filesystem being deleted under it while jffs2's own erase path
+# reads back blocks holding flash_eraseall's cleanmarkers. remount,ro stops that
+# thread (jffs2_remount_fs does it on the way to ro); umount cannot, because the
+# jffs2 is the upperdir of the overlayfs that is still root for init(1).
+reset_env
+run -z --wipe_overlay
+if remounted_ro /overlay && erased /dev/mtd4 \
+    && [ "$(logged_at remount)" -lt "$(logged_at flash_eraseall)" ]; then
+    ok "--wipe_overlay quiesces the overlay read-only BEFORE erasing it"
+else
+    bad "--wipe_overlay must remount the overlay ro before the erase, log='$(cat "$SB/tmp/flash.log")'"
+fi
+
+# A kernel that refuses the remount must not cost the user their reset: erasing
+# it live is what this did before the quiesce existed, so that is the fallback.
+reset_env
+STUB_REMOUNT_RC=1
+run -z --wipe_overlay
+if erased /dev/mtd4 && printf '%s' "$OUT" | grep -q "erasing it live"; then
+    ok "a refused remount warns and still erases (no worse than the old behaviour)"
+else
+    bad "a refused remount must not block the erase, rc=$RC out='$OUT'"
+fi
+
+# Nothing to quiesce when the partition carries no mounted filesystem -- a NAND
+# camera whose rootfs_data is UBI, or a root that never mounted an overlay. The
+# lookup must come up empty and step aside rather than remount something else.
+reset_env
+set_mounts no-overlay
+run -z --wipe_overlay
+if erased /dev/mtd4 && ! grep -q remount "$SB/tmp/flash.log"; then
+    ok "an unmounted rootfs_data is erased with no remount attempted"
+else
+    bad "nothing is mounted on rootfs_data; no remount should have been tried, log='$(cat "$SB/tmp/flash.log")'"
+fi
+
 # On a non-flash root init mounts a tmpfs overlay instead, so there is no live
 # upperdir on the partition being erased.
 reset_env
@@ -1064,6 +1123,24 @@ if printf '%s\n' "$rbc" | grep -q 'return 0' && ! printf '%s\n' "$rbc" | grep -q
     ok "reboot_system returns rather than exits (caller owns the status)"
 else
     bad "reboot_system must return on the honoured path so die() keeps its own exit 1"
+fi
+
+# The quiesce is only a quiesce if it precedes the erase, and the mount point has
+# to be looked up rather than assumed: after the pivot the overlay is at
+# /mnt/overlay, on the in-place fallback it is still at /overlay. A hardcoded
+# path would silently remount nothing on one of the two paths.
+wo=$(sed -n '/^do_wipe_overlay()/,/^}/p' "$SRC")
+if printf '%s\n' "$wo" | grep -q 'quiesce_overlay' \
+    && [ "$(printf '%s\n' "$wo" | grep -n quiesce_overlay | head -1 | cut -d: -f1)" \
+       -lt "$(printf '%s\n' "$wo" | grep -n flash_eraseall | head -1 | cut -d: -f1)" ]; then
+    ok "do_wipe_overlay quiesces before it erases"
+else
+    bad "do_wipe_overlay must call quiesce_overlay before flash_eraseall"
+fi
+if sed -n '/^quiesce_overlay()/,/^}/p' "$SRC" | grep -q '/proc/mounts'; then
+    ok "quiesce_overlay looks the mount point up (it moves with the pivot)"
+else
+    bad "quiesce_overlay must read /proc/mounts; the overlay is at /mnt/overlay after the pivot"
 fi
 
 # Every write that lands on flash the camera is running from has to be marked,

--- a/.github/scripts/test_sysupgrade.sh
+++ b/.github/scripts/test_sysupgrade.sh
@@ -95,8 +95,13 @@ printf '#!/bin/sh\necho "S95majestic $1" >> "$FLASH_LOG"\nexit 0\n' \
 set_mounts() {
     printf 'tmpfs %s/tmp tmpfs rw,relatime 0 0\nproc %s/proc proc rw,relatime 0 0\n' \
         "$SB" "$SB" > "$SB/proc/mounts"
-    [ "no-overlay" = "${1:-}" ] \
-        || printf '/dev/mtdblock4 /overlay jffs2 rw,relatime 0 0\n' >> "$SB/proc/mounts"
+    case "${1:-}" in
+        no-overlay) ;;
+        # What general/overlay/init writes on a NAND camera: the same partition,
+        # spelled as a UBI volume rather than an mtdblock device.
+        ubi) printf 'ubi0:rootfs_data /overlay ubifs rw,relatime 0 0\n' >> "$SB/proc/mounts" ;;
+        *)   printf '/dev/mtdblock4 /overlay jffs2 rw,relatime 0 0\n' >> "$SB/proc/mounts" ;;
+    esac
 }
 set_mounts
 
@@ -665,9 +670,22 @@ else
     bad "a refused remount must not block the erase, rc=$RC out='$OUT'"
 fi
 
-# Nothing to quiesce when the partition carries no mounted filesystem -- a NAND
-# camera whose rootfs_data is UBI, or a root that never mounted an overlay. The
-# lookup must come up empty and step aside rather than remount something else.
+# A NAND camera mounts the very same partition as "ubi0:rootfs_data", not as an
+# mtdblock device (general/overlay/init). A lookup that only knows the block
+# device spelling passes every test above and still no-ops on every UBI board.
+reset_env
+set_mounts ubi
+run -z --wipe_overlay
+if remounted_ro /overlay && erased /dev/mtd4 \
+    && [ "$(logged_at remount)" -lt "$(logged_at flash_eraseall)" ]; then
+    ok "a ubifs overlay is quiesced too (init mounts it as ubi0:rootfs_data)"
+else
+    bad "--wipe_overlay must quiesce a ubifs overlay as well, log='$(cat "$SB/tmp/flash.log")'"
+fi
+
+# Nothing to quiesce when the partition carries no mounted filesystem at all --
+# a root that never brought an overlay up, or one whose upper layer is tmpfs.
+# The lookup must come up empty and step aside rather than remount something else.
 reset_env
 set_mounts no-overlay
 run -z --wipe_overlay

--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -324,6 +324,9 @@ do_update_firmware() {
 # it: "Newly-erased block contained word 0x20031985" (magic 0x1985, nodetype
 # 0x2003 -- the marker `flash_eraseall -j` writes).
 #
+# The same applies to a ubifs overlay on a NAND camera -- a background thread
+# and a live medium being erased under it -- so both spellings are handled below.
+#
 # The overlay cannot be unmounted. It is the upperdir AND workdir of the
 # overlayfs that is still root for init(1), majestic, dropbear and getty, so that
 # superblock holds a reference to this mount for as long as they exist: umount is
@@ -346,9 +349,16 @@ do_update_firmware() {
 # is at /mnt/overlay, and on the in-place fallback it is still at /overlay.
 quiesce_overlay() {
 	local blk=$(get_device "rootfs_data" | sed 's|/dev/mtd|/dev/mtdblock|')
-	local mp=$(awk -v d="$blk" '$1 == d { print $2; exit }' /proc/mounts)
-	# Not mounted (NAND/UBI, or an overlay this camera never mounted): the erase
-	# is unopposed already and there is nothing to quiesce.
+	# Two spellings for the same partition, because init mounts it two ways: a
+	# jffs2 camera gets /dev/mtdblockN, a ubifs one gets ubi0:rootfs_data (see
+	# general/overlay/init). Matching only the first would quietly no-op on every
+	# UBI board, where the race is the same and the cure is the same --
+	# ubifs_remount_ro() stops the background thread and commits, just as
+	# jffs2_remount_fs() stops the GC thread.
+	local mp=$(awk -v d="$blk" '
+		$1 == d || $1 ~ /^ubi[0-9]+:rootfs_data$/ { print $2; exit }' /proc/mounts)
+	# Nothing mounted on it -- an overlay this camera never brought up, or a root
+	# that put its upper layer in tmpfs instead. The erase is unopposed already.
 	[ -n "$mp" ] || return 0
 	sync
 	# A refusal is a warning, not a die: erasing it live is exactly what this

--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -1,6 +1,6 @@
 #!/bin/sh
 # OpenIPC.org | 2025
-scr_version=1.0.61
+scr_version=1.0.62
 
 args="$@"
 LOCK_FILE=/tmp/sysupgrade.lock
@@ -312,10 +312,59 @@ do_update_firmware() {
 	echo_c 32 "Firmware updated"
 }
 
+# Stop the kernel writing to the overlay before erasing the medium under it.
+#
+# do_wipe_overlay hands flash_eraseall a partition that is still a mounted, RW
+# jffs2 with its garbage-collect thread running, so two agents end up erasing and
+# writing the same medium at once. Both notice. The GC thread walks a filesystem
+# that is being deleted under it -- "Node header CRC failed ... {ffff,ffff,...}",
+# "Node totlen on flash (0xffffffff) != totlen from node ref", and inodes lost
+# outright to "no data nodes found for ino #20" -- while jffs2's own erase path
+# reads back a block it has just erased and finds someone else's cleanmarker in
+# it: "Newly-erased block contained word 0x20031985" (magic 0x1985, nodetype
+# 0x2003 -- the marker `flash_eraseall -j` writes).
+#
+# The overlay cannot be unmounted. It is the upperdir AND workdir of the
+# overlayfs that is still root for init(1), majestic, dropbear and getty, so that
+# superblock holds a reference to this mount for as long as they exist: umount is
+# EBUSY by construction, and umount -l only detaches it from our namespace while
+# the superblock and the GC thread live on. pivot_root does not help and is not
+# meant to -- it moved THIS script's root off the doomed partition, nobody
+# else's, which is why enter_ramfs leaves the old root mounted at /mnt.
+#
+# Remounting it read-only is enough, and does work: jffs2_remount_fs() stops the
+# garbage-collect thread on the way to ro, which leaves flash_eraseall as the
+# only thing touching the medium. Anything still writing through the overlayfs
+# gets EROFS instead of reaching flash -- the outcome we want a second before a
+# reboot that is going to wipe it anyway.
+#
+# Measured on an hi3516ev300 with an overlay carrying real write history: 3 of 4
+# runs logged jffs2 errors before this, 0 of 5 after. An empty overlay is silent
+# either way, which is why a bench that has just been reset never shows it.
+#
+# The mount point is looked up rather than assumed: after the pivot the overlay
+# is at /mnt/overlay, and on the in-place fallback it is still at /overlay.
+quiesce_overlay() {
+	local blk=$(get_device "rootfs_data" | sed 's|/dev/mtd|/dev/mtdblock|')
+	local mp=$(awk -v d="$blk" '$1 == d { print $2; exit }' /proc/mounts)
+	# Not mounted (NAND/UBI, or an overlay this camera never mounted): the erase
+	# is unopposed already and there is nothing to quiesce.
+	[ -n "$mp" ] || return 0
+	sync
+	# A refusal is a warning, not a die: erasing it live is exactly what this
+	# did before, so falling back to that is never worse than the status quo.
+	if mount -o remount,ro "$mp" 2>&3; then
+		echo "Overlay $mp remounted read-only"
+	else
+		echo_c 33 "Could not remount $mp read-only; erasing it live."
+	fi
+}
+
 do_wipe_overlay() {
 	echo_c 33 "\nOverlayFS"
 	echo "Erase overlay partition"
 	[ "$flash_type" = "nand" ] || jffs2="-j"
+	quiesce_overlay
 	mark_live_flash_dirty
 	set_progress flash_eraseall $jffs2 "$(get_device "rootfs_data")"
 }


### PR DESCRIPTION
Closes #2300.

`do_wipe_overlay()` hands `flash_eraseall` a partition that is still a mounted, read-write jffs2 with its garbage-collect thread running. Two agents then erase and write the same medium at once, and both of them notice.

The GC thread walks a filesystem being deleted underneath it:

```text
jffs2: Header CRC failed on REF_PRISTINE node at 0x00706874: Read 0xffffffff, calculated 0x44660075
jffs2: notice: (573) jffs2_get_inode_nodes: Node header CRC failed at 0x886bac. {ffff,ffff,ffffffff,ffffffff}
jffs2: Node totlen on flash (0xffffffff) != totlen from node ref (0x0000002c)
jffs2: warning: (573) jffs2_do_read_inode_internal: no data nodes found for ino #20
```

and jffs2's own erase path reads back a block it has just erased and finds someone else's data in it:

```text
jffs2: Newly-erased block contained word 0x20031985 at offset 0x003b0000
```

`0x20031985` is a jffs2 cleanmarker — magic `0x1985`, nodetype `0x2003` — the one `flash_eraseall -j` writes.

## Why not just unmount it

It can't be. The jffs2 is the `upperdir` **and** `workdir` of the overlayfs that is still root for init(1), majestic, dropbear and getty:

```text
/dev/mtdblock4 /overlay jffs2 rw,relatime 0 0
overlay / overlay rw,relatime,lowerdir=/,upperdir=/overlay/root,workdir=/overlay/work 0 0
```

That superblock holds a reference to the mount for as long as those processes exist, so `umount` is `EBUSY` by construction and `umount -l` only detaches it from our namespace while the superblock and the GC thread live on.

`pivot_root` does not help here and was never meant to — it moves *this script's* root off the partition it is about to overwrite (#2251), nobody else's, which is why `enter_ramfs()` deliberately leaves the old root mounted at `/mnt`. Nothing in the pivot changes in this PR.

## What this does instead

`mount -o remount,ro` works on it even with the overlayfs live on top, and `jffs2_remount_fs()` stops the garbage-collect thread on the way to read-only. Measured on the running camera:

```text
# ps w | grep jffs2
  573 root      0:00 [jffs2_gcd_mtd4]
# mount -o remount,ro /overlay ; echo rc=$?
rc=0
# ps w | grep jffs2
(gone)
```

That leaves `flash_eraseall` as the only thing touching the medium. Writes still arriving through the overlayfs get `EROFS` instead of reaching flash, which is the outcome we want a second before a reboot that wipes it anyway. `flash_eraseall` writes the raw `/dev/mtdN` character device and never needed the mount.

Shape notes:

- The mount point is **looked up** in `/proc/mounts`, not assumed: after the pivot the overlay is at `/mnt/overlay`, on the in-place fallback it is still at `/overlay`. A hardcoded path would silently remount nothing on one of the two paths. Confirmed on hardware — the patched run reports `/mnt/overlay`.
- `awk` and `sed` are already in the applet list `enter_ramfs()` stages, so this works after the pivot.
- Not mounted at all (NAND/UBI `rootfs_data`, or a root that never mounted an overlay) → the lookup comes up empty and the function steps aside.
- A refused remount **warns and erases live**, which is exactly what this did before, so the fallback is never worse than the status quo.

## Verification

**On hardware** — lab hi3516ev300, NOR, serial console, `ignore_loglevel` on the cmdline (see below), the patched script pushed onto the camera and `sysupgrade -n --web` run with an overlay pre-loaded with ~6 MB of write history each time:

| | runs | produced live-kernel jffs2 errors |
|---|---|---|
| before | 4 | **3** |
| after | 5 | **0** |

The reset itself is still correct after a patched run:

```text
/dev/mtdblock4   8.7M  328.0K  8.4M   4% /overlay      <- freshly wiped
/overlay/root/: crond.reboot  etc  var                 <- test churn gone
/dev/mtdblock4 /overlay jffs2 rw,relatime              <- rw again on the next boot
  573 root  0:00 [jffs2_gcd_mtd4]                      <- GC thread back
root fs writable OK ; dmesg | grep jffs2 -> nothing
```

An **empty** overlay is silent either way — that is why a bare `flash_eraseall` loop reproduces nothing and why this hides on a bench that has just been reset. It needs a populated one.

**In the test suite** — `.github/scripts/test_sysupgrade.sh`, 107 checks green. Five are new:

```text
ok   --wipe_overlay quiesces the overlay read-only BEFORE erasing it
ok   a refused remount warns and still erases (no worse than the old behaviour)
ok   an unmounted rootfs_data is erased with no remount attempted
ok   do_wipe_overlay quiesces before it erases
ok   quiesce_overlay looks the mount point up (it moves with the pivot)
```

Checked that they fail against the unpatched script rather than passing vacuously — four of the five do (the fifth is the no-op path, which is correct either way):

```text
FAIL --wipe_overlay must remount the overlay ro before the erase
FAIL a refused remount must not block the erase
FAIL do_wipe_overlay must call quiesce_overlay before flash_eraseall
FAIL quiesce_overlay must read /proc/mounts; the overlay is at /mnt/overlay after the pivot
```

The harness gains a `remount` branch in the `mount` stub (logged, with `STUB_REMOUNT_RC` to inject a kernel that refuses), a jffs2 line in the fake `/proc/mounts` plus `set_mounts no-overlay` to remove it, and a `logged_at` helper so the ordering can be asserted rather than assumed.

## Scope

This does not touch #2298 — the camera that fails to come back after a reset does so because U-Boot boots an unverified uImage that occasionally has a bit flipped in it. One of the five runs above still needed a power cycle for that reason; its jffs2 side was clean. The two are independent.

## Footnote

None of these kernel messages are visible on a stock camera: `/etc/sysctl.conf` sets `kernel.printk = 3 3 1 3` and S02sysctl applies it, but the live value is `0 0 0 0` on hi3516ev300, hi3516cv300 and gk7205v200 (ssc30kq keeps `3 3 1 3`). `console_loglevel=0` suppresses even `KERN_EMERG`. Everything above needed `ignore_loglevel` on the kernel cmdline to see at all. Worth fixing separately — a camera that panics is currently indistinguishable from one that hung.
