### PR TITLE
hisilicon: load the Cipher engine on cv500 and ev200

### DIFF
--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = 5ccb5e9a
+HISILICON_OPENSDK_VERSION = 5ccb5e9a276d0d4514551fbe69c7a423de2d09d2
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE

--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = 2d637e35
+HISILICON_OPENSDK_VERSION = 5ccb5e9a
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE

--- a/general/package/hisilicon-osdrv-hi3516cv500/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516cv500/files/script/load_hisilicon
@@ -172,9 +172,28 @@ insert_ko() {
 
     # insert_gyro
     modprobe open_wdt
+
+    # Cipher engine -> /dev/cipher. majestic's native WebRTC takes AES-CTR for
+    # its SRTP transform from here: measured on this part, 86.4us of CPU per
+    # 1100-byte packet in software against 38.4 through the engine, because
+    # the driver sleeps on its completion interrupt and gives the CPU back
+    # while the block works. See docs/hisi/cipher-engine.md in majestic.
+    #
+    # The module has shipped in this image for as long as the opensdk install
+    # has globbed open_*.ko; nothing ever loaded it, so /dev/cipher did not
+    # exist and majestic silently stayed in software. Costs ~170 KB of module
+    # plus 8 KB of DMA descriptors (SYMC_NODE_SIZE * 2 per channel, 8
+    # channels).
+    #
+    # Last, and after open_osal: modprobe would otherwise pull osal in as a
+    # dependency at whatever point this ran, ahead of insert_osal's own
+    # arguments. Failure is not an error -- a kernel without the block simply
+    # has no module to find, and that must not abort sensor bring-up.
+    modprobe open_cipher 2>/dev/null
 }
 
 remove_ko() {
+    rmmod -w open_cipher 2>/dev/null
     rmmod -w open_wdt
     # rmmod_gyro
     # rmmod -w open_user

--- a/general/package/hisilicon-osdrv-hi3516ev200/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516ev200/files/script/load_hisilicon
@@ -208,9 +208,29 @@ insert_ko() {
 	modprobe open_mipi_rx
 	#	modprobe open_user
 	modprobe open_wdt
+
+	# Cipher engine -> /dev/cipher. majestic's native WebRTC takes AES-CTR
+	# for its SRTP transform from here: measured on an hi3516ev300, 86.0us of
+	# CPU per 1100-byte packet in software against 41.9 through the engine,
+	# because the driver sleeps on its completion interrupt and gives the CPU
+	# back while the block works. See docs/hisi/cipher-engine.md in majestic.
+	#
+	# New here in a way it is not on the other HiSilicon boards: this family
+	# never packaged a cipher module at all, and openhisilicon only started
+	# building one for hi3516ev200 recently. The vendor prebuilt could not
+	# have been used -- it links against hil_mmb_getby_phys_2, which this
+	# tree's osal did not export.
+	#
+	# Last, and after open_osal: modprobe would otherwise pull osal in as a
+	# dependency at whatever point this ran, ahead of insert_osal's own
+	# arguments. Failure is not an error -- an image built before that
+	# openhisilicon bump simply has no module to find, and that must not
+	# abort sensor bring-up.
+	modprobe open_cipher 2>/dev/null
 }
 
 remove_ko() {
+	rmmod -w open_cipher 2>/dev/null
 	rmmod -w open_wdt
 	#	rmmod -w hi_user
 	remove_audio


### PR DESCRIPTION
Every HiSilicon V3/V4 part has a Cipher block. No OpenIPC image has ever loaded its driver, so `/dev/cipher` does not exist on any shipped camera and majestic's native WebRTC stack has been doing the whole SRTP transform on the CPU.

Two commits: load the module, and bump `openhisilicon` to the commit that lets hi3516ev200 build one.

## `hisilicon: load the Cipher engine on hi3516cv500 and hi3516ev200`

A `modprobe open_cipher` at the end of `insert_ko()`, and `rmmod -w open_cipher` first in `remove_ko()`, in both families' `load_hisilicon`.

Measured per 1100-byte packet — the size majestic's SRTP actually runs over — software against the engine, on the two lab boards:

| board | mbedTLS 2.25 | Cipher engine |
|---|---|---|
| hi3516av300 (cv500) | 86.4 µs CPU | 38.4 µs |
| hi3516ev300 (ev200) | 86.0 µs CPU | 41.9 µs |

Both a little over half. More is saved in CPU than in wall clock, because the V4 driver sleeps on its completion interrupt and gives the core back while the block works — which is the resource a camera is short of. majestic probes the device once and falls back to mbedTLS when it is absent, so nothing here is load-bearing for a board that lacks it.

**Placed last in `insert_ko()`, not beside the `open_hwrng` modprobe near the top,** and that is the one non-obvious part. `open_cipher` depends on `open_osal`, so `modprobe` would pull osal in as a dependency at whatever point this ran — ahead of `insert_osal()`, which loads it with the `mmz=` arguments that decide the whole memory layout. Last means osal is already up on its own terms. `remove_ko()` drops it first, in reverse.

Errors are swallowed for the same reason `open_hwrng` swallows them: a board whose kernel has no cipher block, or an image built before the bump below, simply has no module to find, and that must not abort sensor bring-up.

**Not done for hi3516cv300**, which also ships an unloaded cipher module. It is the one measured board where the engine *loses* — 164 µs against 150 — because its gen-3 driver busy-polls instead of sleeping, so no CPU comes back either. majestic's backend is gen-4 only, and loading it there would cost two 1 MB contiguous kernel allocations on a 27 MB board to buy nothing.

## `hisilicon-opensdk: bump to 5ccb5e9a for the ev200 cipher module`

Two commits since the current pin: one CI-only, and OpenIPC/openhisilicon#214, which teaches openhisilicon to build a cipher module for hi3516ev200 from the Hi3516EV200 SDK's own driver source. hi3516ev200/ev300 is the one HiSilicon family whose image has never carried a cipher module *at all* — cv500 and cv300 both package one and never load it; here there was nothing to load — so the previous commit does nothing on those boards until this moves.

#214 also carries two fixes that reach beyond ev200:

* `mmz_mmb_getby_phys_2` was the one `mmb_` function still on a plain `EXPORT_SYMBOL`, so `hil_mmb_getby_phys_2` was never aliased and any source-built vendor driver referencing it failed to load.
* The vendor's symc wait treated `-ERESTARTSYS` as success, returning a buffer the DMA had not written yet. That bug already ships on hi3516av300, where the cipher module is built today.

### Rootfs cost

ev200 gets its modules through buildroot's `kernel-module` infra, so `open_cipher.ko` lands in `/lib/modules/<kver>/extra/` with no packaging change here, and depmod records the `open_osal` dependency. Stripped and squashed it costs about **50 KB**.

Checked rather than assumed, against the 2026-08-27 nightly. The ev200-family boards on the 5120 KB NOR cap:

| board | today | headroom after |
|---|---|---|
| hi3518ev200_lite | 4692 KB | ~378 KB |
| hi3516ev200_lite | 4704 KB | ~366 KB |
| hi3516ev300_neo | 4660 KB | ~410 KB |
| hi3516ev300_lite | 4800 KB | ~270 KB |
| hi3518ev300_lite | 4920 KB | ~150 KB |

The `ultimate` variants are on an 8192 KB cap with 440 KB or more spare. The tightest board keeps 150 KB.

Worth flagging while I was in there: the trim block in `hisilicon-opensdk.mk` still describes `hi3518ev300_lite` as sitting at exactly 5120/5120. That stopped being true when the three sensors it drops were dropped — it is at 4920 KB now. Left alone in this PR.

cv500 is unaffected by the bump: its cipher module has always been built and installed there, and only the first commit makes anything load it.

## Testing

* On hi3516av300: `modprobe open_cipher` resolves, `/dev/cipher` appears, `rmmod -w open_cipher` unloads it cleanly.
* On hi3516ev300: with an openhisilicon build carrying #214, the module loads and a userspace harness drives it through 600 differential AES-CTR cases — every length from 1 byte to 2048, byte-identical to mbedTLS, nothing written past the requested length — plus known-answer checks for NIST SP 800-38A F.5.1 and a vector across a 32-bit counter wrap.
* On hi3516ev300 without it: the absent case returns quietly and the script carries on.
* `.github/scripts/test_load_hisilicon.sh`, `test_sysupgrade.sh` and `ci-matrix.py --self-test` pass locally.

## What this does not do

Nothing consumes `/dev/cipher` yet. majestic's side is a separate change that lands only once these builds are published, which is why the module having no user for a while is the intended state and why every failure path here is silent.
