### PR TITLE
excludes: say when a prune entry no longer matches anything

### DIFF
--- a/.github/scripts/test_excludes_report.sh
+++ b/.github/scripts/test_excludes_report.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+# Regression test for the excludes step in general/scripts/rootfs_script.sh.
+#
+# The per-board scripts/excludes/<model>_<variant>.list files name files by
+# hand, so they go stale in one direction with nothing saying so: a package
+# renames or drops a sensor blob and the entry that used to prune it silently
+# prunes nothing, while the board keeps paying for whatever replaced it.
+# OpenIPC/builder's hi3518ev200_lite list names 25 sensor .so files where the
+# package now ships 17, which nobody could have known from a build log.
+#
+# What is checked:
+#   Part 1 — behaviour: run the real rootfs_script.sh against a synthetic
+#            TARGET_DIR and assert that present entries are removed, absent
+#            entries are reported, comments and blank lines are skipped, a
+#            file with no trailing newline is still read, and the exit status
+#            stays 0 whatever the list says.
+#   Part 2 — drift: the script must still route the list through a loop that
+#            can tell the two cases apart. A revert to a bare `xargs ... rm`
+#            fails here immediately.
+#
+# Pure shell, no build, runs in under a second.
+
+set -eu
+
+SCRIPT_UNDER_TEST="${SCRIPT_UNDER_TEST:-general/scripts/rootfs_script.sh}"
+
+fail=0
+ok()  { echo "ok   $*"; }
+bad() { echo "FAIL $*"; fail=$((fail + 1)); }
+
+[ -f "$SCRIPT_UNDER_TEST" ] || { echo "FAIL cannot find $SCRIPT_UNDER_TEST"; exit 1; }
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# ----- Part 1: behaviour -----
+# rootfs_script.sh does a lot besides the excludes step -- os-release stamping,
+# the libstdc++ prune, the late-overlay lists. Give it just enough of an
+# environment that those are no-ops and only the excludes block does work.
+ext="$work/general"
+mkdir -p "$ext/scripts/excludes"
+target="$work/target"
+mkdir -p "$target/usr/lib/sensors" "$target/etc/sensors" "$target/usr/lib"
+: > "$target/usr/lib/sensors/libsns_present.so"
+: > "$target/etc/sensors/present.ini"
+ln -s /nowhere "$target/etc/sensors/broken.ini"     # dangling symlink: -e is false, it must still go
+: > "$work/br2config"
+
+# No trailing newline on the last line -- a `while read` without the
+# `|| [ -n "$entry" ]` guard drops it, and the last entry in these lists is a
+# real file.
+printf '%s\n' \
+	'/usr/lib/sensors/libsns_present.so' \
+	'# a comment, and an empty line follow' \
+	'' \
+	'/usr/lib/sensors/libsns_gone.so' \
+	'/etc/sensors/broken.ini' > "$ext/scripts/excludes/testsoc_testvariant.list"
+printf '%s' '/etc/sensors/present.ini' >> "$ext/scripts/excludes/testsoc_testvariant.list"
+
+out="$work/out.txt"
+set +e
+env TARGET_DIR="$target" \
+	BR2_EXTERNAL_GENERAL_PATH="$ext" \
+	BR2_CONFIG="$work/br2config" \
+	OPENIPC_SOC_MODEL=testsoc \
+	OPENIPC_VARIANT=testvariant \
+	bash "$SCRIPT_UNDER_TEST" > "$out" 2>&1
+status=$?
+set -e
+
+[ "$status" -eq 0 ] && ok "exit status is 0" \
+	|| bad "exit status is $status, a stale excludes entry must not break a build"
+
+[ ! -e "$target/usr/lib/sensors/libsns_present.so" ] && ok "present entry was removed" \
+	|| bad "present entry survived"
+[ ! -e "$target/etc/sensors/present.ini" ] && ok "entry on a line without a trailing newline was removed" \
+	|| bad "last entry ignored -- the read loop drops a file with no trailing newline"
+[ ! -L "$target/etc/sensors/broken.ini" ] && ok "dangling symlink was removed" \
+	|| bad "dangling symlink survived -- the -L arm is missing"
+
+grep -q 'excludes: /usr/lib/sensors/libsns_gone.so matched no file' "$out" \
+	&& ok "absent entry is reported" || bad "absent entry was not reported"
+grep -q 'excludes: 1 of 4 entries' "$out" \
+	&& ok "summary counts 1 stale of 4 real entries" \
+	|| bad "summary line wrong or missing: $(grep '^excludes: [0-9]' "$out" || echo '<none>')"
+grep -q 'matched no file' "$out" && ! grep -q "excludes: # " "$out" \
+	&& ok "comment lines are not treated as paths" || bad "a comment line was treated as a path"
+
+# ----- Part 2: drift -----
+# Anchored on the loop, not on the message text, so wording can change freely.
+if grep -q 'while IFS= read -r entry' "$SCRIPT_UNDER_TEST" &&
+   grep -q 'matched no file' "$SCRIPT_UNDER_TEST"; then
+	ok "excludes step still routes the list through a reporting loop"
+else
+	bad "excludes step no longer reports stale entries -- reverted to a bare xargs?"
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+	echo "All excludes-report checks passed."
+else
+	echo "$fail check(s) failed."
+	exit 1
+fi

--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -65,6 +65,22 @@ jobs:
   # Deliberately syntax-only. A bashism audit (checkbashisms) over the same set
   # is a much larger change -- `local` alone is used throughout -- and is worth
   # doing separately rather than smuggling into a coverage PR.
+  excludes-report:
+    name: excludes lists report what they no longer prune
+    if: >-
+      github.repository == 'OpenIPC/firmware' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !github.event.repository.private)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # rootfs_script.sh only reaches its excludes step during a board build,
+      # and a stale entry there is invisible by construction -- it removes
+      # nothing and says nothing. This drives the real script against a
+      # synthetic target instead, so the reporting is covered without paying
+      # for a build.
+      - run: bash .github/scripts/test_excludes_report.sh
+
   shipped-shell-parse:
     name: shipped shell scripts parse
     if: >-

--- a/general/scripts/rootfs_script.sh
+++ b/general/scripts/rootfs_script.sh
@@ -23,8 +23,34 @@ if grep -q "USES_MUSL=y" ${BR2_CONFIG}; then
 fi
 
 LIST="${BR2_EXTERNAL_GENERAL_PATH}/scripts/excludes/${OPENIPC_SOC_MODEL}_${OPENIPC_VARIANT}.list"
-if [ -f ${LIST} ]; then
-	xargs -a ${LIST} -I % rm -f ${TARGET_DIR}%
+if [ -f "${LIST}" ]; then
+	# These lists name files by hand, so they go stale in one direction without
+	# anything saying so: a package renames or drops a sensor blob and the entry
+	# that used to prune it silently prunes nothing, while the board keeps paying
+	# for whatever replaced it. OpenIPC/builder's hi3518ev200_lite list names 25
+	# sensor .so files where the package now ships 17. The old form was a single
+	# `xargs -a ... rm -f`, which cannot tell the two cases apart -- and fed its
+	# `#` separator lines to rm as literal paths besides.
+	#
+	# Report, never fail: an image that ships a few kB it meant to drop is a
+	# size problem to look at, not a reason to break the build.
+	stale=0
+	total=0
+	while IFS= read -r entry || [ -n "${entry}" ]; do
+		case "${entry}" in
+			''|\#*) continue ;;
+		esac
+		total=$((total + 1))
+		if [ -e "${TARGET_DIR}${entry}" ] || [ -L "${TARGET_DIR}${entry}" ]; then
+			rm -f "${TARGET_DIR}${entry}"
+		else
+			stale=$((stale + 1))
+			echo "excludes: ${entry} matched no file"
+		fi
+	done < "${LIST}"
+	if [ ${stale} -gt 0 ]; then
+		echo "excludes: ${stale} of ${total} entries in ${LIST##*/} matched no file"
+	fi
 fi
 
 if [ -f "${LATE_OVERLAY_LIST}" ]; then


### PR DESCRIPTION
One of two PRs adding drift detection between this repo and OpenIPC/builder, after [#2308 (comment)](https://github.com/OpenIPC/firmware/pull/2308#issuecomment-5412650683) turned out to have three separate instances behind it. This is the cheap half and it lives here because it benefits every consumer of `rootfs_script.sh`, not just builder. The other half is [OpenIPC/builder#129](https://github.com/OpenIPC/builder/pull/129).

## The problem

`scripts/excludes/<model>_<variant>.list` names files by hand, so it goes stale in one direction with nothing to show for it: a package renames or drops a sensor blob, the entry that used to prune it now prunes nothing, and the board keeps paying for whatever replaced it. The step was one line:

```sh
xargs -a ${LIST} -I % rm -f ${TARGET_DIR}%
```

which cannot tell "removed a file" from "removed nothing" — and fed the `#` separator lines these lists use to `rm` as literal paths besides.

## The case that prompted it

OpenIPC/builder's `hi3518ev200_lite.list` names **25** sensor `.so` files where `hisilicon-osdrv-hi3516cv200` now ships **17**. Eight entries have been pruning nothing for however long. Meanwhile six sensor libraries it does *not* name — 188KB uncompressed — ship on a camera with one sensor:

```
libsns_gc2033.so  36K   libsns_imx323_i2c_dc_v2.so  44K   libsns_imx327.so  20K
libsns_imx307.so  20K   libsns_imx323_i2c_dc_v3.so  44K   libsns_sc2232.so  24K
```

That device is 4KB over its rootfs cap. Nothing in any build log said so.

## What changes

Each entry is checked before removal, misses are named, and a count is printed at the end:

```
excludes: /usr/lib/sensors/libsns_gone.so matched no file
excludes: 1 of 4 entries in testsoc_testvariant.list matched no file
```

**Report, never fail.** An image carrying a few kB it meant to drop is something to look at, not a reason to break a build. Boards whose lists are accurate print nothing new, so this is silent for everyone it does not concern.

The loop also fixes two things the `xargs` form got away with by accident rather than intent: comment and blank lines are skipped explicitly, and a final entry with no trailing newline is still read.

Deliberately *not* here: reporting files that ship but are **not** named. That needs the built image and a notion of which directories a list is responsible for, and it would fire on every board at once. This half is free.

## Test

`test_excludes_report.sh` drives the real `rootfs_script.sh` against a synthetic `TARGET_DIR` — no build:

```console
$ bash .github/scripts/test_excludes_report.sh
ok   exit status is 0
ok   present entry was removed
ok   entry on a line without a trailing newline was removed
ok   dangling symlink was removed
ok   absent entry is reported
ok   summary counts 1 stale of 4 real entries
ok   comment lines are not treated as paths
ok   excludes step still routes the list through a reporting loop
```

Against the **pre-change** script it fails 4 of 8 and passes the other 4:

```console
$ SCRIPT_UNDER_TEST=/tmp/old_rootfs.sh bash .github/scripts/test_excludes_report.sh
ok   exit status is 0
ok   present entry was removed
ok   entry on a line without a trailing newline was removed
ok   dangling symlink was removed
FAIL absent entry was not reported
FAIL summary line wrong or missing: <none>
FAIL a comment line was treated as a path
FAIL excludes step no longer reports stale entries -- reverted to a bare xargs?
```

The four that pass are the part worth stating: **removal behaviour is unchanged**, including the dangling symlink (`-e` is false for one, so there is an explicit `-L` arm) and the unterminated last line. Only the reporting is new.

Part 2 of the test is a drift check anchored on the loop rather than the message text, so wording can change freely but a revert to a bare `xargs` fails immediately.

## Test plan

- [x] `bash .github/scripts/test_excludes_report.sh` — 8/8
- [x] same test against the pre-change script — 4 fail, 4 pass, as above
- [x] `python3 .github/scripts/lint-workflow-shell.py` — 49 run blocks parse clean
- [x] `python3 .github/scripts/ci-matrix.py --self-test` — ok (99 boards, 132 packages, 52 cases)
- [x] `bash .github/scripts/test_sysupgrade.sh` — all checks passed
- [x] `bash -n general/scripts/rootfs_script.sh`
- [x] Two clean builds of `ssc333_lite_meari-speed-6s` proving the pruning is unchanged — see below

## Proof that pruning is unchanged

`rootfs_script.sh` runs on the build host and can only ever `rm -f` listed paths, so the claim to test is whether the *set of removed files* moved. Two clean builds of `ssc333_lite_meari-speed-6s` — a device that actually has an excludes list — from identical trees differing only in `general/scripts/rootfs_script.sh`:

**Target file lists are identical: 665 paths, no diff.** That is the only thing `rm -f` can influence.

Every remaining byte difference between the two trees is accounted for and none of it is this change:

| difference | files | cause |
|---|---|---|
| `TIME_STAMP=1787691263` vs `…65` | `usr/lib/os-release` | stamped by `date +TIME_STAMP=%s`, the same line in both versions |
| `NT_GNU_BUILD_ID` (20 bytes) | 9 `.ko` | non-reproducible build |
| embedded build clock | `busybox` (**1 byte**, `20:50:15`→`20:50:17`), `8188fu.ko` (`20:53:53`→`20:53:57`) | `__TIME__` |

9 of the 11 differing binaries are byte-identical once the build-id note is masked; the other two differ only in an embedded clock string. The script never rewrites a file, so none of this is reachable from it.

**No board in this repository has an excludes list.** `general/scripts/excludes/` does not exist here, so `[ -f "${LIST}" ]` is false for all 99 boards and the changed branch never executes for any of them. The consumers are OpenIPC/builder's retail devices — which is why the verification above uses one.

And it earns its keep immediately on that device:

```
excludes: /etc/sensors/sc2338.bin matched no file
excludes: /lib/modules/4.9.84/sigmastar/sensor_jxq03_mipi.ko matched no file
excludes: /lib/modules/4.9.84/sigmastar/sensor_sc2338_mipi.ko matched no file
excludes: 3 of 36 entries in ssc333_lite.list matched no file
```

Three stale entries in a shipping device's list that nothing could have surfaced before.
