### PR TITLE
ci: .gitignore and .editorconfig reach no build

### DIFF
--- a/.github/scripts/ci-matrix.py
+++ b/.github/scripts/ci-matrix.py
@@ -280,6 +280,11 @@ MARKDOWN = re.compile(r"^(?!general/|br-ext-chip-).*\.md$")
 # Configuration for the code-review service, which reads these on the PR and
 # never on a build host. Anchored to whole paths for the same reason LICENSE is.
 REVIEW_CONFIG = re.compile(r"^(?:\.pr_agent\.toml|pr_compliance_checklist\.yaml)$")
+# Repository metadata read by git and by editors, never by a build host: no
+# recipe consults either, and .gitignore only decides what is offered to be
+# committed in the first place. Anchored to whole paths for the same reason
+# LICENSE is -- general/.gitignore, if one ever appears, is not this one.
+REPO_META = re.compile(r"^(?:\.gitignore|\.editorconfig)$")
 GITHUB_META = re.compile(r"^\.github/(?:CODEOWNERS|PULL_REQUEST_TEMPLATE\.md|ISSUE_TEMPLATE/)")
 WORKFLOW = re.compile(r"^\.github/workflows/([^/]+)$")
 GITHUB_SCRIPT = re.compile(r"^\.github/scripts/([^/]+)$")
@@ -465,7 +470,8 @@ def classify(tree, changed, labels=(), event="pull_request", draft=False):
 
     boards, smoked = set(), False
     for path in changed:
-        if DOCS.match(path) or MARKDOWN.match(path) or REVIEW_CONFIG.match(path):
+        if DOCS.match(path) or MARKDOWN.match(path) or REVIEW_CONFIG.match(path) \
+                or REPO_META.match(path):
             continue
         if GITHUB_META.match(path):
             continue
@@ -792,6 +798,8 @@ def self_test():
         ([".github/workflows/lint.yml"], 0, "the workflow linter never builds"),
         ([".github/scripts/lint-workflow-shell.py"], 0, "its script"),
         ([".github/PULL_REQUEST_TEMPLATE.md"], 0, "PR template"),
+        ([".gitignore"], 0, "git metadata"),
+        ([".editorconfig"], 0, "editor metadata"),
         (["contrib/openipc-bisect/openipc-bisect"], 0, "developer tooling"),
         ([".pr_agent.toml", "docs/architecture.md"], 0, "review config plus docs"),
         (["best_practices.md",
@@ -808,6 +816,8 @@ def self_test():
          full, "same name under general/ is not the checklist"),
         ([".pr_agent.toml.orig"], full, "a merge leftover is not the config"),
         (["tools/.pr_agent.toml"], full, "same name in a subdirectory is not the config"),
+        (["general/.gitignore"], full, "a .gitignore under general/ is not the root one"),
+        ([".gitignore.bak"], full, "a backup is not the ignore file"),
     ]
     for paths, expected, what in cases:
         got = len(classify(tree, paths)["rows"])

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,13 @@ buildroot-*/
 output/
 buildroot-*
 .DS_Store
+
+# CLAUDE.md tells contributors to give each board its own TARGET=$(PWD)/output-<board>,
+# because a shared output/ carries one board's artifacts into the next board's build.
+# Ignore the whole shape, not just the output/ the Makefile defaults to.
+output-*/
+
+# Per-developer AI assistant overrides. The tracked CLAUDE.md / AGENTS.md is the
+# shared one; these are personal and never belong in a pull request.
+CLAUDE.local.md
+.claude/settings.local.json


### PR DESCRIPTION
## Problem

`ci-matrix.py` already knows that `LICENSE`, `README`, `docs/`, `contrib/`, markdown outside
the build tree, the review-agent config and `.github/` metadata cannot change a byte of any
image, and returns no boards for them. Git and editor metadata is the same class and was
missing, so it fell through to the "unknown widens" rule:

```
$ echo '.gitignore' | python3 .github/scripts/ci-matrix.py --stdin
ci-matrix: 99/99 boards (needs_build=True) --- .gitignore affects every board
```

Adding one ignore rule therefore cost the full matrix — roughly 2000 runner-minutes to prove
that ignoring a scratch directory still builds 99 identical images. No recipe reads either
file; `.gitignore` only decides what git offers to commit in the first place.

This was found while preparing #2329: the `.gitignore` half of that change had to be dropped
to keep a documentation pull request from building every board.

## What this changes

`REPO_META`, matching `.gitignore` and `.editorconfig`, added to the skip set in `classify()`.
Anchored to whole paths, exactly like `LICENSE` and `.pr_agent.toml` before it, with the
negative cases pinned so the anchoring cannot rot: `general/.gitignore` and `.gitignore.bak`
are not this file and still widen.

Then the two ignore rules that motivated it:

- **`output-*/`** — `TARGET` defaults to `output/`, which is already ignored, but building more
  than one board locally means giving each its own `TARGET`, and `output-<board>` is what
  people name them. `CLAUDE.md` now tells contributors to do exactly that. These show up as
  untracked directories in a maintainer's tree today.
- **`CLAUDE.local.md`** and **`.claude/settings.local.json`** — so a personal AI-assistant
  override does not sit unignored next to the shared, tracked `CLAUDE.md` added in #2329.

## Hardware tested on

No camera, and none can apply: nothing here reaches one. This changes which boards CI selects
and what git offers to commit. No package, defconfig, kernel config, overlay file or build
recipe is touched, so no image byte changes and there is no camera behaviour to observe
before or after.

The property that actually needs proving for a change like this is the opposite one — that
the new rule cannot make an image-affecting path skip its builds. That is what the self-test
cases below pin, and they are the honest substitute for a dmesg paste. Fabricating camera
output to fill this heading would be worse than leaving it empty.

## Evidence

The gap, and that it is closed:

```
$ printf '.gitignore\n.editorconfig\n' | python3 .github/scripts/ci-matrix.py --stdin
ci-matrix: 0/99 boards (needs_build=False) --- nothing that reaches a build
needs-build=false
reason=nothing that reaches a build
```

The selector's own gate, which is where the new cases live:

```
$ python3 .github/scripts/ci-matrix.py --self-test
ci-matrix: self-test ok (99 boards, 132 packages, 56 cases)
```

52 cases before, 56 now: two positive (`.gitignore`, `.editorconfig` → 0 boards) and two
negative (`general/.gitignore`, `.gitignore.bak` → full matrix).

## Why this pull request still builds everything

It edits `ci-matrix.py`, and the file deliberately refuses to narrow for itself — its own
self-test pins that as *"this file picks the boards, so it cannot pick fewer for itself"*.
So the fix pays the full matrix once, here, and every later change to these paths is free.
That is also why it is separate from #2329 rather than folded into it.

## Scope

- [x] No kernel patches under `general/package/all-patches/linux/` (those go to [OpenIPC/linux](https://github.com/OpenIPC/linux))
- [x] No files specific to a single retail camera model (those go to [OpenIPC/builder](https://github.com/OpenIPC/builder))
- [x] No probing or bring-up tooling (that goes to [OpenIPC/ipctool](https://github.com/OpenIPC/ipctool))
- [x] Nothing under `general/overlay/` or in a shared `load_<vendor>` script hardcodes a value specific to my board
- [ ] Package sources come from an OpenIPC repository, and any version bump keeps at least the specificity of the pin it replaces (a new package should pin a full 40-character SHA) — *not applicable, no package is added or changed*
- [x] No `LD_PRELOAD`, and no binaries that cannot be rebuilt from source
- [ ] New code is selected by a defconfig, so CI actually builds it — *not applicable; the new code is in the selector, covered by its own self-test cases*
