### PR TITLE
xm530: autoload the SD card driver at boot

### DIFF
--- a/.github/scripts/check_target_modules.sh
+++ b/.github/scripts/check_target_modules.sh
@@ -40,6 +40,7 @@ check_module() {
 }
 
 check_module BR2_PACKAGE_WIREGUARD_LINUX_COMPAT wireguard.ko
+check_module BR2_PACKAGE_XIONGMAI_OSDRV_XM530 sdio0_sd.ko
 
 if [ "$fail" -ne 0 ]; then
 	echo "check_target_modules: regression detected" >&2

--- a/.github/scripts/check_target_modules.sh
+++ b/.github/scripts/check_target_modules.sh
@@ -25,13 +25,13 @@ fi
 
 fail=0
 
-# config-var → expected .ko filename
+# config-var → expected .ko path (relative to lib/modules/<version>/)
 # Add new pairs here when a kernel-module package is introduced.
 check_module() {
 	var="$1"
 	ko="$2"
 	grep -q "^${var}=y" "$CONFIG" || return 0
-	if find "$TARGET_DIR/lib/modules" -name "$ko" | grep -q .; then
+	if find "$TARGET_DIR/lib/modules" -path "*/$ko" | grep -q .; then
 		echo "OK: $ko present (${var}=y)"
 	else
 		echo "MISSING: ${var}=y but $ko not found under $TARGET_DIR/lib/modules/" >&2
@@ -40,7 +40,7 @@ check_module() {
 }
 
 check_module BR2_PACKAGE_WIREGUARD_LINUX_COMPAT wireguard.ko
-check_module BR2_PACKAGE_XIONGMAI_OSDRV_XM530 sdio0_sd.ko
+check_module BR2_PACKAGE_XIONGMAI_OSDRV_XM530 xiongmai/sdio0_sd.ko
 
 if [ "$fail" -ne 0 ]; then
 	echo "check_target_modules: regression detected" >&2

--- a/general/package/xiongmai-osdrv-xm530/post-build-hook.sh
+++ b/general/package/xiongmai-osdrv-xm530/post-build-hook.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# xiongmai-osdrv-xm530 post-build hook.
+#
+# The vendor SD card driver (Arasan SDHC, module name sdio0_sd) ships in the
+# image but nothing ever loads it: it is not listed in /etc/modules, so
+# S35modules never modprobes it and /dev/mmcblk0 does not appear even with a
+# card in the slot. mdev's automount helper and majestic's record path expect
+# the card at /dev/mmcblk0p1.
+#
+# general/overlay/etc/modules is shared by every SoC, so the entry is appended
+# here, only for the images that select this package. The hook must run after
+# the rootfs overlay is applied, hence late-post-build-hooks.list rather than
+# the package's INSTALL_TARGET_CMDS.
+set -eu
+
+TARGET_DIR="${1:?target dir required}"
+
+MODULES="${TARGET_DIR}/etc/modules"
+if [ ! -f "${MODULES}" ]; then
+	echo "xiongmai-osdrv-xm530: ${MODULES} not found, cannot append sdio0_sd" >&2
+	exit 1
+fi
+
+if ! grep -qx "sdio0_sd" "${MODULES}"; then
+	printf 'sdio0_sd\n' >> "${MODULES}"
+fi

--- a/general/package/xiongmai-osdrv-xm530/post-build-hook.sh
+++ b/general/package/xiongmai-osdrv-xm530/post-build-hook.sh
@@ -11,6 +11,12 @@
 # here, only for the images that select this package. The hook must run after
 # the rootfs overlay is applied, hence late-post-build-hooks.list rather than
 # the package's INSTALL_TARGET_CMDS.
+#
+# Hot-plug is out of scope: the driver loads with detect=0, so sdio0_powerup()
+# leaves GPIO49 (sdio0_detect) unmuxed and need_detect/need_poll are both 0.
+# A card present at boot enumerates; one inserted afterwards is not detected.
+# /etc/modules takes arguments, so "sdio0_sd detect=1" is available if that
+# should change.
 set -eu
 
 TARGET_DIR="${1:?target dir required}"

--- a/general/scripts/late-post-build-hooks.list
+++ b/general/scripts/late-post-build-hooks.list
@@ -1,3 +1,4 @@
 # config-symbol:hook-script-relative-path
 BR2_PACKAGE_OPENIPC_NFS_ROOT:package/openipc-nfs-root/post-build-hook.sh
 BR2_PACKAGE_LIBNL:scripts/prune-libnl.sh
+BR2_PACKAGE_XIONGMAI_OSDRV_XM530:package/xiongmai-osdrv-xm530/post-build-hook.sh


### PR DESCRIPTION
## Problem

On XM530 boards the vendor SD card driver (Arasan SDHC, kernel module
`sdio0_sd`) ships in the image but is never loaded: `general/overlay/etc/modules`
only lists `vfat` and `exfat`, so `S35modules` never modprobes it. With a card in
the slot the kernel shows no mmc controller and no `/dev/mmcblk0`; mdev's
automount helper (`/lib/mdev/automount.sh`) and majestic's record path
(`/mnt/mmcblk0p1/%F`) both expect the card at `/dev/mmcblk0p1`, so SD storage is
dead out of the box.

The module entry is appended to `/etc/modules` by a late post-build hook keyed on
`BR2_PACKAGE_XIONGMAI_OSDRV_XM530` (xm530 and xm550 defconfigs), because
`general/overlay/etc/modules` is shared by every SoC and must stay board-agnostic.
`check_target_modules.sh` additionally asserts `sdio0_sd.ko` lands in the image
whenever the package is selected.

## Hardware tested on

XM530AI (marking 30WX1), board IPC-RB-BLK530AI-0235P-AB0 V1.03, "anbiux-A8B-3mp",
128GB FAT32 (SDXC) card.
```
root@openipc-xm530:~# ipctool 
The ipctool installed as remote GitHub plugin
---
chip:
  vendor: Xiongmai
  model: XM530
board:
  vendor: Xiongmai
ethernet:
  mac: "f4:b1:9c:a8:ca:1f"
rom:
- type: nor
  block: 64K
  partitions:
    - name: boot
      size: 0x40000
      sha1: 69533542
      contains:
        - name: xmcrypto
          offset: 0x2fc00
        - name: uboot-env
          offset: 0x30000
    - name: env
      size: 0x10000
      sha1: 71a375d2
    - name: kernel
      size: 0x200000
      sha1: 0e79e563
    - name: rootfs
      size: 0x500000
      path: /,squashfs
      sha1: dc91c741
    - name: rootfs_data
      size: 0xb0000
      path: /overlay,jffs2,rw
  size: 8M
ram:
  total: 64M
  media: 29M
firmware:
  kernel: "3.10.103+ (SMP Tue Aug 18 23:09:10 UTC 2026)"
  toolchain: buildroot-gcc-13.3.0
  main-app: /tmp/majestic
sensors:
- vendor: SmartSens
  model: SC3335
  control:
    bus: 0
    type: i2c
    addr: 0x60
root@openipc-xm530:~# 

```
## Evidence

Before — card inserted, kernel has no idea it exists:

```
root@openipc-xm530:~# cat /proc/partitions
major minor  #blocks  name
  31        0        256 mtdblock0
  31        1         64 mtdblock1
  31        2       2048 mtdblock2
  31        3       5120 mtdblock3
  31        4        704 mtdblock4
root@openipc-xm530:~# dmesg | grep -ci mmc
0
```

After (this patch, verified across a reboot):

```
arasan_set_clock:
	new freq 400000
mmc0: driver initialized... IRQ: 73, Base addr 0xc4e00000
arasan_set_clock:
	new freq 50000000
mmc0: new high speed SDXC card at address b368
mmcblk0: mmc0:b368 TW000 116 GiB
 mmcblk0: p1

root@openipc-xm530:~# df -h /mnt/mmcblk0p1
Filesystem       Size  Used Avail Use% Mounted on
/dev/mmcblk0p1   116G  32K  116G   1% /mnt/mmcblk0p1
```

Note: the kernel only supports vfat for the card (exfat is not built in and has
no module in this tree), so the card must be FAT32; this patch does not change
that.

## Scope

- [x] No kernel patches under `general/package/all-patches/linux/` (those go to [OpenIPC/linux](https://github.com/OpenIPC/linux))
- [x] No files specific to a single retail camera model (those go to [OpenIPC/builder](https://github.com/OpenIPC/builder))
- [x] No probing or bring-up tooling (that goes to [OpenIPC/ipctool](https://github.com/OpenIPC/ipctool))
- [x] Nothing under `general/overlay/` or in a shared `load_<vendor>` script hardcodes a value specific to my board
- [x] Package sources come from an OpenIPC repository, and any version bump keeps at least the specificity of the pin it replaces (a new package should pin a full 40-character SHA)
- [x] No `LD_PRELOAD`, and no binaries that cannot be rebuilt from source
- [x] New code is selected by a defconfig, so CI actually builds it
