### PR TITLE
[no ci] Implement MAC address setting in extutils

### DIFF
--- a/general/overlay/usr/sbin/extutils
+++ b/general/overlay/usr/sbin/extutils
@@ -50,6 +50,16 @@ case "$CMD" in
 		fi
 		;;
 
+	set_mac)
+		if fw_printenv -n ethaddr >/dev/null 2>&1; then
+			echo "ethaddr: $(fw_printenv -n ethaddr)"
+		else
+			mac=$(od -An -tx1 -N5 /dev/urandom | tr -d ' ' | sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\)$/02:\1:\2:\3:\4:\5/')
+			fw_setenv ethaddr "$mac"
+			echo "ethaddr: $mac"
+		fi
+		;;
+
         sysinfo)
 		echo ""
 		echo "Firmware:"


### PR DESCRIPTION
Add functionality to set MAC address if not already set.

There was no way to auto-install the MAC without going into the WebUI

<!--
Review standards for this repository live in best_practices.md and
pr_compliance_checklist.yaml at the repo root. Reading them first is the fastest
way to get a PR merged.

Not every change needs every section — a typo fix does not need an oscilloscope
trace. But a change that alters what runs on a camera needs all four.
-->

## Problem

<!--
The symptom, and which board(s) show it. "Improves stability" is not a symptom.
If this adds new hardware support, say which SoC and which sensor instead.
-->

## Hardware tested on

Ingenic T31N and SigmaStar SSC378Q boards

<!--
SoC and board, e.g. "gk7205v200, Xiaomi Dafang". CI proves an image builds; only
your board can prove it boots and streams.

If you have not run this on a camera, the PR is not ready — say so here and open
it as a draft rather than leaving the section blank.
-->

## Evidence

<!--
Before and after: logs, dmesg, ipcinfo output, stream behaviour, image size.
Paste the output. A description of the output is not the output.
-->

Before:

```
There was no way to auto-install the MAC without going into the WebUI
```

After:

```
Now you can call the option when creating device auto-configuration scripts
```

## Scope

<!-- Tick only what you have actually checked. An unticked box is fine; a wrongly ticked one is not. -->

- [ ] No kernel patches under `general/package/all-patches/linux/` (those go to [OpenIPC/linux](https://github.com/OpenIPC/linux))
- [ ] No files specific to a single retail camera model (those go to [OpenIPC/builder](https://github.com/OpenIPC/builder))
- [ ] No probing or bring-up tooling (that goes to [OpenIPC/ipctool](https://github.com/OpenIPC/ipctool))
- [ ] Nothing under `general/overlay/` or in a shared `load_<vendor>` script hardcodes a value specific to my board
- [ ] Package sources come from an OpenIPC repository, and any version bump keeps at least the specificity of the pin it replaces (a new package should pin a full 40-character SHA)
- [ ] No `LD_PRELOAD`, and no binaries that cannot be rebuilt from source
- [ ] New code is selected by a defconfig, so CI actually builds it
