### PR TITLE
ci: publish the boards that did build when the matrix goes red

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -378,7 +378,23 @@ jobs:
   publish:
     name: Publish releases
     needs: [preflight, buildroot]
+    # The leading status function is load-bearing. A job whose `needs` failed is
+    # skipped by default, and an `if:` lifts that only when it CONTAINS a status
+    # function -- reading `needs.buildroot.result` inside the `contains()` below
+    # does not count. So from #2184, which moved the release writes out of the
+    # matrix jobs and into this one, until this line, any single failing board
+    # skipped this job outright and the whole fleet's nightly went unwritten:
+    # the 2026-08-23 nightly lost all 113 images to one board 4KB over its size
+    # cap, and 2026-08-12 lost them the same way. Before #2184 each board
+    # uploaded from its own matrix job, so a bad board took down only itself;
+    # this restores that property without giving up the single-writer fix.
+    #
+    # `!cancelled()` rather than `always()`: the `contains()` already drops a
+    # cancelled or skipped matrix, but a run cancelled AFTER a green matrix
+    # would still start uploading under `always()`, and a half-written nightly
+    # is the thing this job exists to avoid.
     if: >-
+      !cancelled() &&
       github.event_name != 'pull_request' &&
       needs.preflight.outputs.should_build == 'true' &&
       contains(fromJSON('["success", "failure"]'), needs.buildroot.result)
@@ -428,6 +444,13 @@ jobs:
             fi
           elif [ "${count}" -eq 0 ]; then
             echo "::notice::matrix failed and produced nothing; no release to write"
+          else
+            # The partial case this job was always meant to serve, unreachable
+            # until the `!cancelled()` above. Say so out loud: the boards that
+            # did not build keep their PREVIOUS image on nightly/latest, which
+            # is the right outcome for a flasher but is invisible next to the
+            # freshly-written ones.
+            echo "::warning::partial publish: matrix failed, writing the ${count} asset(s) that did build; nightly and latest keep their previous image for every board that did not build — see the Build summary job for the per-board breakdown"
           fi
 
       # Drive the release writes ourselves instead of softprops/action-gh-release.


### PR DESCRIPTION
## Symptom

The nightly of 2026-08-23 built 95 of 96 boards. `gk7205v300_lite` came out 4KB over its
5120KB rootfs cap. That one board cost **every** board its nightly:

- no `nightly-20260823-*` release exists
- all 113 `openipc.*.tgz` assets on `nightly` and `latest` are still the ones written on 08-22

Anyone who flashed any board from `nightly` or `latest` that day got a day-stale image, for a
reason that had nothing to do with their board.

## Cause

`publish` is documented as best-effort — *"publish whatever boards produced, even if some
failed"* — and its condition already lists `'failure'` as an accepted matrix result:

```yaml
needs: [preflight, buildroot]
if: >-
  github.event_name != 'pull_request' &&
  needs.preflight.outputs.should_build == 'true' &&
  contains(fromJSON('["success", "failure"]'), needs.buildroot.result)
```

It never got that far. A job whose `needs` failed is skipped by default, and an `if:` overrides
that **only when it contains a status function**. Reading `needs.buildroot.result` inside
`contains()` does not count. The job was skipped outright, never evaluated, and reported
`skipped` rather than anything red.

This is a regression from #2184, which moved the release writes out of the matrix jobs into a
single writer to stop the concurrent-upload HTTP 500s. That consolidation was right; before it,
each board uploaded from its own job, so a failing board took down only itself.

Both non-PR runs that have failed since #2184 lost their whole release this way:

| run | boards failed | `publish` |
|---|---|---|
| [32671517237](https://github.com/OpenIPC/firmware/actions/runs/32671517237) (08-23) | 1 of 96 | `skipped` |
| [31649720825](https://github.com/OpenIPC/firmware/actions/runs/31649720825) (08-12) | 92 of 96 | `skipped` |

Matching holes in the dated releases: no `nightly-20260812`, no `nightly-20260823`.

## Fix

`!cancelled() &&` on the publish gate, which lifts the implicit `success()`.

`!cancelled()` rather than `always()` on purpose: the `contains()` already drops a cancelled or
skipped matrix, but a run cancelled *after* a green matrix would still start uploading under
`always()`, and a half-written nightly is what the single-writer design exists to avoid.

Also adds a `::warning::partial publish: …` line to `Collect assets`, naming how many assets are
being written and stating that boards which did not build keep their previous image on
`nightly`/`latest` — true and correct for a flasher, but invisible next to freshly-written ones.

## What is deliberately unchanged

The gate still fails the run when any board fails. That is the decision recorded in `ci-gate`
and re-affirmed in #2271 — *"the nightly's product is a COMPLETE set of images … green would be
a lie"* — and it is untouched here.

Both properties are meant to hold at once, and now do: **the run reports red and still delivers
the images it built.** The `ci-gate` comment already assumed this was the behaviour, describing a
failed board as one that *"leaves `nightly` and `latest` pointing at yesterday's image for it"* —
singular. This makes that true.

## Verification

- `build.yml` parses under PyYAML and the condition survives as a string. The `>-` block scalar
  is load-bearing: a leading `!` in a single-line `if:` would be read as a YAML tag.
- `python3 .github/scripts/lint-workflow-shell.py` — 48/48 run blocks parse clean
- `python3 .github/scripts/ci-matrix.py --self-test` — ok (99 boards, 132 packages, 52 cases)
- Condition audited across every path. PR, scheduled no-op, clone guard, cancelled run and
  all-boards-failed all still skip. Only "matrix failed, some boards built" changes from skip to
  publish; on that path `Collect assets` finds a non-zero count and the existing publish step
  runs, which is the code path the job was written for and has never reached.

Not verified end-to-end against a live run with a deliberately failing board — that needs a
nightly to fail, which tonight's very likely will: `gk7205v300_lite` is still over its cap.

## Test plan

- [x] `lint-workflow-shell.py` clean
- [x] `ci-matrix.py --self-test` clean
- [x] YAML parses, `if:` string intact
- [ ] first partially-failed nightly writes a dated release plus fresh `nightly`/`latest` for the
      boards that built, and the gate is still red

## Related

`gk7205v300_lite` needs its own fix to get back under 5120KB — it has been at 0KB headroom since
08-21 and the warning fired every night. Next boards on the same cliff: `hi3516ev300_lite` and
`hi3516ev300_ultimate` at 1KB of uImage headroom, `gk7205v200_lite` and `hi3516av300_neo` at 8KB.

`OpenIPC/builder` `.github/workflows/master.yml` has a byte-identical gate under the same
"best-effort by design" comment; fixed separately.
