### PR TITLE
kernel: make the neo fragments' VT and INPUT lines actually disable

### DIFF
--- a/br-ext-chip-hisilicon/board/hi3516av100/hi3516av100.neo.config
+++ b/br-ext-chip-hisilicon/board/hi3516av100/hi3516av100.neo.config
@@ -49,6 +49,11 @@ CONFIG_SYSVIPC=y
 # CONFIG_CROSS_MEMORY_ATTACH is not set
 CONFIG_KERNEL_XZ=y
 
+# CONFIG_EXPERT gates the *prompt* on VT, INPUT, KALLSYMS, COREDUMP and
+# NAMESPACES, so without it olddefconfig forces each of them back to its
+# default and the corresponding "is not set" lines below do nothing at all.
+CONFIG_EXPERT=y
+
 # Timer — Cortex-A7 architected ARM timer
 CONFIG_ARM_ARCH_TIMER=y
 CONFIG_ARM_ARCH_TIMER_EVTSTREAM=y
@@ -203,14 +208,18 @@ CONFIG_RD_XZ=y
 CONFIG_EARLY_PRINTK=y
 
 # Trim — av100 is RAM-permissive (1 GiB) but keep kernel small
-# CONFIG_COREDUMP is not set
+# Pinned on: see the KALLSYMS note below -- not validated on a neo board yet.
+CONFIG_COREDUMP=y
 # CONFIG_ETHTOOL_NETLINK is not set
 # CONFIG_BPF_SYSCALL is not set
 # CONFIG_AUDIT is not set
 # CONFIG_PROFILING is not set
 # CONFIG_KPROBES is not set
 # CONFIG_FTRACE is not set
-# CONFIG_KALLSYMS is not set
+# Pinned on: EXPERT makes this switchable, but a kernel without KALLSYMS
+# prints raw addresses instead of symbol names in an oops, and no neo board
+# has been booted to check that trade. Its own change, with hardware.
+CONFIG_KALLSYMS=y
 # CONFIG_PRINTK_TIME is not set
 CONFIG_CC_OPTIMIZE_FOR_SIZE=y
 
@@ -224,7 +233,8 @@ CONFIG_CC_OPTIMIZE_FOR_SIZE=y
 # CONFIG_FAT_FS is not set
 # CONFIG_CONFIGFS_FS is not set
 # CONFIG_CGROUPS is not set
-# CONFIG_NAMESPACES is not set
+# Pinned on: see the KALLSYMS note above -- not validated on a neo board yet.
+CONFIG_NAMESPACES=y
 # CONFIG_USB_SUPPORT is not set
 # CONFIG_WATCHDOG is not set
 # CONFIG_MMC is not set

--- a/br-ext-chip-hisilicon/board/hi3516cv100/hi3516cv100.neo.config
+++ b/br-ext-chip-hisilicon/board/hi3516cv100/hi3516cv100.neo.config
@@ -49,6 +49,11 @@ CONFIG_SYSVIPC=y
 # CONFIG_CROSS_MEMORY_ATTACH is not set
 CONFIG_KERNEL_XZ=y
 
+# CONFIG_EXPERT gates the *prompt* on VT, INPUT, KALLSYMS, COREDUMP and
+# NAMESPACES, so without it olddefconfig forces each of them back to its
+# default and the corresponding "is not set" lines below do nothing at all.
+CONFIG_EXPERT=y
+
 # Timers — cv300 has dual SP804
 CONFIG_HZ_PERIODIC=y
 # CONFIG_HIGH_RES_TIMERS is not set
@@ -187,14 +192,18 @@ CONFIG_RD_XZ=y
 CONFIG_EARLY_PRINTK=y
 
 # Trim — cv300 is RAM-constrained (128MB)
-# CONFIG_COREDUMP is not set
+# Pinned on: see the KALLSYMS note below -- not validated on a neo board yet.
+CONFIG_COREDUMP=y
 # CONFIG_ETHTOOL_NETLINK is not set
 # CONFIG_BPF_SYSCALL is not set
 # CONFIG_AUDIT is not set
 # CONFIG_PROFILING is not set
 # CONFIG_KPROBES is not set
 # CONFIG_FTRACE is not set
-# CONFIG_KALLSYMS is not set
+# Pinned on: EXPERT makes this switchable, but a kernel without KALLSYMS
+# prints raw addresses instead of symbol names in an oops, and no neo board
+# has been booted to check that trade. Its own change, with hardware.
+CONFIG_KALLSYMS=y
 # CONFIG_PRINTK_TIME is not set
 CONFIG_CC_OPTIMIZE_FOR_SIZE=y
 
@@ -208,7 +217,8 @@ CONFIG_CC_OPTIMIZE_FOR_SIZE=y
 # CONFIG_FAT_FS is not set
 # CONFIG_CONFIGFS_FS is not set
 # CONFIG_CGROUPS is not set
-# CONFIG_NAMESPACES is not set
+# Pinned on: see the KALLSYMS note above -- not validated on a neo board yet.
+CONFIG_NAMESPACES=y
 # CONFIG_USB_SUPPORT is not set
 # CONFIG_WATCHDOG is not set
 # CONFIG_MMC is not set

--- a/br-ext-chip-hisilicon/board/hi3516cv200/hi3516cv200.neo.config
+++ b/br-ext-chip-hisilicon/board/hi3516cv200/hi3516cv200.neo.config
@@ -49,6 +49,11 @@ CONFIG_SYSVIPC=y
 # CONFIG_CROSS_MEMORY_ATTACH is not set
 CONFIG_KERNEL_XZ=y
 
+# CONFIG_EXPERT gates the *prompt* on VT, INPUT, KALLSYMS, COREDUMP and
+# NAMESPACES, so without it olddefconfig forces each of them back to its
+# default and the corresponding "is not set" lines below do nothing at all.
+CONFIG_EXPERT=y
+
 # Timers — cv300 has dual SP804
 CONFIG_HZ_PERIODIC=y
 # CONFIG_HIGH_RES_TIMERS is not set
@@ -187,14 +192,18 @@ CONFIG_RD_XZ=y
 CONFIG_EARLY_PRINTK=y
 
 # Trim — cv300 is RAM-constrained (128MB)
-# CONFIG_COREDUMP is not set
+# Pinned on: see the KALLSYMS note below -- not validated on a neo board yet.
+CONFIG_COREDUMP=y
 # CONFIG_ETHTOOL_NETLINK is not set
 # CONFIG_BPF_SYSCALL is not set
 # CONFIG_AUDIT is not set
 # CONFIG_PROFILING is not set
 # CONFIG_KPROBES is not set
 # CONFIG_FTRACE is not set
-# CONFIG_KALLSYMS is not set
+# Pinned on: EXPERT makes this switchable, but a kernel without KALLSYMS
+# prints raw addresses instead of symbol names in an oops, and no neo board
+# has been booted to check that trade. Its own change, with hardware.
+CONFIG_KALLSYMS=y
 # CONFIG_PRINTK_TIME is not set
 CONFIG_CC_OPTIMIZE_FOR_SIZE=y
 
@@ -208,7 +217,8 @@ CONFIG_CC_OPTIMIZE_FOR_SIZE=y
 # CONFIG_FAT_FS is not set
 # CONFIG_CONFIGFS_FS is not set
 # CONFIG_CGROUPS is not set
-# CONFIG_NAMESPACES is not set
+# Pinned on: see the KALLSYMS note above -- not validated on a neo board yet.
+CONFIG_NAMESPACES=y
 # CONFIG_USB_SUPPORT is not set
 # CONFIG_WATCHDOG is not set
 # CONFIG_MMC is not set

--- a/br-ext-chip-hisilicon/board/hi3516cv300/hi3516cv300.neo.config
+++ b/br-ext-chip-hisilicon/board/hi3516cv300/hi3516cv300.neo.config
@@ -48,6 +48,11 @@ CONFIG_SYSVIPC=y
 # CONFIG_CROSS_MEMORY_ATTACH is not set
 CONFIG_KERNEL_XZ=y
 
+# CONFIG_EXPERT gates the *prompt* on VT, INPUT, KALLSYMS, COREDUMP and
+# NAMESPACES, so without it olddefconfig forces each of them back to its
+# default and the corresponding "is not set" lines below do nothing at all.
+CONFIG_EXPERT=y
+
 # Timers — cv300 has dual SP804
 CONFIG_HZ_PERIODIC=y
 # CONFIG_HIGH_RES_TIMERS is not set
@@ -186,14 +191,18 @@ CONFIG_RD_XZ=y
 CONFIG_EARLY_PRINTK=y
 
 # Trim — cv300 is RAM-constrained (128MB)
-# CONFIG_COREDUMP is not set
+# Pinned on: see the KALLSYMS note below -- not validated on a neo board yet.
+CONFIG_COREDUMP=y
 # CONFIG_ETHTOOL_NETLINK is not set
 # CONFIG_BPF_SYSCALL is not set
 # CONFIG_AUDIT is not set
 # CONFIG_PROFILING is not set
 # CONFIG_KPROBES is not set
 # CONFIG_FTRACE is not set
-# CONFIG_KALLSYMS is not set
+# Pinned on: EXPERT makes this switchable, but a kernel without KALLSYMS
+# prints raw addresses instead of symbol names in an oops, and no neo board
+# has been booted to check that trade. Its own change, with hardware.
+CONFIG_KALLSYMS=y
 # CONFIG_PRINTK_TIME is not set
 CONFIG_CC_OPTIMIZE_FOR_SIZE=y
 
@@ -207,7 +216,8 @@ CONFIG_CC_OPTIMIZE_FOR_SIZE=y
 # CONFIG_FAT_FS is not set
 # CONFIG_CONFIGFS_FS is not set
 # CONFIG_CGROUPS is not set
-# CONFIG_NAMESPACES is not set
+# Pinned on: see the KALLSYMS note above -- not validated on a neo board yet.
+CONFIG_NAMESPACES=y
 # CONFIG_USB_SUPPORT is not set
 # CONFIG_WATCHDOG is not set
 # CONFIG_MMC is not set

--- a/br-ext-chip-hisilicon/board/hi3516cv500/hi3516av300.neo.config
+++ b/br-ext-chip-hisilicon/board/hi3516cv500/hi3516av300.neo.config
@@ -55,6 +55,11 @@ CONFIG_SYSVIPC=y
 # CONFIG_CROSS_MEMORY_ATTACH is not set
 CONFIG_KERNEL_XZ=y
 
+# CONFIG_EXPERT gates the *prompt* on VT, INPUT, KALLSYMS, COREDUMP and
+# NAMESPACES, so without it olddefconfig forces each of them back to its
+# default and the corresponding "is not set" lines below do nothing at all.
+CONFIG_EXPERT=y
+
 # Timers
 CONFIG_HZ_PERIODIC=y
 # CONFIG_HIGH_RES_TIMERS is not set
@@ -219,7 +224,8 @@ CONFIG_DEBUG_HISI_BVT_UART=y
 CONFIG_EARLY_PRINTK=y
 
 # Disable unnecessary features to save kernel size (following EV300 neo)
-# CONFIG_COREDUMP is not set
+# Pinned on: see the KALLSYMS note below -- not validated on a neo board yet.
+CONFIG_COREDUMP=y
 # CONFIG_ETHTOOL_NETLINK is not set
 # CONFIG_BPF_SYSCALL is not set
 # CONFIG_AUDIT is not set
@@ -227,7 +233,10 @@ CONFIG_EARLY_PRINTK=y
 # CONFIG_KPROBES is not set
 # CONFIG_FTRACE is not set
 # CONFIG_DEBUG_BUGVERBOSE is not set
-# CONFIG_KALLSYMS is not set
+# Pinned on: EXPERT makes this switchable, but a kernel without KALLSYMS
+# prints raw addresses instead of symbol names in an oops, and no neo board
+# has been booted to check that trade. Its own change, with hardware.
+CONFIG_KALLSYMS=y
 # CONFIG_PRINTK_TIME is not set
 CONFIG_CC_OPTIMIZE_FOR_SIZE=y
 
@@ -241,7 +250,8 @@ CONFIG_CC_OPTIMIZE_FOR_SIZE=y
 # CONFIG_FAT_FS is not set
 # CONFIG_CONFIGFS_FS is not set
 # CONFIG_CGROUPS is not set
-# CONFIG_NAMESPACES is not set
+# Pinned on: see the KALLSYMS note above -- not validated on a neo board yet.
+CONFIG_NAMESPACES=y
 
 # Disable ARM crypto accelerators (save ~15KB, software fallback used)
 # CONFIG_CRYPTO_SHA256_ARM is not set

--- a/br-ext-chip-hisilicon/board/hi3519v101/hi3516av200.neo.config
+++ b/br-ext-chip-hisilicon/board/hi3519v101/hi3516av200.neo.config
@@ -55,6 +55,11 @@ CONFIG_SYSVIPC=y
 # CONFIG_CROSS_MEMORY_ATTACH is not set
 CONFIG_KERNEL_XZ=y
 
+# CONFIG_EXPERT gates the *prompt* on VT, INPUT, KALLSYMS, COREDUMP and
+# NAMESPACES, so without it olddefconfig forces each of them back to its
+# default and the corresponding "is not set" lines below do nothing at all.
+CONFIG_EXPERT=y
+
 # Timers
 CONFIG_HZ_PERIODIC=y
 # CONFIG_HIGH_RES_TIMERS is not set
@@ -219,7 +224,8 @@ CONFIG_DEBUG_HISI_BVT_UART=y
 CONFIG_EARLY_PRINTK=y
 
 # Disable unnecessary features to save kernel size (following EV300 neo)
-# CONFIG_COREDUMP is not set
+# Pinned on: see the KALLSYMS note below -- not validated on a neo board yet.
+CONFIG_COREDUMP=y
 # CONFIG_ETHTOOL_NETLINK is not set
 # CONFIG_BPF_SYSCALL is not set
 # CONFIG_AUDIT is not set
@@ -227,7 +233,10 @@ CONFIG_EARLY_PRINTK=y
 # CONFIG_KPROBES is not set
 # CONFIG_FTRACE is not set
 # CONFIG_DEBUG_BUGVERBOSE is not set
-# CONFIG_KALLSYMS is not set
+# Pinned on: EXPERT makes this switchable, but a kernel without KALLSYMS
+# prints raw addresses instead of symbol names in an oops, and no neo board
+# has been booted to check that trade. Its own change, with hardware.
+CONFIG_KALLSYMS=y
 # CONFIG_PRINTK_TIME is not set
 CONFIG_CC_OPTIMIZE_FOR_SIZE=y
 
@@ -241,7 +250,8 @@ CONFIG_CC_OPTIMIZE_FOR_SIZE=y
 # CONFIG_FAT_FS is not set
 # CONFIG_CONFIGFS_FS is not set
 # CONFIG_CGROUPS is not set
-# CONFIG_NAMESPACES is not set
+# Pinned on: see the KALLSYMS note above -- not validated on a neo board yet.
+CONFIG_NAMESPACES=y
 
 # Disable ARM crypto accelerators (save ~15KB, software fallback used)
 # CONFIG_CRYPTO_SHA256_ARM is not set


### PR DESCRIPTION
Second follow-up to #2308. Six `*.neo` seed fragments carry blocks headed `# Trim` and `# Disable subsystems not needed on IP cameras`, and **five of the lines in them have never done anything**.

`CONFIG_VT`, `CONFIG_INPUT`, `CONFIG_KALLSYMS`, `CONFIG_COREDUMP` and `CONFIG_NAMESPACES` all have their prompt gated on `CONFIG_EXPERT`, which these fragments do not set. `olddefconfig` finds each one invisible, forces it back to its default, and silently discards the `is not set` line. #2308 fixed this for `hi3516ev300.neo` — a full config that already had EXPERT. These six are the seed fragments it left behind.

All six use the same kernel (`openipc/linux` `upstream-patches`), so one Kconfig tree answers for all of them.

## What each line costs, checked rather than assumed

| symbol | who uses it here |
|---|---|
| `VT` | nothing — same case as #2308 |
| `INPUT` | nothing — no input driver configured, nothing opens `/dev/input` |
| `KALLSYMS` | nothing reads `/proc/kallsyms` anywhere in the tree or in a built rootfs |
| `NAMESPACES` | nothing. busybox `setpriv` is enabled but does not need them; no `unshare`, `setns`, `CLONE_NEW*` or `/proc/self/ns` use |
| `COREDUMP` | nothing sets `core_pattern` or an `RLIMIT_CORE` |

**Only two of the five change here.** `VT` and `INPUT` are the two already proven on real cameras — VT on a gk7205v200 in #2308, INPUT on an hi3516cv300 in #2309, both flashed and md5-checked against the on-flash bytes, both still booting and streaming afterwards. `KALLSYMS`, `COREDUMP` and `NAMESPACES` have not been, and no `*_neo` board is in the lab. A neo image is a mainline-kernel port, and the boards here have no serial console — blind-flashing one to manufacture evidence would risk a board rather than prove anything.

So those three are pinned on by name (`CONFIG_KALLSYMS=y`, `CONFIG_COREDUMP=y`, `CONFIG_NAMESPACES=y`), each with a comment saying why. The file still states exactly what it produces, which is the point; it just stops short of three switches nobody has watched boot. They want their own change, with a neo board on a bench.

## EXPERT is not free — the part worth knowing

`menuconfig EXPERT` carries `select DEBUG_KERNEL`, commented upstream as *"Unhide debug options, to make the on-by-default options visible"*. So:

- `DEBUG_KERNEL` turns **on**, and cannot be turned off again while EXPERT is set
- `DEBUG_MISC` follows it (`default DEBUG_KERNEL`)
- `DEBUG_MEMORY_INIT` flips **off**, because its default is literally `!EXPERT`

Each fragment gains a comment saying so, so the next person does not spend an afternoon working out why an `is not set` line does nothing.

(This same `select` is why #2309 carries a second commit correcting five configs from #2308 that still claim `DEBUG_KERNEL` is off when their built kernel has it on.)

## Measured — `hi3516cv200_neo`, master vs this branch

| | master | this branch | Δ |
|---|---|---|---|
| `zImage` | 1 878 272 | 1 780 520 | **−97 752 (−95 KB)** |
| vmlinux text | 4 176 058 | 3 976 314 | −199 744 |
| vmlinux data | 1 392 200 | 1 317 868 | −74 332 |
| vmlinux bss | 191 548 | 188 572 | −2 976 |

**39 symbols leave** the generated `.config`: the VT cluster, and the INPUT/HID cluster including `KEYBOARD_ATKBD`, `SERIO_LIBPS2`, `I2C_HID` and the nine `MOUSE_PS2_*` drivers. **Four arrive**: `EXPERT`, `DEBUG_KERNEL`, `DEBUG_MISC`, `DEBUG_INFO_NONE`. `KALLSYMS`, `COREDUMP`, `NAMESPACES` and `ELFCORE` are byte-for-byte unchanged — verified in the generated config, not just in the source file.

(Letting all five go would have been −288 KB rather than −95 KB. The other 193 KB is available once a neo board can be booted with them off.)

## Test plan

- [x] `python3 .github/scripts/ci-matrix.py --self-test` — ok
- [x] All 195 EXPERT-gated symbols in this kernel enumerated from its own Kconfig, and cross-referenced against all six fragments — the five above are the complete set that changes
- [x] `hi3516cv200_neo` built from master and from this branch; full 52-out/4-in `.config` delta reviewed symbol by symbol
- [x] Confirmed in the generated `.config` that `KALLSYMS`, `COREDUMP` and `NAMESPACES` come out unchanged
- [x] The two symbols this PR does change are the two already flash-verified on real cameras — VT on gk7205v200 (#2308), INPUT on hi3516cv300 (#2309)

No `*_neo` board is in the lab, and this PR is scoped so that nothing ships here which has not already been booted on real hardware in one of the two predecessor PRs.
