### PR TITLE
package: declare the runtime binaries these scripts have been inheriting

### DIFF
--- a/general/package/adaptive-link/Config.in
+++ b/general/package/adaptive-link/Config.in
@@ -1,5 +1,9 @@
 config BR2_PACKAGE_ADAPTIVE_LINK
 	bool "Adaptive link (not enabled by default)"
+	# adaptive-link.mk already lists yaml-cli-multi in _DEPENDENCIES, but that is
+	# build ordering, not Kconfig enablement -- it does not put the binary in the
+	# image. The runtime need has to be a select.
+	select BR2_PACKAGE_YAML_CLI_MULTI
 	help
 	  Controls the bitrate and other link parameters depending on the link quality.
 	  https://github.com/OpenIPC/adaptive-link

--- a/general/package/quirc-openipc/Config.in
+++ b/general/package/quirc-openipc/Config.in
@@ -1,6 +1,12 @@
 config BR2_PACKAGE_QUIRC_OPENIPC
 	bool "quirc-openipc"
 	select BR2_PACKAGE_LIBJPEG_OPENIPC
+	# files/qrscan.sh plays a confirmation sound through majestic with the curl
+	# BINARY once a QR code resolves, and S97qrscan starts it at boot whenever
+	# wlandev is set. The binary is a sub-option of libcurl-openipc, so both
+	# symbols are needed -- selecting only the sub-option leaves it inert.
+	select BR2_PACKAGE_LIBCURL_OPENIPC
+	select BR2_PACKAGE_LIBCURL_OPENIPC_CURL
 	help
 	  QR codes are a type of high-density matrix barcodes, and quirc is a library for extracting and decoding them from images.
 	  https://github.com/dlbeer/quirc

--- a/general/package/sigmastar-osdrv-infinity6e/Config.in
+++ b/general/package/sigmastar-osdrv-infinity6e/Config.in
@@ -1,5 +1,10 @@
 config BR2_PACKAGE_SIGMASTAR_OSDRV_INFINITY6E
 	bool "sigmastar-osdrv-infinity6e"
 	select BR2_PACKAGE_SIGMASTAR_OSDRV_SENSORS
+	# files/script/* is installed wholesale into /usr/bin, so zoom.sh ships with
+	# the driver modules and reads video0.size out of majestic's config with
+	# yaml-cli nine times over. Satisfied until now only by yaml-cli happening to
+	# be in 122 of 125 defconfigs.
+	select BR2_PACKAGE_YAML_CLI
 	help
 	  Sigmastar infinity6e kernel modules

--- a/general/package/wifibroadcast-ng/Config.in
+++ b/general/package/wifibroadcast-ng/Config.in
@@ -9,6 +9,16 @@ config BR2_PACKAGE_WIFIBROADCAST_NG
 	# WebUI stopped needing it, so the dependency has to be declared where it is
 	# actually used rather than inherited from an unrelated package.
 	select BR2_PACKAGE_JSONFILTER
+	# ...and the same script reads /etc/wfb.yaml with yaml-cli, writes the wlan
+	# adapter into it with yaml-cli-multi, and fetches majestic's config with the
+	# curl binary (not just the library). yaml-cli happened to be on 122 of 125
+	# defconfigs and curl on the same 122, so none of this ever surfaced;
+	# yaml-cli-multi was never guaranteed anywhere and is genuinely absent from a
+	# stock lite image.
+	select BR2_PACKAGE_YAML_CLI
+	select BR2_PACKAGE_YAML_CLI_MULTI
+	select BR2_PACKAGE_LIBCURL_OPENIPC
+	select BR2_PACKAGE_LIBCURL_OPENIPC_CURL
 	help
 	  Long-range packet radio link based on raw WiFi radio.
 	  https://github.com/svpcom/wfb-ng


### PR DESCRIPTION
## Summary

Follow-up to #2304. Dropping `BR2_PACKAGE_JSONFILTER` from every defconfig exposed that `wifibroadcast-ng` ran `jsonfilter` without ever selecting it — it had worked purely because every defconfig happened to set the symbol for the WebUI's benefit. 630e3bb fixed that one during review. This is the rest of the same class.

Found by mapping binary → owning package from each `.mk`'s install paths, grepping every shipped `#!` script for those names, and subtracting whatever the calling package already selects.

| package | undeclared runtime dependency |
|---|---|
| `wifibroadcast-ng` | `yaml-cli` (`:243`), `yaml-cli-multi` (`:71`), `curl` (`:129`) |
| `quirc-openipc` | `curl`, in `files/qrscan.sh` — installed to `/usr/sbin` and started at boot by `S97qrscan` whenever `wlandev` is set |
| `sigmastar-osdrv-infinity6e` | `yaml-cli`, nine times in `files/script/zoom.sh`, which ships because the `.mk` installs `files/script/*` wholesale into `/usr/bin` |
| `adaptive-link` | `yaml-cli-multi`, which its `.mk` lists in `_DEPENDENCIES` — build ordering, not Kconfig enablement |

## curl needs both symbols

`BR2_PACKAGE_LIBCURL_OPENIPC_CURL` lives inside `if BR2_PACKAGE_LIBCURL_OPENIPC`, so selecting only the sub-option leaves it inert. Both are selected.

Incidental find while checking this: 28 `ultimate` defconfigs set the curl sub-option *without* the parent. They are fine — `uacme-openipc` selects the parent — but that is the same implicit chain this PR is trying to stop relying on.

## How reachable is any of this

Only one case is live. `yaml-cli` is in 122 of 125 defconfigs and the curl binary in the same 122, so those held by luck exactly the way `jsonfilter` did — every board that needs them has them today. The three without are `s2l22m_lite`, `s2l33m_lite` and `hi3519dv500_toolchain`, none of which enables the affected packages.

`yaml-cli-multi` is the real one: it was never guaranteed anywhere, and is **absent from a stock lite image** — checked on the ssc30kq lab board, `which yaml-cli-multi` → nothing. Enabling `wifibroadcast-ng` or `adaptive-link` there today ships a script that fails at runtime, on a drone.

## Two the sweep flagged that are NOT fixed

Neither dependency is real, so a `select` would have been wrong:

- `baresip-openipc` — the only `curl` line in `files/dtmf_0.sh` is commented out (`# timeout 2 curl -s …`).
- `comgt` — `files/mywifi_tg.sh` is never installed; `comgt.mk` ships only the `comgt` binary.

## Verification

`kconfiglib` over all four packages plus their select targets — parses clean, every selected symbol resolves, no unmet dependencies:

```
all Config.in parsed OK

with all four enabled, the depended-on symbols resolve to:
    BR2_PACKAGE_LIBCURL_OPENIPC            = y   <-- OK
    BR2_PACKAGE_LIBCURL_OPENIPC_CURL       = y   <-- OK
    BR2_PACKAGE_YAML_CLI                   = y   <-- OK
    BR2_PACKAGE_YAML_CLI_MULTI             = y   <-- OK
    BR2_PACKAGE_JSONFILTER                 = y   <-- OK

unmet-dependency warnings: none
```

Repo gates:

```
ci-matrix: self-test ok (99 boards, 132 packages, 52 cases)
checked 129 shell script(s) — all parsed clean under busybox ash
checked 48 run block(s) — all run blocks parse clean
```

No image changes on any board in the matrix: every symbol these now select is already enabled wherever the selecting package is enabled. `NOT_BUILT` is unchanged — `yaml-cli-multi`, `wifibroadcast-ng` and `adaptive-link` all stay unbuilt here, and `--self-test` will say so if that ever changes.

## Test plan

- [x] `kconfiglib` confirms all four parse and every select resolves with no unmet dependencies
- [x] `ci-matrix.py --self-test` passes, `NOT_BUILT` unchanged
- [x] `test_shell_parse.sh` and `lint-workflow-shell.py` pass
- [x] Each call site confirmed to be a real, shipped, executed invocation — and the two that are not were left alone
- [x] `yaml-cli-multi` absence confirmed on real hardware (ssc30kq)
- [ ] Full board matrix — runs here
