### PR TITLE
majestic: match the daemon by executable, not by a stale pidfile

### DIFF
--- a/general/package/majestic/files/S95majestic
+++ b/general/package/majestic/files/S95majestic
@@ -7,28 +7,44 @@
 [ -r /etc/TZ ] && export TZ=$(cat /etc/TZ)
 
 DAEMON="majestic"
-PIDFILE="/var/run/$DAEMON.pid"
+DAEMON_PATH="/usr/bin/$DAEMON"
 DAEMON_ARGS="-s"
+
+# Find the daemon by executable, never through a pidfile. Given -p, busybox
+# start-stop-daemon inspects only the pid that file holds and never scans
+# /proc, so the moment that pid is stale it can no longer see the live daemon:
+# -S starts a SECOND majestic, which dies on the busy sensor HAL and leaves its
+# own dead pid behind in the file, and -K without -x signals whatever unrelated
+# process has since reused the pid. -x scans every process instead, and -a
+# keeps argv[0] as "majestic" so ps output and name-based tools are unchanged.
+running() {
+	start-stop-daemon -t -K -q -x "$DAEMON_PATH"
+}
 
 start() {
 	echo -n "Starting $DAEMON: "
-	start-stop-daemon -b -m -S -q -p "$PIDFILE" -x "$DAEMON" -- $DAEMON_ARGS
-	if [ $? -eq 0 ]; then
-		echo "OK"
-	else
-		echo "FAIL"
-	fi
+	start-stop-daemon -b -S -q -x "$DAEMON_PATH" -a "$DAEMON" -- $DAEMON_ARGS
+	case $? in
+		0) echo "OK"; return 0 ;;
+		1) echo "OK (already running)"; return 0 ;;
+		*) echo "FAIL"; return 1 ;;
+	esac
 }
 
 stop() {
 	echo -n "Stopping $DAEMON: "
-	start-stop-daemon -K -q -p "$PIDFILE"
-	if [ $? -eq 0 ]; then
-		rm -f "$PIDFILE"
-		echo "OK"
-	else
+	start-stop-daemon -K -q -x "$DAEMON_PATH"
+	i=0
+	while running && [ $i -lt 10 ]; do
+		i=$((i + 1))
+		sleep 1
+	done
+	if running; then
 		echo "FAIL"
+		return 1
 	fi
+	rm -f "/var/run/$DAEMON.pid"
+	echo "OK"
 }
 
 case "$1" in
@@ -37,13 +53,13 @@ case "$1" in
 		;;
 
 	restart)
-		stop
+		stop || exit 1
 		sleep 3
 		start
 		;;
 
 	reload)
-		killall -1 "$DAEMON"
+		start-stop-daemon -K -s 1 -q -x "$DAEMON_PATH"
 		;;
 
 	*)


### PR DESCRIPTION
Supersedes #2245 and #2250. Both reported the same failure from opposite ends and both diagnoses were close but not quite right, so I reproduced the whole thing on a Hi3516EV300 (busybox 1.36.1) and traced it to one flag.

## Root cause: `-p`

Busybox `start-stop-daemon`'s `do_procinit()` reads **only** the pid the pidfile holds and never scans `/proc`. `-x` is then just a filter applied to that single pid. So the moment the pidfile is stale, `start-stop-daemon` cannot see the live daemon at all.

With majestic live as pid 1177 and the pidfile poisoned with a dead pid:

```
# start-stop-daemon -b -m -S -q -p /var/run/majestic.pid -x majestic -- -s
rc=0                      # started a SECOND majestic, pid 1233
# sleep 4; pidof majestic
1177                      # the duplicate is already dead
# cat /var/run/majestic.pid
1233                      # ...and -m wrote its dead pid into the file
```

The second instance dies on the busy sensor HAL, but `-m` has already overwritten the pidfile with its pid. Every later `start` re-poisons the file, so the state is self-perpetuating.

That single mechanism explains both reports without needing any majestic-internal watchdog:

- #2250's *"pidfile ends up containing pids that never correspond to a live majestic (456, 1355, 1843, 1856, 1870)"* — those were short-lived duplicates.
- #2245's *"pidfile said 3408, majestic ran as pid 869"* — 3408 was a duplicate that lost the encoder and exited.

`stop()` was worse. It passed `-p` with **no** `-x`, so it signalled whatever process now owned that pid. Pointed at an unrelated live process, it killed that process and left majestic running:

```
# sleep 600 & echo $! > /var/run/majestic.pid
1260
# start-stop-daemon -K -q -p /var/run/majestic.pid
rc=0
# victim 1260: KILLED     # majestic 1177: still running
```

## Two corrections to #2250's reasoning

- **`-x majestic` (bare name) is not the problem.** Busybox compares `/proc/PID/cmdline` argv[0] as well as the `/proc/PID/exe` symlink, and I measured the bare form matching correctly (rc=0). The absolute path is not what fixes detection — dropping `-p` is.
- **Dropping `-p` without `-a` is a silent compat regression.** argv[0] becomes `/usr/bin/majestic`, `ps` output changes, and bare-name `start-stop-daemon -x majestic` matchers start returning rc=1. Adding `-a majestic` keeps argv[0] as `majestic` while `-x /usr/bin/majestic` still matches through the exe symlink, so nothing observable changes.

## The fix

`-x /usr/bin/majestic` scans every process, and `-a majestic` keeps the identity stable:

- **`start`** is idempotent. A second start is refused, reports success, and leaves the running daemon untouched — so the script is safe to call unconditionally from a crond watchdog (`* * * * * /etc/init.d/S95majestic start`), with no `pgrep`/`pidof` pre-check that can itself go stale on a zombie.
- **`stop`** polls until the daemon is genuinely gone (measured: 1 s) instead of sleeping a fixed 4 s, and returns non-zero if it survives, so `restart` aborts rather than stacking a second instance.
- **`reload`** signals through the same matcher instead of `killall`.

Nothing in the tree reads `/var/run/majestic.pid`, so removing it is safe; `stop` deletes a leftover file so it cannot mislead anyone debugging.

## Verification (Hi3516EV300 + IMX335, busybox 1.36.1, kernel 4.9.37)

| # | Check | Result |
|---|---|---|
| 0 | `sh -n` under busybox ash | OK |
| 2 | `stop` kills the daemon and clears the pidfile | OK, 1.04 s |
| 3 | `stop` when already stopped | OK, rc=0 (not FAIL) |
| 4 | `start` — argv[0] stays `majestic` | `ps`: `majestic -s` |
| 5 | `start` while running | idempotent, rc=0, pid unchanged |
| 6 | **stale pidfile + `start`** | no duplicate spawned |
| 7 | **pidfile pointing at an innocent process + `stop`** | victim survives |
| 8 | `restart` from stopped | OK |
| 9 | `restart` while running | exactly one daemon, 4.05 s |
| 10 | `reload` | SIGHUP delivered, daemon survives |
| 11 | `kill -9` + unconditional watchdog tick | recovers, RTSP back |
| 12 | bad argument | usage, rc=1 |
| 13 | `pidof` / `killall` / `ps` / bare `-x majestic` | all unchanged |

Cold boot on the fixed script: exactly one majestic, `argv[0]` = `majestic`, no pidfile, `:554` and `:80` listening, and the `/etc/TZ` re-read from #2244 still propagates (`TZ=GMT0`).

## Follow-up

Eleven other init scripts carry the same `-b -m -S -p` / `-K -p` pattern and therefore the same latent duplicate-spawn and wrong-pid-kill defects: `S60crond`, `S01syslogd`, `S49ntpd`, `S50dropbear`, `S96onvifserver`, `S89edge`, `S97baresip`, `S50mdnsd`, `S60siproxd`, `S60precision-time`, `S90matter`. They bite far less often because those daemons rarely die and get restarted. Filed separately rather than widening this PR's blast radius across every board's boot path.

Credit to @zavaruev (#2250) for the pidfile-as-stale-oracle diagnosis and the watchdog-safety framing, and to @phedoreanu (#2245) for spotting the duplicate-daemon symptom and insisting `stop` verify the daemon is actually gone.
