### PR TITLE
ci: publish an ASan toolchain for the boards where it is proven

### DIFF
--- a/.github/workflows/toolchain-asan.yml
+++ b/.github/workflows/toolchain-asan.yml
@@ -1,0 +1,73 @@
+name: toolchain-asan
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: 'Board to build the ASan toolchain for'
+        required: true
+        default: t31_lite
+        type: choice
+        options:
+          # Only boards where ASan has been proven end-to-end on real hardware
+          # with `scripts/asan.sh smoke` in the majestic repo. Building a
+          # toolchain is easy; knowing its sanitizer actually reports a leak on
+          # that SoC is not, and an unproven entry here would ship a green run
+          # that means nothing. Add a board once, and only once, smoke has
+          # reported the planted leak on it.
+          - t31_lite
+
+env:
+  TAG_NAME: toolchain-asan
+
+# Declared rather than inherited, the same way lint.yml argues for: the upload
+# step needs to create a release, and nothing else here needs any of it.
+permissions:
+  contents: write
+
+jobs:
+  toolchain-asan:
+    name: ASan toolchain (${{inputs.platform}})
+    runs-on: ubuntu-22.04
+    # A gcc built with libsanitizer runs a little over an hour on a runner. The
+    # default is six hours, which is long enough for a step that has hung rather
+    # than failed to hold a runner for most of a working day before saying so.
+    timeout-minutes: 150
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      # Deliberately no "skip if the release asset already exists" shortcut,
+      # which is what toolchain.yml does across its thirty-odd boards. The whole
+      # value of this artifact is the libsanitizer patches it carries, and those
+      # change; a run that quietly declined to rebuild would keep serving a
+      # toolchain missing the fix that was the reason for dispatching it.
+      - name: Build toolchain
+        run: |
+          GCC=$(make BOARD=${{inputs.platform}} toolname)-asan.tgz
+          make BOARD=${{inputs.platform}} toolchain-asan
+          SDK=$(find output/images -name '*_sdk-buildroot.tar.gz')
+          mv "${SDK}" "${GCC}"
+          echo "GCC=${GCC}" >> ${GITHUB_ENV}
+
+      # A toolchain that builds is not a toolchain that sanitizes. The checks
+      # live in a script rather than here so that whoever builds one by hand --
+      # which is the documented way to add a board -- can run exactly what CI
+      # runs before proposing it.
+      - name: Verify the artifact
+        run: bash general/scripts/verify-asan-toolchain.sh "${GCC}" output
+
+      - name: Upload toolchain
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{env.TAG_NAME}}
+          make_latest: false
+          files: ${{env.GCC}}
+          body: |
+            ASan-enabled OpenIPC toolchains: the stock ones in the `toolchain`
+            release are built without a sanitizer runtime, so there is no
+            `libasan.so` to deploy alongside an instrumented binary.
+
+            Consumed by majestic's `scripts/asan.sh` — see `docs/asan.md` there.
+            Prove the sanitizer works on your board with `scripts/asan.sh smoke`
+            before believing a leak-free `check`.

--- a/.github/workflows/toolchain-asan.yml
+++ b/.github/workflows/toolchain-asan.yml
@@ -2,19 +2,23 @@ name: toolchain-asan
 on:
   workflow_dispatch:
     inputs:
-      platform:
-        description: 'Board to build the ASan toolchain for'
+      family:
+        description: 'SoC family to build the ASan toolchain for'
         required: true
-        default: t31_lite
+        default: ingenic-t31
         type: choice
         options:
-          # Only boards where ASan has been proven end-to-end on real hardware
-          # with `scripts/asan.sh smoke` in the majestic repo. Building a
-          # toolchain is easy; knowing its sanitizer actually reports a leak on
-          # that SoC is not, and an unproven entry here would ship a green run
-          # that means nothing. Add a board once, and only once, smoke has
-          # reported the planted leak on it.
-          - t31_lite
+          # SoC families, not boards: `make toolname` yields
+          # toolchain.<vendor>-<family>, so one artefact serves every board on
+          # the family and the defconfig below is only where its configuration
+          # is read from. t31_lite and t31_ultimate produce the same toolchain.
+          #
+          # A family is listed only once ASan has been proven end-to-end on real
+          # hardware of that family, with `scripts/asan.sh smoke` in the
+          # majestic repo. Building a toolchain is easy; knowing its sanitizer
+          # actually reports is not, and an unproven entry here would ship a
+          # green run that means nothing.
+          - ingenic-t31
 
 env:
   TAG_NAME: toolchain-asan
@@ -26,7 +30,7 @@ permissions:
 
 jobs:
   toolchain-asan:
-    name: ASan toolchain (${{inputs.platform}})
+    name: ASan toolchain (${{inputs.family}})
     runs-on: ubuntu-22.04
     # A gcc built with libsanitizer runs a little over an hour on a runner. The
     # default is six hours, which is long enough for a step that has hung rather
@@ -44,8 +48,23 @@ jobs:
       # toolchain missing the fix that was the reason for dispatching it.
       - name: Build toolchain
         run: |
-          GCC=$(make BOARD=${{inputs.platform}} toolname)-asan.tgz
-          make BOARD=${{inputs.platform}} toolchain-asan
+          set -eu
+          # Any defconfig on the family will do; the toolchain it produces is
+          # named for the family, not for this board.
+          case "${{inputs.family}}" in
+          ingenic-t31) BOARD=t31_lite ;;
+          *) echo "::error::no defconfig mapped for ${{inputs.family}}"; exit 1 ;;
+          esac
+          NAME=$(make BOARD="${BOARD}" toolname)
+          # Catches a mapping that has drifted from the family it claims to
+          # serve, which would otherwise publish an artefact under a name no
+          # consumer asked for.
+          test "${NAME}" = "toolchain.${{inputs.family}}" || {
+            echo "::error::${BOARD} yields ${NAME}, not toolchain.${{inputs.family}}"
+            exit 1
+          }
+          GCC=${NAME}-asan.tgz
+          make BOARD="${BOARD}" toolchain-asan
           SDK=$(find output/images -name '*_sdk-buildroot.tar.gz')
           mv "${SDK}" "${GCC}"
           echo "GCC=${GCC}" >> ${GITHUB_ENV}

--- a/general/scripts/verify-asan-toolchain.sh
+++ b/general/scripts/verify-asan-toolchain.sh
@@ -1,0 +1,149 @@
+#!/bin/sh
+# Check that an ASan toolchain can actually sanitize, before anyone trusts it.
+#
+# A toolchain that builds is not a toolchain that sanitizes, and the gap between
+# the two is not theoretical. Of the six libsanitizer defects that stood between
+# an Ingenic camera and a working ASan, five announced themselves -- a hang, a
+# SEGV, a refusal -- and the sixth handed you a clean run with no leaks and exit
+# 0. Anything that ships a toolchain has to say more than "the build succeeded".
+#
+# Run against a tarball on its own to check a downloaded toolchain, or with a
+# build tree to also check that the libsanitizer patches were applied:
+#
+#   general/scripts/verify-asan-toolchain.sh toolchain.ingenic-t31-asan.tgz
+#   general/scripts/verify-asan-toolchain.sh <tarball> output
+#
+# What this cannot tell you is whether the sanitizer *reports* on your SoC. That
+# needs the target, and it is what majestic's `scripts/asan.sh smoke --host
+# <camera>` exists to answer. Run that before believing a leak-free `check`.
+
+set -u
+
+TARBALL=${1:-}
+TARGET_DIR=${2:-}
+PATCH_ROOT=${3:-general/package/all-patches/gcc}
+
+if [ -z "$TARBALL" ]; then
+	echo "usage: $0 <sdk-tarball> [buildroot-output-dir] [patch-root]" >&2
+	exit 2
+fi
+
+fail=0
+ok()   { echo "ok   $*"; }
+bad()  { echo "FAIL $*"; fail=$((fail + 1)); }
+note() { echo "--   $*"; }
+
+[ -f "$TARBALL" ] || { bad "$TARBALL does not exist"; exit 1; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# ---------------------------------------------------------------------------
+# 1. The libsanitizer patches were applied.
+#
+# They live in per-gcc-version directories, and Buildroot applies nothing at all
+# when the version it selected has no directory -- no warning, no failure. A
+# Buildroot bump that moves gcc from 13.3.0 to 14.x therefore produces a
+# toolchain that builds, links, runs, and never reports a leak. That is the same
+# outcome as the sixth defect above, reached by a different route, and it is
+# invisible unless something looks.
+if [ -z "$TARGET_DIR" ]; then
+	note "no build tree given: skipping the patch check."
+	note "pass Buildroot's output dir as the second argument to include it."
+elif [ ! -d "$TARGET_DIR" ]; then
+	bad "$TARGET_DIR is not a directory"
+else
+	build=$(echo "$TARGET_DIR"/build/host-gcc-final-*)
+	if [ ! -d "$build" ]; then
+		bad "no $TARGET_DIR/build/host-gcc-final-* -- gcc was not built here"
+	else
+		ver=${build##*host-gcc-final-}
+		applied=$build/.applied_patches_list
+		if [ ! -d "$PATCH_ROOT/$ver" ]; then
+			bad "gcc is $ver but $PATCH_ROOT/$ver does not exist"
+			note "the libsanitizer patches were not applied to this build."
+			note "port them to $ver before publishing anything built here."
+		elif [ ! -f "$applied" ]; then
+			bad "$applied is missing -- cannot tell which patches were applied"
+		else
+			n=0
+			missing=0
+			for p in "$PATCH_ROOT/$ver"/*libsanitizer*.patch; do
+				[ -e "$p" ] || break
+				base=${p##*/}
+				if grep -qF "$base" "$applied"; then
+					n=$((n + 1))
+				else
+					bad "$base ships for gcc $ver but was not applied"
+					missing=$((missing + 1))
+				fi
+			done
+			if [ "$missing" -ne 0 ]; then
+				note "$missing of $((n + missing)) shipped patches did not apply."
+				note "the checks below will still pass: a toolchain missing these"
+				note "builds, links, and cannot find a leak. That is the point."
+			elif [ "$n" -lt 2 ]; then
+				bad "only $n libsanitizer patch(es) found for gcc $ver"
+				note "expected the musl compat patch plus the target's own fixes."
+			else
+				ok "$n libsanitizer patches applied for gcc $ver"
+			fi
+		fi
+	fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2. The packaged tarball carries a runtime.
+#
+# Checked in the tarball rather than in the build tree because those are two
+# different things: the SDK bundle is assembled separately, and its sysroot copy
+# is the one that gets deployed next to the binary on the camera.
+mkdir -p "$WORK/sdk"
+if ! tar -xf "$TARBALL" -C "$WORK/sdk" --strip-components=1; then
+	bad "cannot unpack $TARBALL"
+	exit 1
+fi
+
+libs=$(find "$WORK/sdk" -name 'libasan.so.*' 2>/dev/null)
+if [ -z "$libs" ]; then
+	bad "no libasan.so.* in $TARBALL"
+	note "most likely --enable-libsanitizer did not reach the gcc configure"
+	note "line; check BR2_EXTRA_GCC_CONFIG_OPTIONS in the generated defconfig."
+else
+	for l in $libs; do
+		ok "runtime $(basename "$l") $(wc -c <"$l" | tr -d ' ') bytes"
+	done
+fi
+
+# ---------------------------------------------------------------------------
+# 3. The compiler in the tarball links -fsanitize=address.
+#
+# A libasan.so sitting in the sysroot does not mean the driver knows to use it.
+# The two are configured separately, and a gcc built without sanitizer support
+# rejects the flag outright while the library sits there looking present.
+# bin/ carries the driver under more than one name -- the full triple and a
+# short alias -- and they are the same compiler. Sorted only so the choice does
+# not depend on directory order.
+cc=$(find "$WORK/sdk/bin" -maxdepth 1 -name '*-gcc' 2>/dev/null | sort | tail -1)
+if [ -z "$cc" ]; then
+	bad "no cross gcc in $TARBALL"
+else
+	printf '#include <stdlib.h>\nint main(void){ (void)malloc(64); return 0; }\n' \
+		>"$WORK/leak.c"
+	if ! "$cc" -fsanitize=address -g -o "$WORK/leak" "$WORK/leak.c" 2>"$WORK/cc.err"; then
+		bad "$(basename "$cc") cannot link -fsanitize=address"
+		sed 's/^/     /' "$WORK/cc.err"
+	elif ! readelf -d "$WORK/leak" 2>/dev/null | grep -q libasan; then
+		bad "the test binary did not pick up libasan"
+	else
+		ok "$(basename "$cc") links -fsanitize=address"
+	fi
+fi
+
+echo
+if [ "$fail" -ne 0 ]; then
+	echo "$fail check(s) failed -- do not publish this toolchain"
+	exit 1
+fi
+echo "toolchain looks sane. It is still unproven until 'scripts/asan.sh smoke'"
+echo "reports the planted leak on the board itself."


### PR DESCRIPTION
Stacked on #2312 — retarget to `master` once that merges. Without those
libsanitizer patches a t31 ASan toolchain builds and then hangs before `main()`,
so the two are not independently useful.

## What this adds

`make BOARD=<board> toolchain-asan` has existed since #2003 and produces a gcc
with a sanitizer runtime. What has been missing is delivery: every agent wanting
to leak-check majestic on a musl board builds its own gcc first — eleven minutes
— and then has no way to hand the result to the next person.

- `.github/workflows/toolchain-asan.yml` — dispatch it, get
  `toolchain.<vendor>-<family>-asan.tgz` under a `toolchain-asan` release tag.
- `general/scripts/verify-asan-toolchain.sh` — the checks, as a script rather
  than a block of YAML, so whoever builds one by hand runs exactly what CI runs.

majestic's `build.sh` downloads the `-asan` variant on its own for any
non-`Release` build, so on a listed board the whole procedure becomes
`scripts/asan.sh smoke --host <camera>`.

The first toolchain is already published, built from this branch and verified on
the lab t31:
https://github.com/OpenIPC/firmware/releases/tag/toolchain-asan

## Three things that are deliberate

**The board list is a `choice`, not free text, and holds only `t31_lite`.** An
entry means someone ran majestic's `scripts/asan.sh smoke` on that hardware and
the sanitizer reported the planted faults. Building a toolchain proves nothing
about whether its sanitizer *reports*: five of the six mips32 defects fixed in
#2312 announce themselves, and the sixth hands you a clean run with exit 0.

**No "skip if the asset already exists".** `toolchain.yml` does that and across
thirty-odd boards it is right. Here the entire value of the artifact is the
libsanitizer patches it carries, and those change; a run that quietly declined
to rebuild would keep serving a toolchain missing the fix that was the reason
for dispatching it.

**It verifies before it uploads.** That the patches applied to the gcc version
Buildroot actually selected, that the packaged tarball carries a runtime, and
that its compiler links `-fsanitize=address`.

The first of those is the one that matters. The patches live in per-version
directories, so a Buildroot bump moves gcc out from under them, Buildroot
applies nothing, and the build still succeeds — producing a toolchain silently
unable to find a leak. Same failure mode as that sixth defect, by a different
route.

That is not a hypothetical, and the script demonstrates it. Run against
yesterday's t31 build tree with today's patch set:

```
FAIL 0004-libsanitizer-mips-ptrace-stack-pointer.patch ships for gcc 13.3.0 but was not applied
FAIL 0005-libsanitizer-no-unwinder-reentry.patch ships for gcc 13.3.0 but was not applied
...
--   6 of 9 shipped patches did not apply.
ok   runtime libasan.so.8 1460928 bytes
ok   mipsel-openipc-linux-musl-gcc links -fsanitize=address
```

**Both cheap checks pass on the broken toolchain.** Only the patch check
catches it.

## Verification

`general/scripts/verify-asan-toolchain.sh` on the published artifact:

```
ok   9 libsanitizer patches applied for gcc 13.3.0
ok   runtime libasan.so.8 1494724 bytes
ok   mipsel-openipc-linux-musl-gcc links -fsanitize=address
```

And on the lab t31 (mipsel o32 musl, 64 MB, `--low-memory`), the part no script
can answer — majestic's `scripts/asan.sh smoke`:

```
AddressSanitizer: heap-buffer-overflow ... READ of size 1  -> asan_probe_overflow
AddressSanitizer: heap-buffer-overflow ... WRITE of size 1 -> asan_probe_overflow
LeakSanitizer: detected memory leaks ... 81 byte(s)        -> asan_probe_leak_here
3 suspended thread(s) checked, every stack pointer inside its stack
```

`.github/scripts/lint-workflow-shell.py` passes; shellcheck clean under `-s sh`.