### PR TITLE
Makefile: keep the host C dialect out of host C++ builds, and make gcc-compat block

### DIFF
--- a/.github/workflows/gcc-compat.yml
+++ b/.github/workflows/gcc-compat.yml
@@ -1,26 +1,89 @@
+# Does the tree still build on the host compilers people actually have?
+#
+# Five `gcc:N` containers build one board from scratch. What it catches is host
+# toolchain rot -- a Buildroot-pinned host package whose configure stops
+# compiling when a new GCC changes a language default -- which no target build
+# can see, because those run under our own cross toolchains.
+#
+# This is a REQUIRED check, via the GCC Gate job at the bottom, and it is
+# required because it spent 2026-08-26 to 2026-08-27 red on master without
+# anyone noticing: #2311 introduced the breakage and merged with its own five
+# rows red, and nothing ran the workflow again because it only fired on PRs
+# touching these paths. An advisory check that reports a real breakage and is
+# merged over is worse than no check -- it costs the minutes and buys the
+# confidence without earning it.
+#
+# The narrowing therefore happens in the `select` job below, which ALWAYS runs,
+# never in a `paths:` filter on the trigger. This is the same lesson build.yml
+# records: a workflow filtered out by `paths:` does not run at all, so a
+# required check from it would stay pending forever and the PR could never be
+# merged. Off the relevant paths, `select` costs about ten seconds and the gate
+# passes on a skipped matrix.
 name: gcc-compat
 on:
   pull_request:
     branches:
       - master
-    paths:
-      - 'Makefile'
-      - 'general/package/**/*.mk'
-      - 'general/package/all-patches/**'
-      - '.github/workflows/gcc-compat.yml'
   schedule:
     - cron: '0 6 * * 0'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
-  gcc-compat:
-    name: GCC ${{matrix.gcc}}
+  select:
+    name: Select GCC rows
     # Same guard rail as build.yml's preflight: run where the minutes are
     # free or explicitly asked for, skip unattended/billed mirror runs.
     if: >-
       github.repository == 'OpenIPC/firmware' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && !github.event.repository.private)
+    runs-on: ubuntu-latest
+    outputs:
+      needed: ${{ steps.pick.outputs.needed }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: pick
+        name: Can this change reach a host build?
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -eu
+          # The weekly cron and a manual dispatch have no diff to narrow by,
+          # and are the runs whose whole purpose is to catch a GCC that moved
+          # under a tree that did not.
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+            echo "$GITHUB_EVENT_NAME: running the full matrix"
+            exit 0
+          fi
+          # Ask for the PR's own file list rather than diffing two SHAs. A
+          # two-dot diff against base.sha also reports whatever landed on master
+          # since the branch point -- which would run five containers because
+          # somebody else touched a .mk -- and a three-dot one needs a merge
+          # base this shallow checkout does not have.
+          files=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR/files" -q '.[].filename')
+          echo "changed:"; echo "$files" | sed 's/^/  /'
+          # The same set the `paths:` filter used to carry: the top-level
+          # Makefile (host flags, Buildroot version, the prepare: patches), any
+          # package recipe, the global patch dir, and this file.
+          if echo "$files" | grep -qE '^(Makefile$|general/package/.*\.mk$|general/package/all-patches/|\.github/workflows/gcc-compat\.yml$)'; then
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+            echo "-> host builds are reachable; running the matrix"
+          else
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            echo "-> nothing here reaches a host build; skipping the matrix"
+          fi
+
+  gcc:
+    name: GCC ${{matrix.gcc}}
+    needs: select
+    if: needs.select.outputs.needed == 'true'
     runs-on: ubuntu-latest
     container:
       image: gcc:${{matrix.gcc}}
@@ -50,3 +113,43 @@ jobs:
         run: make BOARD=gk7205v200_lite
         env:
           FORCE_UNSAFE_CONFIGURE: 1
+
+  # The required context. Branch protection cannot require `GCC 12`..`GCC 16`
+  # directly, because on a PR that does not reach a host build those five never
+  # run and would sit pending forever.
+  gcc-gate:
+    name: GCC Gate
+    needs: [select, gcc]
+    # always() so the gate still reports when a needed job fails -- but not on a
+    # run whose select the guard above deliberately skipped, where it would read
+    # select=skipped and turn a saved build into a red run. Upstream the added
+    # disjunct is true, so this reduces to always().
+    if: >-
+      always() && (github.repository == 'OpenIPC/firmware' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !github.event.repository.private))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the host-build matrix to succeed
+        run: |
+          echo "select=${{ needs.select.result }} needed=${{ needs.select.outputs.needed }} matrix=${{ needs.gcc.result }}"
+          if [ "${{ needs.select.result }}" != "success" ]; then
+            echo "::error::GCC row selection did not succeed"; exit 1
+          fi
+          if [ "${{ needs.select.outputs.needed }}" = "true" ]; then
+            # One failing container out of five still fails the run. They build
+            # the same board from the same tree and differ only in the host
+            # compiler, so a single red row IS the finding.
+            if [ "${{ needs.gcc.result }}" != "success" ]; then
+              echo "::error::a host GCC row did not succeed"; exit 1
+            fi
+          else
+            # Not blanket-accepting 'skipped': a selector that decided a change
+            # was irrelevant and then ran the matrix anyway, or one that let a
+            # cancelled matrix through, would otherwise read as green.
+            if [ "${{ needs.gcc.result }}" != "skipped" ]; then
+              echo "::error::matrix reported '${{ needs.gcc.result }}' for a change that does not reach a host build"; exit 1
+            fi
+            echo "no host build reachable from this change"
+          fi
+          echo "GCC Gate: pass"

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ export CMAKE_POLICY_VERSION_MINIMUM := 3.5
 # version bump for every affected host package. Applies only to host C builds,
 # is overridable from the environment, and is a no-op on hosts whose GCC still
 # defaults to gnu17.
+#
+# "Applies only to host C builds" is what the prepare: rule below has to make
+# true -- Buildroot appends HOST_CFLAGS to HOST_CXXFLAGS wholesale.
 HOST_CFLAGS ?= -O2 -std=gnu17
 export HOST_CFLAGS
 
@@ -62,6 +65,23 @@ prepare:
 			$(TARGET)/buildroot-$(BR_VER)/linux/Config.in || \
 		sed -i '/source "linux\/Config.ext.in"/a source "$$BR2_EXTERNAL_GENERAL_PATH/linux/Config.ext.in"' \
 			$(TARGET)/buildroot-$(BR_VER)/linux/Config.in; \
+	fi
+	@# Keep the C dialect pinned at the top of this file out of host C++ builds.
+	@# package/Makefile.in does `HOST_CXXFLAGS += $$(HOST_CFLAGS)`, so -std=gnu17
+	@# reaches every host C++ compile, where it is not a C++ dialect at all: g++
+	@# ignores it and prints "command-line option '-std=gnu17' is valid for
+	@# C/ObjC but not for C++". Compilation still succeeds -- what does not is
+	@# CMake, whose cm_check_cxx_feature discards any feature whose try_compile
+	@# output contains the word "warning" (Source/Checks/cm_cxx_features.cmake).
+	@# host-cmake therefore decides the compiler has no std::unique_ptr and
+	@# aborts its own configure, taking every `make BOARD=...` with it.
+	@# Filtering -std= rather than that one value so a C dialect set from the
+	@# environment does not reintroduce this.
+	@if test -f $(TARGET)/buildroot-$(BR_VER)/package/Makefile.in; then \
+		grep -qF 'filter-out -std=%' \
+			$(TARGET)/buildroot-$(BR_VER)/package/Makefile.in || \
+		sed -i 's|^HOST_CXXFLAGS += \$$(HOST_CFLAGS)$$|HOST_CXXFLAGS += $$(filter-out -std=%,$$(HOST_CFLAGS))|' \
+			$(TARGET)/buildroot-$(BR_VER)/package/Makefile.in; \
 	fi
 
 help:


### PR DESCRIPTION
`gcc-compat` has been red on master since #2311 landed on 2026-08-26 — all five rows, GCC 12 through 16, identically. Two commits: fix it, then make it impossible for the same thing to happen quietly again.

## `Makefile: keep the host C dialect out of host C++ builds`

#2311 pinned the host C dialect to `gnu17` so host-gmp's configure would stop failing under GCC 15's `gnu23` default, and said it "applies only to host C builds". It does not. Buildroot's `package/Makefile.in` has

```make
HOST_CXXFLAGS += $(HOST_CFLAGS)
```

so `-std=gnu17` reaches every host C++ compile, where it is not a C++ dialect at all. g++ ignores it and warns:

```
cc1plus: warning: command-line option '-std=gnu17' is valid for C/ObjC but not for C++
```

**The compile still succeeds.** What fails is CMake. `cm_check_cxx_feature` (`Source/Checks/cm_cxx_features.cmake`) filters a handful of known-benign warnings out of its `try_compile` output and then discards any feature whose output still matches `/warning/i`:

```cmake
# If using the feature causes warnings, treat it as broken/unavailable.
if(check_output MATCHES "(^|[ :])[Ww][Aa][Rr][Nn][Ii][Nn][Gg]")
  set(CMake_HAVE_CXX_${FEATURE} OFF CACHE INTERNAL "TRY_COMPILE" FORCE)
endif()
```

That `cc1plus` line matches. So `make_unique`, `unique_ptr` and `filesystem` all report `no`, host-cmake stops with *"The C++ compiler does not support C++11 (e.g. std::unique_ptr)"*, and it takes every `make BOARD=...` with it — which is why the failure looks nothing like a flags problem in the log.

Reproduced directly against cmake 3.28.3, the version Buildroot pins here, both directions:

| | result |
|---|---|
| `CFLAGS="-O2 -std=gnu17" CXXFLAGS="-O2 -std=gnu17"` | fails at `CMakeLists.txt:93`, same message |
| `CFLAGS="-O2 -std=gnu17" CXXFLAGS="-O2"` | `Configuring done` |

**Neither variable can fix this from outside**, which is why the fix is where it is. `HOST_CFLAGS` is where the flag has to go. `HOST_CXXFLAGS` uses `+=`, so an environment value is appended to rather than replaced. And overriding either on the make command line makes Buildroot's own `+=` a no-op — which drops `-I$(HOST_DIR)/include`, and under `BR2_PER_PACKAGE_DIRECTORIES` there is no correct value to substitute for it, since `HOST_DIR` differs per package.

So the one line gets patched, in the `prepare:` rule that already patches the extracted tree, guarded for idempotency the same way the existing patch there is. `-std=` is filtered as a pattern rather than as that one value, so a dialect set from the environment cannot reintroduce it:

```make
HOST_CXXFLAGS += $(filter-out -std=%,$(HOST_CFLAGS))
```

Verified against the real `package/Makefile.in`: C keeps `-O2 -std=gnu17 -I/h/include`, C++ gets `-O2 -I/h/include`, and a second `make prepare` is a no-op.

## `ci: make gcc-compat a required check, and narrow it in a job`

This is the half that matters more. An advisory check that reports a real breakage and gets merged over is worse than no check — it costs the minutes and buys the confidence without earning it. #2311 merged with its own five rows red, and nothing ran the workflow again for a day and fourteen merges, because it only fired on PRs touching four paths and none of them did.

The five per-container contexts **cannot** be required directly: on a PR that reaches no host build they never run, and a required check that never runs sits pending forever — `build.yml` records exactly this lesson at the top of its own selector. So the narrowing moves out of the trigger's `paths:` filter and into a `select` job that always runs, and a `GCC Gate` job becomes the single requirable context.

* `select` asks the API for the PR's own file list rather than diffing base against head. A two-dot diff also reports whatever landed on master since the branch point, so an unrelated `.mk` merged by somebody else would start five containers; a three-dot diff needs a merge base the shallow checkout does not have.
* Off the relevant paths the entire workflow is one ten-second job.
* The gate fails on **any** red row. Five containers build one board from one tree and differ only in host compiler, so a single red row is the finding, not noise.
* It does not blanket-accept a skipped matrix either — a selector that called a change irrelevant and then ran the matrix anyway, or let a cancelled one through, would otherwise read as green.

### One step left after merge

Landing this only *creates* the context. `GCC Gate` still has to be added to master's required status checks alongside `CI Gate` and `qodo-gate` for any of it to block — a settings change, not a file in this tree. I can do that once this merges; say the word.

## Testing

`lint-workflow-shell.py` parses all four new run blocks clean, `build-summary.py --self-test`, `test_excludes_report.sh`, `test_load_hisilicon.sh` and `test_sysupgrade.sh` all pass, and this PR touches `Makefile`, so its own `gcc-compat` matrix is the real check on the first commit.
