### PR TITLE
Makefile: pin the host C dialect so toolchains build on GCC 15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,18 @@ BR_CONF = $(TARGET)/openipc_defconfig
 TARGET ?= $(PWD)/output
 export CMAKE_POLICY_VERSION_MINIMUM := 3.5
 
+# GCC 15 defaults to -std=gnu23, where an empty parameter list means "takes no
+# arguments" rather than "unspecified". Several host packages Buildroot pins
+# here predate that and their configure probes stop compiling: gmp 6.3.0 fails
+# its compiler test with "too many arguments to function 'g'", which surfaces as
+# the far less helpful "could not find a working compiler" and halts any
+# `make toolchain` on a current distro. Pin the dialect rather than carry a
+# version bump for every affected host package. Applies only to host C builds,
+# is overridable from the environment, and is a no-op on hosts whose GCC still
+# defaults to gnu17.
+HOST_CFLAGS ?= -O2 -std=gnu17
+export HOST_CFLAGS
+
 CONFIG = $(error variable BOARD not defined)
 TIMER := $(shell date +%s)
 


### PR DESCRIPTION
`make toolchain` (and `make BOARD=<board>` generally) fails on any distro shipping GCC 15.

GCC 15 defaults to `-std=gnu23`, where an empty parameter list means *"takes no arguments"* rather than *"unspecified"*. Several host packages Buildroot pins here predate that. gmp 6.3.0 is the first to hit it — its compiler probe fails with:

```
conftest.c:12:48: error: too many arguments to function 'g'; expected 0, have 6
```

which configure then reports as:

```
configure: error: could not find a working compiler, see config.log for details
```

That message sends you hunting for a missing toolchain rather than a dialect mismatch, and it stops the build before any target package is reached.

## The change

Pin the dialect for host C builds, rather than carrying a version bump for every affected host package. It sits next to the existing `CMAKE_POLICY_VERSION_MINIMUM` export, which solves the same class of problem for CMake's minimum-version policy.

- Host C only — target flags and C++ builds untouched
- Overridable from the environment (`HOST_CFLAGS=... make ...`)
- A no-op on hosts whose GCC still defaults to `gnu17`

## Why CI hasn't seen this

The runners are `ubuntu-22.04`, which ships GCC 11. This only bites people building locally on a current distro — which is now most of them, Ubuntu 25.10 and Fedora 42 included.

## Verification

On Ubuntu with GCC 15.2: `make BOARD=hi3516ev300_lite toolchain` fails at `host-gmp` without this and completes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)