### PR TITLE
init scripts: match daemons by name, not by a stale pidfile

### DIFF
--- a/general/overlay/etc/init.d/S01syslogd
+++ b/general/overlay/etc/init.d/S01syslogd
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 DAEMON="syslogd"
-PIDFILE="/var/run/$DAEMON.pid"
 
 # Size (KiB) of the in-RAM circular log buffer. Defaults to 64 KiB so stock
 # cameras spend no extra memory; the WebUI (Information > Logs) can raise it by
@@ -10,25 +9,41 @@ SYSLOG_SIZE=64
 [ -r /etc/default/syslogd ] && . /etc/default/syslogd
 DAEMON_ARGS="-n -C${SYSLOG_SIZE:-64} -t"
 
+# Find the daemon by name, never through a pidfile. Given -p, busybox
+# start-stop-daemon inspects only the pid that file holds and never scans
+# /proc, so the moment that pid is stale it can no longer see the live daemon:
+# -S starts a second copy, and -K without -x signals whatever unrelated process
+# has since reused the pid. -x scans every process instead. The name form is
+# required here rather than an absolute path: syslogd is a busybox applet, so
+# /proc/PID/exe points at /bin/busybox and only argv[0] identifies the daemon.
+running() {
+	start-stop-daemon -t -K -q -x "$DAEMON"
+}
+
 start() {
 	echo -n "Starting $DAEMON: "
-	start-stop-daemon -b -m -S -q -p "$PIDFILE" -x "$DAEMON" -- $DAEMON_ARGS
-	if [ $? -eq 0 ]; then
-		echo "OK"
-	else
-		echo "FAIL"
-	fi
+	start-stop-daemon -b -S -q -x "$DAEMON" -- $DAEMON_ARGS
+	case $? in
+		0) echo "OK"; return 0 ;;
+		1) echo "OK (already running)"; return 0 ;;
+		*) echo "FAIL"; return 1 ;;
+	esac
 }
 
 stop() {
 	echo -n "Stopping $DAEMON: "
-	start-stop-daemon -K -q -p "$PIDFILE"
-	if [ $? -eq 0 ]; then
-		rm -f "$PIDFILE"
-		echo "OK"
-	else
+	start-stop-daemon -K -q -x "$DAEMON"
+	i=0
+	while running && [ $i -lt 10 ]; do
+		i=$((i + 1))
+		sleep 1
+	done
+	if running; then
 		echo "FAIL"
+		return 1
 	fi
+	rm -f "/var/run/$DAEMON.pid"
+	echo "OK"
 }
 
 case "$1" in
@@ -37,7 +52,7 @@ case "$1" in
 		;;
 
 	restart|reload)
-		stop
+		stop || exit 1
 		sleep 1
 		start
 		;;

--- a/general/overlay/etc/init.d/S49ntpd
+++ b/general/overlay/etc/init.d/S49ntpd
@@ -1,28 +1,43 @@
 #!/bin/sh
 
 DAEMON="ntpd"
-PIDFILE="/var/run/$DAEMON.pid"
 DAEMON_ARGS="-n"
+
+# Find the daemon by name, never through a pidfile. Given -p, busybox
+# start-stop-daemon inspects only the pid that file holds and never scans
+# /proc, so the moment that pid is stale it can no longer see the live daemon:
+# -S starts a second copy, and -K without -x signals whatever unrelated process
+# has since reused the pid. -x scans every process instead. The name form is
+# required here rather than an absolute path: ntpd is a busybox applet, so
+# /proc/PID/exe points at /bin/busybox and only argv[0] identifies the daemon.
+running() {
+	start-stop-daemon -t -K -q -x "$DAEMON"
+}
 
 start() {
 	echo -n "Starting $DAEMON: "
-	start-stop-daemon -b -m -S -q -p "$PIDFILE" -x "$DAEMON" -- $DAEMON_ARGS
-	if [ $? -eq 0 ]; then
-		echo "OK"
-	else
-		echo "FAIL"
-	fi
+	start-stop-daemon -b -S -q -x "$DAEMON" -- $DAEMON_ARGS
+	case $? in
+		0) echo "OK"; return 0 ;;
+		1) echo "OK (already running)"; return 0 ;;
+		*) echo "FAIL"; return 1 ;;
+	esac
 }
 
 stop() {
 	echo -n "Stopping $DAEMON: "
-	start-stop-daemon -K -q -p "$PIDFILE"
-	if [ $? -eq 0 ]; then
-		rm -f "$PIDFILE"
-		echo "OK"
-	else
+	start-stop-daemon -K -q -x "$DAEMON"
+	i=0
+	while running && [ $i -lt 10 ]; do
+		i=$((i + 1))
+		sleep 1
+	done
+	if running; then
 		echo "FAIL"
+		return 1
 	fi
+	rm -f "/var/run/$DAEMON.pid"
+	echo "OK"
 }
 
 case "$1" in
@@ -31,7 +46,7 @@ case "$1" in
 		;;
 
 	restart|reload)
-		stop
+		stop || exit 1
 		sleep 1
 		start
 		;;

--- a/general/overlay/etc/init.d/S50dropbear
+++ b/general/overlay/etc/init.d/S50dropbear
@@ -4,6 +4,15 @@ DAEMON="dropbear"
 PIDFILE="/var/run/$DAEMON.pid"
 DAEMON_ARGS="-R -B -k -p 22 -K 300"
 
+# This script keeps its pidfile, unlike the other init scripts. dropbear forks
+# a child per SSH session, and every one of them shares the listener's name and
+# executable, so matching with -x would make "stop" and "restart" kill all live
+# SSH sessions -- including the one running the command. The pidfile is the
+# only thing that singles out the listener, and here it is trustworthy: there
+# is no -b/-m below, so dropbear daemonises itself and writes the file itself
+# rather than start-stop-daemon guessing at it. -x is added to -K purely as a
+# guard, so that a pid reused after an unclean shutdown cannot be signalled.
+
 start() {
 	echo -n "Starting $DAEMON: "
 	umask 077
@@ -17,7 +26,7 @@ start() {
 
 stop() {
 	echo -n "Stopping $DAEMON: "
-	start-stop-daemon -K -q -p "$PIDFILE"
+	start-stop-daemon -K -q -p "$PIDFILE" -x "$DAEMON"
 	if [ $? -eq 0 ]; then
 		rm -f "$PIDFILE"
 		echo "OK"

--- a/general/overlay/etc/init.d/S60crond
+++ b/general/overlay/etc/init.d/S60crond
@@ -1,28 +1,43 @@
 #!/bin/sh
 
 DAEMON="crond"
-PIDFILE="/var/run/$DAEMON.pid"
 DAEMON_ARGS="-f -c /etc/crontabs"
+
+# Find the daemon by name, never through a pidfile. Given -p, busybox
+# start-stop-daemon inspects only the pid that file holds and never scans
+# /proc, so the moment that pid is stale it can no longer see the live daemon:
+# -S starts a second copy, and -K without -x signals whatever unrelated process
+# has since reused the pid. -x scans every process instead. The name form is
+# required here rather than an absolute path: crond is a busybox applet, so
+# /proc/PID/exe points at /bin/busybox and only argv[0] identifies the daemon.
+running() {
+	start-stop-daemon -t -K -q -x "$DAEMON"
+}
 
 start() {
 	echo -n "Starting $DAEMON: "
-	start-stop-daemon -b -m -S -q -p "$PIDFILE" -x "$DAEMON" -- $DAEMON_ARGS
-	if [ $? -eq 0 ]; then
-		echo "OK"
-	else
-		echo "FAIL"
-	fi
+	start-stop-daemon -b -S -q -x "$DAEMON" -- $DAEMON_ARGS
+	case $? in
+		0) echo "OK"; return 0 ;;
+		1) echo "OK (already running)"; return 0 ;;
+		*) echo "FAIL"; return 1 ;;
+	esac
 }
 
 stop() {
 	echo -n "Stopping $DAEMON: "
-	start-stop-daemon -K -q -p "$PIDFILE"
-	if [ $? -eq 0 ]; then
-		rm -f "$PIDFILE"
-		echo "OK"
-	else
+	start-stop-daemon -K -q -x "$DAEMON"
+	i=0
+	while running && [ $i -lt 10 ]; do
+		i=$((i + 1))
+		sleep 1
+	done
+	if running; then
 		echo "FAIL"
+		return 1
 	fi
+	rm -f "/var/run/$DAEMON.pid"
+	echo "OK"
 }
 
 case "$1" in
@@ -31,7 +46,7 @@ case "$1" in
 		;;
 
 	restart|reload)
-		stop
+		stop || exit 1
 		sleep 1
 		start
 		;;

--- a/general/package/baresip-openipc/files/S97baresip
+++ b/general/package/baresip-openipc/files/S97baresip
@@ -1,38 +1,51 @@
 #!/bin/sh
 
 DAEMON="baresip"
-PIDFILE="/var/run/$DAEMON.pid"
 DAEMON_ARGS="-f /etc/baresip"
+
+# Find the daemon by name, never through a pidfile. Given -p, busybox
+# start-stop-daemon inspects only the pid that file holds and never scans
+# /proc, so the moment that pid is stale it can no longer see the live daemon:
+# -S starts a second copy, and -K without -x signals whatever unrelated process
+# has since reused the pid. -x scans every process instead.
+running() {
+	start-stop-daemon -t -K -q -x "$DAEMON"
+}
 
 start() {
 	echo -n "Starting $DAEMON: "
 	sleep 5
-	start-stop-daemon -b -m -S -q -p "$PIDFILE" -x "$DAEMON" -- $DAEMON_ARGS
-	if [ $? -eq 0 ]; then
-		echo "OK"
-	else
-		echo "FAIL"
-	fi
+	start-stop-daemon -b -S -q -x "$DAEMON" -- $DAEMON_ARGS
+	case $? in
+		0) echo "OK"; return 0 ;;
+		1) echo "OK (already running)"; return 0 ;;
+		*) echo "FAIL"; return 1 ;;
+	esac
 }
 
 stop() {
 	echo -n "Stopping $DAEMON: "
-	start-stop-daemon -K -q -p "$PIDFILE"
-	if [ $? -eq 0 ]; then
-		rm -f "$PIDFILE"
-		echo "OK"
-	else
+	start-stop-daemon -K -q -x "$DAEMON"
+	i=0
+	while running && [ $i -lt 10 ]; do
+		i=$((i + 1))
+		sleep 1
+	done
+	if running; then
 		echo "FAIL"
+		return 1
 	fi
+	rm -f "/var/run/$DAEMON.pid"
+	echo "OK"
 }
 
 case "$1" in
 	start|stop)
 		$1
 		;;
-	
+
 	restart|reload)
-		stop
+		stop || exit 1
 		sleep 1
 		start
 		;;
@@ -40,4 +53,5 @@ case "$1" in
 	*)
 		echo "Usage: $0 {start|stop|restart|reload}"
 		exit 1
+		;;
 esac

--- a/general/package/matter/files/S90matter
+++ b/general/package/matter/files/S90matter
@@ -26,7 +26,6 @@
 
 DAEMON=/usr/sbin/matter-server
 NAME=matter-server
-PIDFILE=/var/run/matter-server.pid
 CONFIG=/etc/matter.conf
 
 # Default runtime parameters — override in /etc/matter.conf
@@ -46,43 +45,45 @@ export MATTER_RTSP_URL MATTER_PORT \
        MATTER_VENDOR_NAME MATTER_PRODUCT_NAME MATTER_NODE_LABEL \
        MATTER_HW_VERSION MATTER_SW_VERSION
 
+# Find the daemon by executable, never through a pidfile. Given -p, busybox
+# start-stop-daemon inspects only the pid that file holds and never scans
+# /proc, so the moment that pid is stale it can no longer see the live daemon:
+# -S starts a second copy, and -K without -x signals whatever unrelated process
+# has since reused the pid. A "kill -0 $(cat pidfile)" guard is no better: it
+# reports a reused pid as a live daemon. -x scans every process instead.
+running() {
+	start-stop-daemon -t -K -q -x "$DAEMON"
+}
+
 start() {
 	echo -n "Starting $NAME: "
-	if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
-		echo "already running (pid $(cat "$PIDFILE"))"
-		return 0
-	fi
-	start-stop-daemon -S -b -m -p "$PIDFILE" \
-		-x "$DAEMON" -- "$MATTER_RTSP_URL" "$MATTER_PORT"
-	RETVAL=$?
-	if [ $RETVAL -eq 0 ]; then
-		echo "OK"
-	else
-		echo "FAILED"
-	fi
-	return $RETVAL
+	start-stop-daemon -S -b -x "$DAEMON" -- "$MATTER_RTSP_URL" "$MATTER_PORT"
+	case $? in
+		0) echo "OK"; return 0 ;;
+		1) echo "OK (already running)"; return 0 ;;
+		*) echo "FAILED"; return 1 ;;
+	esac
 }
 
 stop() {
 	echo -n "Stopping $NAME: "
-	if [ ! -f "$PIDFILE" ]; then
-		echo "not running"
-		return 0
-	fi
-	start-stop-daemon -K -q -p "$PIDFILE"
-	RETVAL=$?
-	rm -f "$PIDFILE"
-	if [ $RETVAL -eq 0 ]; then
-		echo "OK"
-	else
+	start-stop-daemon -K -q -x "$DAEMON"
+	i=0
+	while running && [ $i -lt 10 ]; do
+		i=$((i + 1))
+		sleep 1
+	done
+	if running; then
 		echo "FAILED"
+		return 1
 	fi
-	return $RETVAL
+	rm -f "/var/run/$NAME.pid"
+	echo "OK"
 }
 
 status() {
-	if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
-		echo "$NAME is running (pid $(cat "$PIDFILE"))"
+	if running; then
+		echo "$NAME is running (pid $(pidof "$NAME"))"
 		return 0
 	else
 		echo "$NAME is not running"
@@ -93,7 +94,7 @@ status() {
 case "$1" in
 	start)   start   ;;
 	stop)    stop    ;;
-	restart) stop; sleep 1; start ;;
+	restart) stop || exit 1; sleep 1; start ;;
 	status)  status  ;;
 	*)
 		echo "Usage: $0 {start|stop|restart|status}"

--- a/general/package/matter/files/S90matter
+++ b/general/package/matter/files/S90matter
@@ -57,7 +57,7 @@ running() {
 
 start() {
 	echo -n "Starting $NAME: "
-	start-stop-daemon -S -b -x "$DAEMON" -- "$MATTER_RTSP_URL" "$MATTER_PORT"
+	start-stop-daemon -S -b -q -x "$DAEMON" -- "$MATTER_RTSP_URL" "$MATTER_PORT"
 	case $? in
 		0) echo "OK"; return 0 ;;
 		1) echo "OK (already running)"; return 0 ;;

--- a/general/package/mdnsd-openipc/files/S50mdnsd
+++ b/general/package/mdnsd-openipc/files/S50mdnsd
@@ -6,28 +6,41 @@
 #
 
 DAEMON="mdnsd"
-PIDFILE="/var/run/$DAEMON.pid"
 DAEMON_ARGS=""
+
+# Find the daemon by name, never through a pidfile. Given -p, busybox
+# start-stop-daemon inspects only the pid that file holds and never scans
+# /proc, so the moment that pid is stale it can no longer see the live daemon:
+# -S starts a second copy, and -K without -x signals whatever unrelated process
+# has since reused the pid. -x scans every process instead.
+running() {
+	start-stop-daemon -t -K -q -x "$DAEMON"
+}
 
 start() {
 	echo -n "Starting $DAEMON: "
-	start-stop-daemon -b -m -S -q -p "$PIDFILE" -x "$DAEMON" -- $DAEMON_ARGS
-	if [ $? -eq 0 ]; then
-		echo "OK"
-	else
-		echo "FAIL"
-	fi
+	start-stop-daemon -b -S -q -x "$DAEMON" -- $DAEMON_ARGS
+	case $? in
+		0) echo "OK"; return 0 ;;
+		1) echo "OK (already running)"; return 0 ;;
+		*) echo "FAIL"; return 1 ;;
+	esac
 }
 
 stop() {
 	echo -n "Stopping $DAEMON: "
-	start-stop-daemon -K -q -p "$PIDFILE"
-	if [ $? -eq 0 ]; then
-		rm -f "$PIDFILE"
-		echo "OK"
-	else
+	start-stop-daemon -K -q -x "$DAEMON"
+	i=0
+	while running && [ $i -lt 10 ]; do
+		i=$((i + 1))
+		sleep 1
+	done
+	if running; then
 		echo "FAIL"
+		return 1
 	fi
+	rm -f "/var/run/$DAEMON.pid"
+	echo "OK"
 }
 
 case "$1" in
@@ -36,13 +49,13 @@ case "$1" in
 		;;
 
 	restart)
-		stop
+		stop || exit 1
 		sleep 3
 		start
 		;;
 
 	reload)
-		killall -1 "$DAEMON"
+		start-stop-daemon -K -s 1 -q -x "$DAEMON"
 		;;
 
 	*)

--- a/general/package/n3n-openipc/files/S89edge
+++ b/general/package/n3n-openipc/files/S89edge
@@ -6,29 +6,42 @@
 #
 
 DAEMON="n3n-edge"
-PIDFILE="/var/run/$DAEMON.pid"
 DAEMON_ARGS="start"
+
+# Find the daemon by name, never through a pidfile. Given -p, busybox
+# start-stop-daemon inspects only the pid that file holds and never scans
+# /proc, so the moment that pid is stale it can no longer see the live daemon:
+# -S starts a second copy, and -K without -x signals whatever unrelated process
+# has since reused the pid. -x scans every process instead.
+running() {
+	start-stop-daemon -t -K -q -x "$DAEMON"
+}
 
 start() {
 	echo -n "Starting $DAEMON: "
 	modprobe tun
-	start-stop-daemon -b -m -S -q -p "$PIDFILE" -x "$DAEMON" -- $DAEMON_ARGS
-	if [ $? -eq 0 ]; then
-		echo "OK"
-	else
-		echo "FAIL"
-	fi
+	start-stop-daemon -b -S -q -x "$DAEMON" -- $DAEMON_ARGS
+	case $? in
+		0) echo "OK"; return 0 ;;
+		1) echo "OK (already running)"; return 0 ;;
+		*) echo "FAIL"; return 1 ;;
+	esac
 }
 
 stop() {
 	echo -n "Stopping $DAEMON: "
-	start-stop-daemon -K -q -p "$PIDFILE"
-	if [ $? -eq 0 ]; then
-		rm -f "$PIDFILE"
-		echo "OK"
-	else
+	start-stop-daemon -K -q -x "$DAEMON"
+	i=0
+	while running && [ $i -lt 10 ]; do
+		i=$((i + 1))
+		sleep 1
+	done
+	if running; then
 		echo "FAIL"
+		return 1
 	fi
+	rm -f "/var/run/$DAEMON.pid"
+	echo "OK"
 }
 
 case "$1" in
@@ -37,13 +50,13 @@ case "$1" in
 		;;
 
 	restart)
-		stop
+		stop || exit 1
 		sleep 3
 		start
 		;;
 
 	reload)
-		killall -1 "$DAEMON"
+		start-stop-daemon -K -s 1 -q -x "$DAEMON"
 		;;
 
 	*)

--- a/general/package/onvif-simple-server/files/S96onvifserver
+++ b/general/package/onvif-simple-server/files/S96onvifserver
@@ -8,14 +8,24 @@ DAEMON="httpd"
 PIDFILE="/var/run/httpd_onvif.pid"
 DAEMON_ARGS="-p $ONVIF_PORT -h $WWW_PATH -c $HTTPD_CONFIG -f"
 
-# This script keeps its pidfile, unlike the other init scripts. The ONVIF
-# server is a second busybox httpd instance living beside the WebUI's own
-# httpd (S50httpd), and the two are told apart only by their arguments -- which
-# start-stop-daemon cannot match on. Matching by name or executable would let
-# this script stop the WebUI's server, so the pidfile stays as the one thing
-# that distinguishes them. -x is added to -K so that a stale pidfile whose pid
-# has been reused can at most signal some other httpd, never an unrelated
-# process; the pidfile can still go stale and let -S start a second copy.
+# start-stop-daemon can match on a name, an executable or a pidfile, but never
+# on arguments -- and arguments are the only thing telling this server apart
+# from the WebUI's own httpd (S50httpd), both being the same busybox binary.
+# Matching by name or executable would let this script stop the WebUI, and a
+# pidfile on its own goes stale and can name a pid the WebUI has since reused.
+# So identify our instance by scanning for the httpd whose command line carries
+# $HTTPD_CONFIG, which cannot name the wrong server. The pidfile is still
+# written, for anyone reading it, but nothing here trusts it.
+onvif_pid() {
+	for p in $(pidof "$DAEMON" 2>/dev/null); do
+		if tr '\0' '\n' < "/proc/$p/cmdline" 2>/dev/null |
+				grep -qxF "$HTTPD_CONFIG"; then
+			echo "$p"
+			return 0
+		fi
+	done
+	return 1
+}
 
 start() {
 	echo -n "Starting ONVIF HTTPD server: "
@@ -31,23 +41,41 @@ start() {
 	sed -i "s/^ifs=.*/ifs=$network_interface/" $ONVIF_CONFIG
 	echo -e "A:*\n/cgi-bin*:*\n" > $HTTPD_CONFIG
 
+	if onvif_pid > /dev/null; then
+		echo "OK (already running)"
+		return 0
+	fi
+
+	# Our instance is not running, so any pidfile left over is stale and would
+	# only make -S match a pid the WebUI may have reused. Drop it first, then
+	# let -m write a fresh one.
+	rm -f "$PIDFILE"
 	start-stop-daemon -b -m -S -q -p "$PIDFILE" -x "$DAEMON" -- $DAEMON_ARGS
 	if [ $? -eq 0 ]; then
 		echo "OK"
 	else
 		echo "FAIL"
+		return 1
 	fi
 }
 
 stop() {
 	echo -n "Stopping ONVIF HTTPD server: "
-	start-stop-daemon -K -q -p "$PIDFILE" -x "$DAEMON"
-	if [ $? -eq 0 ]; then
-		rm -f "$PIDFILE"
-		echo "OK"
-	else
-		echo "FAIL"
+	pid=$(onvif_pid)
+	if [ -n "$pid" ]; then
+		kill "$pid" 2>/dev/null
+		i=0
+		while onvif_pid > /dev/null && [ $i -lt 10 ]; do
+			i=$((i + 1))
+			sleep 1
+		done
 	fi
+	if onvif_pid > /dev/null; then
+		echo "FAIL"
+		return 1
+	fi
+	rm -f "$PIDFILE"
+	echo "OK"
 }
 
 case "$1" in
@@ -56,7 +84,7 @@ case "$1" in
 		;;
 
 	restart)
-		stop
+		stop || exit 1
 		sleep 3
 		start
 		;;

--- a/general/package/onvif-simple-server/files/S96onvifserver
+++ b/general/package/onvif-simple-server/files/S96onvifserver
@@ -8,6 +8,15 @@ DAEMON="httpd"
 PIDFILE="/var/run/httpd_onvif.pid"
 DAEMON_ARGS="-p $ONVIF_PORT -h $WWW_PATH -c $HTTPD_CONFIG -f"
 
+# This script keeps its pidfile, unlike the other init scripts. The ONVIF
+# server is a second busybox httpd instance living beside the WebUI's own
+# httpd (S50httpd), and the two are told apart only by their arguments -- which
+# start-stop-daemon cannot match on. Matching by name or executable would let
+# this script stop the WebUI's server, so the pidfile stays as the one thing
+# that distinguishes them. -x is added to -K so that a stale pidfile whose pid
+# has been reused can at most signal some other httpd, never an unrelated
+# process; the pidfile can still go stale and let -S start a second copy.
+
 start() {
 	echo -n "Starting ONVIF HTTPD server: "
 
@@ -32,7 +41,7 @@ start() {
 
 stop() {
 	echo -n "Stopping ONVIF HTTPD server: "
-	start-stop-daemon -K -q -p "$PIDFILE"
+	start-stop-daemon -K -q -p "$PIDFILE" -x "$DAEMON"
 	if [ $? -eq 0 ]; then
 		rm -f "$PIDFILE"
 		echo "OK"

--- a/general/package/openipc-precision-time/files/S60precision-time
+++ b/general/package/openipc-precision-time/files/S60precision-time
@@ -5,30 +5,44 @@
 # CLOCK_REALTIME from the LAN's PTP grandmaster. No phc2sys needed.
 
 DAEMON="ptp4l"
-PIDFILE="/var/run/$DAEMON.pid"
+DAEMON_PATH="/usr/sbin/$DAEMON"
 IFACE="${PTP4L_IFACE:-eth0}"
 CONFIG="${PTP4L_CONFIG:-/etc/ptp4l.conf}"
 DAEMON_ARGS="-f $CONFIG -i $IFACE -S"
 
+# Find the daemon by executable, never through a pidfile. Given -p, busybox
+# start-stop-daemon inspects only the pid that file holds and never scans
+# /proc, so the moment that pid is stale it can no longer see the live daemon:
+# -S starts a second copy, and -K without -x signals whatever unrelated process
+# has since reused the pid. -x scans every process instead.
+running() {
+	start-stop-daemon -t -K -q -x "$DAEMON_PATH"
+}
+
 start() {
 	echo -n "Starting $DAEMON: "
-	start-stop-daemon -b -m -S -q -p "$PIDFILE" -x "/usr/sbin/$DAEMON" -- $DAEMON_ARGS
-	if [ $? -eq 0 ]; then
-		echo "OK"
-	else
-		echo "FAIL"
-	fi
+	start-stop-daemon -b -S -q -x "$DAEMON_PATH" -- $DAEMON_ARGS
+	case $? in
+		0) echo "OK"; return 0 ;;
+		1) echo "OK (already running)"; return 0 ;;
+		*) echo "FAIL"; return 1 ;;
+	esac
 }
 
 stop() {
 	echo -n "Stopping $DAEMON: "
-	start-stop-daemon -K -q -p "$PIDFILE"
-	if [ $? -eq 0 ]; then
-		rm -f "$PIDFILE"
-		echo "OK"
-	else
+	start-stop-daemon -K -q -x "$DAEMON_PATH"
+	i=0
+	while running && [ $i -lt 10 ]; do
+		i=$((i + 1))
+		sleep 1
+	done
+	if running; then
 		echo "FAIL"
+		return 1
 	fi
+	rm -f "/var/run/$DAEMON.pid"
+	echo "OK"
 }
 
 case "$1" in
@@ -36,7 +50,7 @@ case "$1" in
 		$1
 		;;
 	restart)
-		stop
+		stop || exit 1
 		sleep 1
 		start
 		;;

--- a/general/package/siproxd-openipc/files/S60siproxd
+++ b/general/package/siproxd-openipc/files/S60siproxd
@@ -6,29 +6,42 @@
 #
 
 DAEMON="siproxd"
-PIDFILE="/var/run/$DAEMON.pid"
 DAEMON_ARGS="-d 8 -c /etc/siproxd.conf"
+
+# Find the daemon by name, never through a pidfile. Given -p, busybox
+# start-stop-daemon inspects only the pid that file holds and never scans
+# /proc, so the moment that pid is stale it can no longer see the live daemon:
+# -S starts a second copy, and -K without -x signals whatever unrelated process
+# has since reused the pid. -x scans every process instead.
+running() {
+	start-stop-daemon -t -K -q -x "$DAEMON"
+}
 
 start() {
 	echo -n "Starting $DAEMON (RAM mode): "
 	modprobe tun
-	start-stop-daemon -b -m -S -q -p "$PIDFILE" -x "$DAEMON" -- $DAEMON_ARGS
-	if [ $? -eq 0 ]; then
-		echo "OK"
-	else
-		echo "FAIL"
-	fi
+	start-stop-daemon -b -S -q -x "$DAEMON" -- $DAEMON_ARGS
+	case $? in
+		0) echo "OK"; return 0 ;;
+		1) echo "OK (already running)"; return 0 ;;
+		*) echo "FAIL"; return 1 ;;
+	esac
 }
 
 stop() {
 	echo -n "Stopping $DAEMON: "
-	start-stop-daemon -K -q -p "$PIDFILE"
-	if [ $? -eq 0 ]; then
-		rm -f "$PIDFILE"
-		echo "OK"
-	else
+	start-stop-daemon -K -q -x "$DAEMON"
+	i=0
+	while running && [ $i -lt 10 ]; do
+		i=$((i + 1))
+		sleep 1
+	done
+	if running; then
 		echo "FAIL"
+		return 1
 	fi
+	rm -f "/var/run/$DAEMON.pid"
+	echo "OK"
 }
 
 case "$1" in
@@ -37,13 +50,13 @@ case "$1" in
 		;;
 
 	restart)
-		stop
+		stop || exit 1
 		sleep 3
 		start
 		;;
 
 	reload)
-		killall -1 "$DAEMON"
+		start-stop-daemon -K -s 1 -q -x "$DAEMON"
 		;;
 
 	*)


### PR DESCRIPTION
Closes #2325. Follow-up to #2324, which fixed the same defect in `S95majestic`. Disjoint files, so the two can land in either order.

## The defect

Given `-p`, busybox `start-stop-daemon`'s `do_procinit()` reads **only** the pid that file holds and never scans `/proc`. `-x` is then just a filter on that single pid, so once the pidfile is stale the live daemon is invisible. Two consequences, both reproduced on a Hi3516EV300 (busybox 1.36.1):

**Duplicate daemons.** `-S` can't see the running instance, so it starts another — and `-m` overwrites the pidfile with the duplicate's pid, so the state is self-perpetuating.

**Killing unrelated processes.** Every `stop()` here passed `-p` with **no `-x`**, so it signalled whatever process now owned that pid:

```
# sleep 600 & echo $! > /var/run/<daemon>.pid
1260
# start-stop-daemon -K -q -p /var/run/<daemon>.pid
rc=0
# victim 1260: KILLED      # the daemon itself: still running
```

## What changed

**Nine scripts** drop the pidfile and match on `-x`, which scans every process: `S01syslogd`, `S49ntpd`, `S50mdnsd`, `S60crond`, `S60precision-time`, `S60siproxd`, `S89edge`, `S90matter`, `S97baresip`. `start` becomes idempotent, `stop` polls until the daemon is genuinely gone before `restart` proceeds, and `reload` signals through the same matcher instead of `killall`.

`S90matter` also loses its `kill -0 "$(cat "$PIDFILE")"` guard, which was the same bug in longhand — it reports a *reused* pid as a live daemon.

## Two things that would have broken a naive sweep

**`syslogd`, `ntpd` and `crond` must match by name, not by absolute path.** They are busybox applets, so `/proc/PID/exe` points at `/bin/busybox` and the majestic-style path form silently never matches — which would have spawned a second syslogd on every board, on every boot. Measured:

```
-x syslogd          -> MATCH (rc=0)
-x /sbin/syslogd    -> no match (rc=1)      # exe is /bin/busybox
-x crond            -> MATCH (rc=0)
-x /usr/sbin/crond  -> no match (rc=1)
```

**Two scripts are deliberately NOT converted**, each with a comment saying why, because name matching would be actively harmful:

- **`S50dropbear`** — dropbear forks a child per SSH session, and every one shares the listener's name *and* executable. `-x` matching would make `stop` and `restart` kill **every live SSH session, including the one running the command**:

  ```
  -K -p PIDFILE -x dropbear  -> stopped dropbear (pid 607)        # listener only, correct
  -K -x dropbear             -> stopped dropbear (pid 908 607)    # 908 was my own session
  ```

  Its pidfile is also the trustworthy kind: there is no `-b`/`-m` in that script, so dropbear daemonises itself and writes the file, rather than start-stop-daemon guessing at it.

- **`S96onvifserver`** — `DAEMON` is `httpd`, a second busybox httpd living beside the WebUI's own (`S50httpd`). The two are told apart only by their arguments, which `start-stop-daemon` cannot match on, so the pidfile stays as the only thing that distinguishes them.

Both still gain an `-x` guard on `-K`, which removes the dangerous half — a reused pid can no longer be signalled by mistake:

```
-K -p <stale pidfile>              -> stopped process in pidfile (pid 1126)   # collateral damage
-K -p <stale pidfile> -x dropbear  -> no dropbear found; none killed          # guarded
```

Nothing outside these scripts reads any of the pidfiles. (`siproxd.conf` sets `pid_file`, but siproxd writes that itself — dropping `-m` removes a competing writer rather than a reader.)

## Verification (Hi3516EV300 + IMX335, busybox 1.36.1, kernel 4.9.37)

Every changed file passes `dash -n` and `sh -n` on-device. The four daemons that actually run on this board were exercised live:

| Check | syslogd | ntpd | crond |
|---|---|---|---|
| stale pidfile + `start` → no duplicate | PASS | PASS | PASS |
| `stop` → gone, pidfile cleared | PASS | PASS | PASS |
| `stop` when already stopped → rc=0 | PASS | PASS | PASS |
| `start` → running, `argv[0]` unchanged | PASS | PASS | PASS |
| `restart` → exactly one daemon | PASS | PASS | PASS |

Plus: `logger` still reaches syslogd after a restart; dropbear's match set verified to be the listener alone; and a **cold boot** brings up syslogd, ntpd, crond, dropbear and majestic exactly once each, with `argv[0]` unchanged for all, the three converted pidfiles absent, dropbear's own pidfile present and correct, and `:22`, `:80` and `:554` listening.

The remaining six daemons (mdnsd, siproxd, ptp4l, n3n-edge, matter-server, baresip) are not enabled on this board, so the real daemons could not be run. Their **init scripts** were exercised on the camera instead, against a small static ARM ELF that waits on `pause()` and dies on the default `SIGTERM`, installed at each daemon's true install path. That gives a genuine `/proc/PID/exe` and `argv[0]`, so the matching, duplicate-refusal and shutdown logic -- the only thing this PR changes -- runs exactly as it will in production. All six pass start, stale-pidfile-no-duplicate, restart-leaves-one, stop, and stop-when-already-stopped; `reload` delivers SIGHUP to the right pid.

The observed `argv[0]` confirms the intended split: mdnsd, siproxd, n3n-edge and baresip keep a bare `argv[0]`, while ptp4l and matter-server keep the absolute `argv[0]` they already had. Nothing observable changes for either group.

What this does not prove is each daemon's own behaviour under restart -- whether siproxd re-binds cleanly, whether ptp4l re-acquires its grandmaster. Those paths are untouched here, but if per-daemon hardware evidence is wanted first, the six can be split into a separate PR and held until each package can be built and run on a board that enables it.

## ONVIF: matching by argument, not by pidfile

Review caught that the `-x httpd` guard accepts *any* httpd, so a stale ONVIF pidfile whose pid the WebUI had reused could still stop the WebUI -- the very thing keeping the pidfile was meant to prevent. `start-stop-daemon` cannot match on arguments, so `S96onvifserver` now matches them itself, scanning for the httpd whose command line carries `$HTTPD_CONFIG`. That names our instance exactly and never the WebUI's, fixing both halves of the defect for this script too.

Verified with two real busybox httpd instances side by side on the camera: ONVIF starts alongside the WebUI, a second start is refused, and with the pidfile poisoned to name the WebUI's pid (1589), `stop` terminated the ONVIF instance (1616) and left the WebUI running.
