### PR TITLE
wpa_supplicant: drop TDLS and 802.11r, which no camera can use

### DIFF
--- a/general/external.mk
+++ b/general/external.mk
@@ -11,5 +11,22 @@ EXTERNAL_VENDOR := $(BR2_EXTERNAL)/../br-ext-chip-$(OPENIPC_SOC_VENDOR)
 OPENIPC_KERNEL := $(OPENIPC_SOC_VENDOR)-$(OPENIPC_SOC_FAMILY)
 OPENIPC_TOOLCHAIN := toolchain/toolchain.$(OPENIPC_KERNEL)
 
+# Buildroot leaves upstream's wpa_supplicant defconfig defaults for TDLS and
+# 802.11r in place and offers no Kconfig switch for either, so every board that
+# enables wpa_supplicant carries both. Neither can fire on a camera: TDLS sets
+# up direct station-to-station data links, and a camera only ever talks to its
+# AP; 802.11r is fast BSS transition, and a fixed-mount camera does not roam
+# between APs. Measured on gk7205v300_lite -- 28,860 and 21,940 bytes of the
+# unstripped binary, 44,976 off the stripped one.
+#
+# Appending to the package's own list rather than patching its defconfig works
+# because Buildroot includes this file (Makefile:545) after package/*/*.mk
+# (Makefile:531), and expands WPA_SUPPLICANT_CONFIGURE_CMDS when the rule runs
+# rather than at parse time. That leaves nothing to rebase when the package is
+# bumped. If a future Buildroot ever reorders those includes this stops taking
+# effect silently, and the symptom is the wpa_supplicant binary going back up
+# by ~45KB in the size report rather than anything failing.
+WPA_SUPPLICANT_CONFIG_DISABLE += CONFIG_TDLS CONFIG_IEEE80211R
+
 include $(sort $(wildcard $(BR2_EXTERNAL)/package/*/*.mk))
 include $(sort $(wildcard $(BR2_EXTERNAL)/package/legacy/*/*.mk))


### PR DESCRIPTION
## Problem

`wpa_supplicant` is 598,426 B on `gk7205v300_lite` — the largest non-vendor package after majestic
and busybox, on a board that had 24KB of rootfs headroom before #2317.

It is already lean where such things usually are not: EAP is off, TLS is off (`tls_none.o` is 165
bytes), and so are WPS, WPA3/SAE, mesh, P2P, D-Bus and hotspot. No defconfig in this tree enables
any of them. What is left is two features inherited from upstream's `defconfig` that Buildroot
offers no Kconfig switch for, so every board that enables wpa_supplicant carries both:

- **`CONFIG_TDLS`** — Tunneled Direct Link Setup, direct station-to-station data links. A camera
  only ever talks to its AP.
- **`CONFIG_IEEE80211R`** — fast BSS transition, for roaming between APs. A fixed-mount camera
  does not roam.

## Fix

One line appended to the package's own `WPA_SUPPLICANT_CONFIG_DISABLE` in `general/external.mk`.
That works rather than needing a patch because Buildroot includes `external.mk` (`Makefile:545`)
after `package/*/*.mk` (`Makefile:531`) and expands `WPA_SUPPLICANT_CONFIGURE_CMDS` when the rule
runs rather than at parse time — so there is nothing to rebase when the package is bumped.

Everything else in the config was measured, not assumed, and deliberately left alone:

| symbol | measured cost | why it stays / goes |
|---|---:|---|
| `CONFIG_TDLS` | 28,860 B | removed — peer-to-peer links, unusable here |
| `CONFIG_IEEE80211R` | 21,940 B | removed — roaming, unusable here |
| `CONFIG_PKCS12` | **0 B** | inert — needs TLS, which is not built |
| `CONFIG_CTRL_IFACE_DBUS_INTRO` | **0 B** | inert — needs D-Bus, which is not built |
| `CONFIG_IEEE80211AC` | **0 B** | compiled unconditionally in 2.10 |
| `CONFIG_BGSCAN_SIMPLE` | 4 B | noise |

Three things kept on purpose:

- **WEXT** — the shipped `general/overlay/etc/network/interfaces.d/wlan0` asks for
  `-D nl80211,wext`, and `wiki/ru/configuration.md` documents `-D wext` alone. Vendor WiFi
  drivers that predate cfg80211 need it.
- **`wpa_cli`** (67,864 B) — `majestic-webui`'s `www/cgi-bin/j/network.cgi` uses it as its primary
  WiFi scan path, with `iwlist` only as fallback.
- **`wpa_passphrase`** (30,176 B) — used by the shipped `wlan0` script and by every wiki page that
  documents WiFi setup.

## Hardware tested on

Goke gk7205v200, lab camera `openipc-gk7205v200`, running `gk7205v200_lite` built from this branch
and flashed over `sysupgrade`.

## Evidence

Before — `make BOARD=gk7205v300_lite` on this branch's parent:

```
- rootfs.squashfs: [4924KB/5120KB]
wpa_supplicant: 500304 B
```

After — same tree, same output dir:

```
- rootfs.squashfs: [4904KB/5120KB]
wpa_supplicant: 455248 B
```

Image bytes:

```
rootfs.squashfs.gk7205v300         5042176 ->   5021696  (-20480 B)
rootfs.cpio                       13435392 ->  13390336  (-45056 B)
openipc.gk7205v300-nor-lite.tgz    6849201 ->   6829878  (-19323 B)
```

Effective build config after the change — `CONFIG_TDLS` and `CONFIG_IEEE80211R` gone, nothing else
moved:

```
CONFIG_DRIVER_WEXT=y CONFIG_DRIVER_NL80211=y CONFIG_LIBNL32=y CONFIG_PKCS12=y
CONFIG_CTRL_IFACE=y CONFIG_BACKEND=file CONFIG_TLS=internal
CONFIG_INTERNAL_LIBTOMMATH=y CONFIG_INTERNAL_LIBTOMMATH_FAST=y
CONFIG_CTRL_IFACE_DBUS_INTRO=y CONFIG_DEBUG_FILE=y CONFIG_IEEE80211AC=y
CONFIG_MATCH_IFACE=y CONFIG_BGSCAN_SIMPLE=y
```

Symbol check on the unstripped binary — the two features are gone and the association and PSK
paths are untouched:

```
tdls                 0
wpa_ft_              0
sme_                 24
wpa_pmk              1
pbkdf2               1
wpa_supplicant_init  4
```

On the camera, after flashing and rebooting:

```
OPENIPC_VERSION=2.6.08.27
 08:05:28 up 4 min,  load average: 0.46, 0.26, 0.10

/usr/sbin/wpa_supplicant  455248 B
/usr/sbin/wpa_cli          67864 B
/usr/sbin/wpa_passphrase   30176 B

wpa_supplicant v2.10
wpa_cli v2.10
network={ ssid="TestNet" psk=45c21ffa733326253794a222c4875b3e20623f1d6615916e707072d14dcd3cb1 }
```

Daemon start, control interface and the `wpa_cli` round-trip, exercised on the camera without WiFi
hardware via the global control socket:

```
=== daemon + global ctrl_iface + wpa_cli round-trip ===
Successfully initialized wpa_supplicant
  daemon up (pid 790)
  -- wpa_cli ping:
PONG
  -- add an interface:
FAIL              <- expected, no such netdev

=== config parser handles a real PSK network block ===
Could not read interface nosuchdev flags: No such device    <- expected
(no parse errors)
```

majestic still runs and serves frames on the flashed camera:

```
majestic: running
snapshot: http 200, 36659 B
```

Link closure over the rebuilt rootfs is unchanged from baseline — the same 25 pre-existing
`libc.so.0` findings from the uClibc-built Goke vendor blobs, no new unresolved links.

Repo gates:

```
ci-matrix: self-test ok (99 boards, 132 packages, 52 cases)
ci-matrix: 99/99 boards --- general/external.mk affects every board
checked 129 shell script(s) / all parsed clean under busybox ash
All strip-shell-comments checks passed.
all run blocks parse clean
All load_hisilicon regression checks passed.
All sysupgrade verification checks passed.
```

## Scope

- [x] No kernel patches under `general/package/all-patches/linux/`
- [x] No files specific to a single retail camera model
- [x] No probing or bring-up tooling
- [x] Nothing under `general/overlay/` or in a shared `load_<vendor>` script hardcodes a value specific to my board
- [x] No package sources or version pins are touched by this PR
- [x] No `LD_PRELOAD`, and no binaries that cannot be rebuilt from source
- [x] `ci-matrix.py` widens `general/external.mk` to the full 99-board matrix
