### PR TITLE
libnl: drop the four sub-libraries nothing on the image links against

### DIFF
--- a/general/scripts/late-post-build-hooks.list
+++ b/general/scripts/late-post-build-hooks.list
@@ -1,2 +1,3 @@
 # config-symbol:hook-script-relative-path
 BR2_PACKAGE_OPENIPC_NFS_ROOT:package/openipc-nfs-root/post-build-hook.sh
+BR2_PACKAGE_LIBNL:scripts/prune-libnl.sh

--- a/general/scripts/prune-libnl.sh
+++ b/general/scripts/prune-libnl.sh
@@ -89,7 +89,15 @@ find "${TARGET_DIR}" -type f ! -path "${LIBDIR}/libnl*" -print0 > "${scan_list}"
 # libraries. Prove the pass can see inside a binary before trusting a negative:
 # every dynamically linked executable here carries libc.so in its dynamic
 # section, musl and uClibc alike.
-if ! xargs -0 -r -a "${scan_list}" grep -qaF -e 'libc.so' </dev/null 2>/dev/null; then
+#
+# "Did anything match" has to come from grep's OUTPUT, not from xargs' exit
+# status. A file list longer than ARG_MAX is split across several grep
+# invocations; `grep -q` exits 1 for every batch that happens to hold no ELF,
+# and xargs reports 123 if any single batch did. Reading that as "the scan is
+# broken" would skip the prune on exactly the large images this exists to help,
+# and skip it silently. Caught in review on #2317.
+libc_seen=$(xargs -0 -r -a "${scan_list}" grep -laF -e 'libc.so' </dev/null 2>/dev/null || true)
+if [ -z "${libc_seen}" ]; then
 	echo "prune-libnl: no libc.so reference found anywhere; scan is not working, not pruning"
 	exit 0
 fi

--- a/general/scripts/prune-libnl.sh
+++ b/general/scripts/prune-libnl.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+# Drop the libnl sub-libraries nothing on the image links against.
+#
+# Buildroot's libnl package installs six shared libraries and offers no
+# configure switch for a subset. On gk7205v300_lite that is 575KB of rootfs, of
+# which only two are reachable: wpa_supplicant's nl80211 driver speaks *generic*
+# netlink, so it links -lnl-3 -lnl-genl-3 and nothing else. The other four are
+# dead weight on every one of the ~97 boards that enable wpa_supplicant:
+#
+#   libnl-route-3  342KB  rtnetlink object model -- links, addresses, routes,
+#                         neighbours, and the whole traffic-control catalogue
+#                         (every qdisc, class and classifier type, every link
+#                         type). Each registers itself from a constructor, so
+#                         --gc-sections cannot drop any of it.
+#   libnl-nf-3      66KB  netfilter; needs libnl-route-3, needed by nothing
+#   libnl-xfrm-3    52KB  IPsec SA/SP
+#   libnl-idiag-3   27KB  inet_diag socket dumps
+#
+# Measured on gk7205v300_lite: 478KB out of the target dir, 176KB off the xz
+# squashfs (5100KB -> 4924KB), which takes that board from 20KB of headroom
+# against its 5120KB cap to 196KB. The initramfs boards get the full 480KB.
+#
+# The set to drop is DERIVED, not hardcoded. OpenIPC/builder carries variants
+# this tree does not build (iw, hostapd, the FPV configs), and a hand-written
+# list would quietly rot the day one of them grows a real libnl-route consumer
+# -- the same one-directional staleness the excludes lists in rootfs_script.sh
+# had to start reporting on. So: scan the image for each SONAME, keep what is
+# referenced, drop what is not.
+#
+# Matching is on raw bytes rather than DT_NEEDED via readelf, for two reasons.
+# It needs no binutils able to read the target's architecture, and it also
+# catches a dlopen()ed name or a library named from a script, neither of which
+# appears in a dynamic section. It over-matches by construction -- a mere
+# mention keeps the library -- which is the direction to fail in: shipping 27KB
+# we could have dropped costs headroom, dropping a library something loads at
+# runtime costs a camera that no longer joins its network.
+set -eu
+
+TARGET_DIR="${1:?target dir required}"
+LIBDIR="${TARGET_DIR}/usr/lib"
+
+[ -d "${LIBDIR}" ] || exit 0
+
+# Every list built below is one path or one SONAME per line, and a rootfs may
+# well sit under a directory with a space in its name.
+IFS='
+'
+
+# Real library files only; the SONAME and linker-name symlinks come off with
+# their target further down.
+libs=$(find "${LIBDIR}" -maxdepth 1 -type f -name 'libnl*-3.so.*' 2>/dev/null | sort)
+[ -n "${libs}" ] || exit 0
+
+# libnl-route-3.so.200.26.0 -> libnl-route-3.so.200, the string a consumer
+# carries in its DT_NEEDED.
+soname_of() {
+	printf '%s\n' "${1##*/}" | sed 's/\(\.so\.[0-9][0-9]*\)\..*$/\1/'
+}
+
+# libnl-route-3.so.200.26.0 -> libnl-route-3, enough to sweep up the two
+# symlinks that point at it.
+stem_of() {
+	printf '%s\n' "${1##*/}" | sed 's/\.so\..*$//'
+}
+
+# All six SONAMEs as a grep argument vector, reused by every pass.
+set --
+for lib in ${libs}; do
+	set -- "$@" -e "$(soname_of "${lib}")"
+done
+
+scan_list=$(mktemp)
+live_files=$(mktemp)
+trap 'rm -f "${scan_list}" "${live_files}"' EXIT
+
+# Which of the six SONAMEs are named by the files listed in $1. grep exits 1 for
+# a batch with no match and xargs turns that into 123, so neither is an error
+# here. The </dev/null keeps grep off the script's own stdin.
+referenced_by() {
+	list="$1"
+	shift
+	xargs -0 -r -a "${list}" grep -oahF "$@" </dev/null 2>/dev/null || true
+}
+
+find "${TARGET_DIR}" -type f ! -path "${LIBDIR}/libnl*" -print0 > "${scan_list}"
+
+# A scan that reads nothing looks exactly like an image that references nothing
+# -- and "nothing references libnl" is the answer that deletes all six
+# libraries. Prove the pass can see inside a binary before trusting a negative:
+# every dynamically linked executable here carries libc.so in its dynamic
+# section, musl and uClibc alike.
+if ! xargs -0 -r -a "${scan_list}" grep -qaF -e 'libc.so' </dev/null 2>/dev/null; then
+	echo "prune-libnl: no libc.so reference found anywhere; scan is not working, not pruning"
+	exit 0
+fi
+
+live=$(referenced_by "${scan_list}" "$@" | sort -u)
+
+# libnl-nf-3 links libnl-route-3, so a live library keeps its own dependencies.
+# Iterate to a fixed point rather than encoding that one edge by hand.
+while :; do
+	: > "${live_files}"
+	for soname in ${live}; do
+		find "${LIBDIR}" -maxdepth 1 -type f -name "${soname}.*" -print0 >> "${live_files}"
+	done
+	merged=$(
+		{
+			printf '%s\n' "${live}"
+			referenced_by "${live_files}" "$@"
+		} | sed '/^$/d' | sort -u
+	)
+	[ "${merged}" = "${live}" ] && break
+	live="${merged}"
+done
+
+freed=0
+dropped=
+kept=
+
+for lib in ${libs}; do
+	soname=$(soname_of "${lib}")
+	if printf '%s\n' "${live}" | grep -qxF "${soname}"; then
+		kept="${kept} ${soname}"
+		continue
+	fi
+	freed=$((freed + $(wc -c < "${lib}")))
+	rm -f "${LIBDIR}/$(stem_of "${lib}")".so*
+	dropped="${dropped} ${soname}"
+done
+
+# /etc/libnl/{classid,pktloc} are the traffic-control classid and packet-location
+# tables, parsed only by lib/route -- and by the CLI helpers, which OpenIPC does
+# not build (BR2_PACKAGE_LIBNL_TOOLS is off everywhere).
+case " ${dropped} " in
+	*" libnl-route-3.so."*)
+		if [ -d "${TARGET_DIR}/etc/libnl" ]; then
+			freed=$((freed + $(cat "${TARGET_DIR}"/etc/libnl/* 2>/dev/null | wc -c)))
+			rm -rf "${TARGET_DIR}/etc/libnl"
+		fi
+		;;
+esac
+
+if [ -n "${dropped}" ]; then
+	echo "prune-libnl: dropped${dropped} ($((freed / 1024))KB), kept${kept:-" nothing"}"
+else
+	echo "prune-libnl: all of${kept} referenced, nothing to drop"
+fi


### PR DESCRIPTION
## Problem

`gk7205v300_lite` builds with 20KB of headroom against its 5120KB rootfs cap and trips the
headroom warning every night. 575KB of that image is `libnl`, and 478KB of it is never loaded.

Buildroot's `libnl` installs six shared libraries and has no configure switch for a subset.
Nothing here selects it directly — `BR2_PACKAGE_WPA_SUPPLICANT_NL80211` is `default y` upstream
and `select`s it, so all six land on the 97 of 125 defconfigs that enable wpa_supplicant.

Only two are reachable. nl80211 is *generic* netlink, so `wpa_supplicant` and `wpa_passphrase`
link `-lnl-3 -lnl-genl-3` and nothing else:

| library | bytes | consumer |
|---|---:|---|
| `libnl-route-3.so.200.26.0` | 342,388 | none |
| `libnl-3.so.200.26.0` | 84,196 | wpa_supplicant, wpa_passphrase |
| `libnl-nf-3.so.200.26.0` | 65,968 | none (itself needs libnl-route-3) |
| `libnl-xfrm-3.so.200.26.0` | 52,292 | none |
| `libnl-idiag-3.so.200.26.0` | 26,708 | none |
| `libnl-genl-3.so.200.26.0` | 14,356 | wpa_supplicant, wpa_passphrase |
| `/etc/libnl/{classid,pktloc}` | 2,662 | `lib/route` only |

`libnl-route-3` dominates because it is a full rtnetlink object model — links, addresses,
routes, neighbours, rules and the entire traffic-control catalogue, each type registering itself
from a constructor, so `--gc-sections` drops none of it.

Checked across the fleet before calling them dead: the only other libnl consumers anywhere are
`rtw-hostapd` here (one board) and `iw` (6 boards) and `hostapd` (4) in OpenIPC/builder — all
generic-netlink users too. `BR2_PACKAGE_LIBNL_TOOLS` is unset everywhere, so libnl's own
`dlopen`-based CLI plugin path is not in play either.

## Fix

A post-build hook keyed on `BR2_PACKAGE_LIBNL` through the existing
`general/scripts/late-post-build-hooks.list` mechanism. One list line, one script, fleet-wide,
no per-board defconfig churn.

The set to drop is **derived, not hardcoded** — a hand-written list would rot silently the day a
board grows a real `libnl-route` consumer, the same one-directional staleness the excludes lists
had to start reporting on. The hook scans the assembled image for each SONAME, keeps what is
referenced, and iterates to a fixed point so a live library keeps its own dependencies (that is
the `libnl-nf-3` → `libnl-route-3` edge, left unencoded).

Matching is on raw bytes rather than `DT_NEEDED` via `readelf`: it needs no binutils able to read
the target's architecture, and it also catches a `dlopen`ed name or a library named from a
script. It over-matches by construction — a mere mention keeps the library — which is the
direction to fail in.

One case needed a guard. A scan that reads nothing is indistinguishable from an image that
references nothing, and that answer deletes all six libraries. So the pass must first find
`libc.so` somewhere in the image; if it cannot, it says so and prunes nothing.

## Hardware tested on

Goke gk7205v200, lab camera `openipc-gk7205v200` (`gk7205v200_lite`) — same SoC family as the
board this targets.

`gk7205v200_lite` built from this branch was flashed to that camera over `sysupgrade` and
booted. It comes up on the new build, majestic runs and returns real frames, and no binary in
the image has an unresolved link. Output below.

## Evidence

Before — `make BOARD=gk7205v300_lite`, this branch's parent (`f3855667`):

```
- uImage: [1783KB/2048KB]
- rootfs.squashfs: [5100KB/5120KB]
-- headroom warning: rootfs.squashfs has 20KB left of 5120KB
```

After — same tree, same output dir, hook enabled:

```
prune-libnl: dropped libnl-idiag-3.so.200 libnl-nf-3.so.200 libnl-route-3.so.200 libnl-xfrm-3.so.200 (478KB), kept libnl-3.so.200 libnl-genl-3.so.200
- uImage: [1783KB/2048KB]
- rootfs.squashfs: [4924KB/5120KB]
```

The headroom warning is gone. Image bytes:

```
rootfs.squashfs.gk7205v300         5222400 ->   5042176  (-180224 B, -176 KB)
rootfs.cpio                       13927424 ->  13435392  (-492032 B, -480 KB)
openipc.gk7205v300-nor-lite.tgz    7029040 ->   6849207  (-179833 B, -175 KB)
uImage.gk7205v300                  1826325 ->   1826325  (      +0 B)
```

Headroom against the 5120KB cap: **20KB → 196KB**.

On the camera — every libnl consumer in a shipped image, via musl `ldd` over each binary:

```
# openipc-gk7205v200, /usr/lib/libnl* excluded from the scan
  /usr/sbin/wpa_passphrase -> libnl-3.so.200 libnl-genl-3.so.200
  /usr/sbin/wpa_supplicant -> libnl-3.so.200 libnl-genl-3.so.200

# ldd /usr/sbin/wpa_supplicant
/lib/ld-musl-arm.so.1 (0x7f622000)
libnl-3.so.200 => /usr/lib/libnl-3.so.200 (0xb6ed4000)
libnl-genl-3.so.200 => /usr/lib/libnl-genl-3.so.200 (0xb6ecf000)
libc.so => /lib/ld-musl-arm.so.1 (0x7f622000)
```

Still on the camera, with the four libraries physically absent — a chroot holding only ld-musl,
libc, the two kept libraries and the two binaries:

```
chroot contains ONLY:
/bin/busybox
/lib/ld-musl-arm.so.1
/lib/libc.so
/usr/lib/libnl-3.so.200
/usr/lib/libnl-3.so.200.26.0
/usr/lib/libnl-genl-3.so.200
/usr/lib/libnl-genl-3.so.200.26.0
/usr/sbin/wpa_passphrase
/usr/sbin/wpa_supplicant

=== wpa_supplicant -v inside the chroot ===
Could not open /dev/urandom.
wpa_supplicant v2.10
Copyright (c) 2003-2022, Jouni Malinen <j@w1.fi> and contributors
exit=0

=== wpa_passphrase inside the chroot ===
network={
	ssid="TestSSID"
	#psk="secretpass123"
	psk=5921a9584c92c6f6f297dc7050d9ff4356665c6c56b04cd2c0236091b3348a79
}
exit=0
```

(The `/dev/urandom` line is the empty chroot having no devfs, not a libnl problem.)

Link closure over the whole pruned rootfs — every `DT_NEEDED` of every ELF, before vs after:

```
before: 25  after: 25
IDENTICAL -- no new unresolved links introduced

all findings are the same one SONAME:
libc.so.0
```

Those 25 are the uClibc-built Goke vendor blobs asking for `libc.so.0`; they are present
unchanged in the baseline image and have nothing to do with this change.

Flashed to the camera and rebooted — `sysupgrade --url=...`:

```
RootFS updated to local+build, 2026-08-26
Unconditional reboot
```

After the reboot, on the camera:

```
OPENIPC_VERSION=2.6.08.26
GITHUB_VERSION="local+build, 2026-08-26"
 16:16:36 up 0 min,  load average: 0.29, 0.07, 0.02

=== libnl on the flashed camera ===
libnl-3.so
libnl-3.so.200
libnl-3.so.200.26.0
libnl-genl-3.so
libnl-genl-3.so.200
libnl-genl-3.so.200.26.0
/etc/libnl: absent

=== wpa_supplicant links and runs ===
	/lib/ld-musl-arm.so.1 (0x7f575000)
	libnl-3.so.200 => /usr/lib/libnl-3.so.200 (0xb6f70000)
	libnl-genl-3.so.200 => /usr/lib/libnl-genl-3.so.200 (0xb6f6b000)
	libc.so => /lib/ld-musl-arm.so.1 (0x7f575000)
wpa_supplicant v2.10

majestic: running (pid 727)

=== any binary with an unresolved link ===
(scan complete)          <- /usr/sbin/* /usr/bin/* /bin/* /sbin/*, nothing reported

=== snapshot from majestic ===
http 200, 38070 bytes
magic: ffd8ff  (ffd8ff = JPEG)
```

The only dmesg errors are the pre-existing SPI-NAND probe failing on a NOR board
(`Cannot found a valid SPI Nand Device`), present before this change too.

Hook behaviour, exercised against real built rootfs trees:

- idempotent — a second run reports `all of libnl-3.so.200 libnl-genl-3.so.200 referenced, nothing to drop`
- a tree with no libnl: silent no-op, exit 0
- positive control failing: `no libc.so reference found anywhere; scan is not working, not pruning`, nothing removed
- planting a binary that names `libnl-nf-3` keeps nf **and** route **and** `/etc/libnl`, while
  still dropping idiag and xfrm — the fixed-point iteration works
- driven end-to-end through `rootfs_script.sh`: fires on `BR2_PACKAGE_LIBNL=y`, does not fire
  when only `BR2_PACKAGE_LIBNL_TOOLS=y` is set

Repo gates:

```
ci-matrix: self-test ok (99 boards, 132 packages, 52 cases)
ci-matrix: 99/99 boards --- general/scripts/prune-libnl.sh affects every board
checked 129 shell script(s) / all parsed clean under busybox ash
129 shipped scripts parse identically after stripping
self-test passed / checked 51 run block(s) / all run blocks parse clean
All load_hisilicon regression checks passed.
All sysupgrade verification checks passed.
```

`shellcheck -s sh` is clean on the new script. `dash -n`, `bash -n` and `busybox ash -n` all
parse it.

## Scope

- [x] No kernel patches under `general/package/all-patches/linux/`
- [x] No files specific to a single retail camera model
- [x] No probing or bring-up tooling
- [x] Nothing under `general/overlay/` or in a shared `load_<vendor>` script hardcodes a value specific to my board
- [x] No package sources or version pins are touched by this PR
- [x] No `LD_PRELOAD`, and no binaries that cannot be rebuilt from source
- [x] Keyed on `BR2_PACKAGE_LIBNL`, which 97 defconfigs reach; `ci-matrix.py` widens this path to the full 99-board matrix
