### PR TITLE
ci: scope the hardware-evidence gate to changes that reach an image

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,16 @@ your board can prove it boots and streams.
 
 If you have not run this on a camera, the PR is not ready — say so here and open
 it as a draft rather than leaving the section blank.
+
+Unless the change cannot alter what the firmware does on a camera — documentation, review
+configuration, repository metadata, this template, CODEOWNERS, or CI machinery
+that only selects, lints or tests. If you are unsure, assume it can. Then say so
+plainly and give the evidence that does apply — a self-test, selector output, a
+parse run. Never paste output from a board that was not exercising the change.
+
+Three that look exempt and are not: a defconfig CI does not build is still a
+real image, a workflow feeding a build input changes image bytes, and the
+post-build scripts under general/scripts/ rewrite every rootfs.
 -->
 
 ## Evidence

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,10 @@ output-*/
 # shared one; these are personal and never belong in a pull request.
 CLAUDE.local.md
 .claude/settings.local.json
+
+# Python bytecode, written next to the CI scripts whenever one of them is
+# imported -- by their own tests, or by anything that loads ci-matrix.py. Never
+# committed: it is a binary with no buildable source, and until #2330 an
+# accidental .pyc widened a docs pull request to the full 99-board matrix.
+__pycache__/
+*.pyc

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -82,10 +82,28 @@ Prioritise, in order:
    Each of these is bound to one exact build of one blob and fails silently at the next
    vendor drop.
 
-6. Claims without evidence. A behaviour change needs a stated symptom and before/after
-   output from real hardware. A test plan whose boxes are unchecked is weaker than no test
-   plan, because it asserts verification that did not happen. A PR that says it was not
-   tested on hardware is not reviewable.
+6. Claims without evidence. A change that can alter an image needs a stated symptom and
+   before/after output from real hardware. A test plan whose boxes are unchecked is weaker
+   than no test plan, because it asserts verification that did not happen. Such a PR
+   saying it was not tested on hardware is not reviewable. Scope this to diffs that reach
+   an image. The test is whether the diff can change what the firmware DOES on a camera,
+   not where the file lives and not whether image bytes differ - every build stamps
+   BUILD_SHA, BUILD_ID and a timestamp into /usr/lib/os-release, so by a byte measure
+   every commit qualifies and the gate becomes unsatisfiable again. Where the answer is
+   genuinely unclear, treat it as not exempt. Exempt in
+   practice: documentation, the review configuration, repository metadata, the pull
+   request template, CODEOWNERS, and CI machinery that only selects, lints or tests
+   (ci-matrix.py, the test_ and lint- scripts, check_target_modules.sh, the workflows
+   running them). Those have no camera behaviour to observe, and asking for one invites
+   the invented evidence this rule exists to catch - judge them on the evidence their
+   class admits, a self-test, selector output, a parse run.
+   Three things look exempt and are not: a defconfig CI does not build is still a real
+   image and needs more evidence than one CI builds, since the selector reports zero
+   boards for it either way; a workflow that sets a build input can change image bytes, as
+   build.yml does through BUILD_ID and BUILD_SHA reaching os-release; and the post-build
+   machinery (general/scripts/rootfs_script.sh, late-overlays.list,
+   late-post-build-hooks.list, the excludes lists) rewrites every rootfs the tree builds.
+   Claiming hardware testing that did not happen is a finding whatever the diff touches.
 
 7. Dead code and scope creep. A new source file that no Config.in selects and no .mk
    builds is not compiled by CI, so nothing proves it even builds. And a diff must do what

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,20 @@ asks for the symptom, the SoC and board, and before/after evidence — paste the
 (`dmesg`, `ipcinfo`, the stream behaviour, the image size). A description of the output is not
 the output.
 
+This applies to any change that can alter what the firmware does on a camera, which is
+nearly all of them. Note it is behaviour, not bytes: every build stamps the commit SHA and
+a timestamp into `/usr/lib/os-release`, so byte equality would make even a typo fix count. The exceptions are documentation, review configuration, repository metadata,
+`CODEOWNERS`, and CI machinery that only selects, lints or tests. The test is what the file
+can change, not where it lives; if that is unclear for your diff, assume it needs a board.
+
+Three things look like exceptions and are not. A zero-board `ci-matrix.py --stdin` result
+does not mean your diff reaches no image: the selector reports zero for every defconfig
+outside its matrix, and some of those are real boards left out for build cost, so editing
+one changes a shipped image with no CI coverage at all. A workflow that feeds a build input
+changes image bytes — `build.yml` sets `BUILD_ID` and `BUILD_SHA`, which land in
+`/usr/lib/os-release` in every rootfs. And the post-build machinery under `general/scripts/`
+rewrites every rootfs the tree builds.
+
 ### Flashing safety
 
 A bad rootfs is discovered after it has been written. Do not flash an untested image onto a

--- a/best_practices.md
+++ b/best_practices.md
@@ -304,13 +304,58 @@ discover otherwise.
 Flag any PR description containing unchecked checkboxes under a test or verification
 heading. Ask for the output, not the checkmark.
 
-### 5.3 "Not tested on hardware" is not reviewable
+### 5.3 "Not tested on hardware" is not reviewable — when the change reaches a camera
 
-A PR that states it was never run on a camera cannot be merged, and no amount of code
-reading substitutes. This applies equally to hedges — "should work on", "untested but",
-"in theory this also fixes".
+A PR that changes what an image contains and states it was never run on a camera cannot
+be merged, and no amount of code reading substitutes. This applies equally to hedges —
+"should work on", "untested but", "in theory this also fixes".
 
 Flag and close. The contributor is welcome to reopen with output from a real board.
+
+The rule is scoped to changes that can reach an image, because that is the thing only
+hardware can settle. Documentation, review configuration, repository metadata, and the
+board-selection logic in `ci-matrix.py` alter no image byte, so there is no before and
+after to observe; `#2330` was flagged for saying so, having changed the selector and
+nothing else. Asking for a dmesg paste there does not raise the standard, it invites a
+paste from a board that was not exercising the change — the fabricated evidence §5.2
+exists to catch.
+
+The test is whether the diff can change what the firmware *does* on a camera — not where
+the file lives, and not whether image bytes differ. Bytes are the wrong measure: every
+build stamps `BUILD_SHA`, `BUILD_ID` and a timestamp into `/usr/lib/os-release`, so a
+documentation commit changes bytes in every image too. Those provenance stamps do not
+count. That phrasing is deliberate: three separate attempts to *enumerate* what reaches an
+image each missed something, and each miss was a hole in the gate, while enumerating the
+exempt side instead immediately started demanding camera output for `CODEOWNERS`. A
+property holds where a list does not. Where the property is genuinely unclear, the change
+is not exempt — the same fail-safe direction `ci-matrix.py` takes when an unrecognised
+path widens the matrix instead of narrowing it.
+
+Exempt in practice: documentation, review configuration, repository metadata, the pull
+request template, `CODEOWNERS`, and the CI machinery that only selects, lints or tests.
+
+The misses are worth naming, because they all look exempt and are not:
+
+A zero-board result from `ci-matrix.py --stdin` does **not** mean a diff reaches no image.
+The selector returns zero for every defconfig outside its matrix, and several of those are
+real boards excluded only for build cost — `fh8852v210_lite` is a real lite firmware whose
+entry reads "internal toolchain: builds gcc+musl from source". Editing such a defconfig
+changes a kernel, a rootfs and a shipped image while the selector reports nothing. Those
+boards need *more* evidence than the ones CI builds, not less, because CI supplies none.
+
+A workflow is not automatically exempt. `build.yml` sets `BUILD_ID` and `BUILD_SHA`, which
+`general/scripts/rootfs_script.sh` writes into `/usr/lib/os-release` in every rootfs it
+builds. A workflow that feeds a build input can change image bytes.
+
+Nor is the post-build machinery. `general/scripts/rootfs_script.sh` prunes `libstdc++`,
+applies the excludes lists, and copies in the late overlays named by `late-overlays.list`
+and `late-post-build-hooks.list`; `strip-shell-comments.awk` rewrites every shipped script.
+None of those is a package, a defconfig or an overlay file, and all of them rewrite the
+rootfs of every board that builds.
+
+What an exempt change still owes is the evidence its own class admits — the self-test that
+covers it, the selector output, the parse run — and the honesty half of the rule does not
+move. Claiming hardware testing that did not happen fails whatever the diff touches.
 
 ---
 

--- a/pr_compliance_checklist.yaml
+++ b/pr_compliance_checklist.yaml
@@ -185,10 +185,32 @@ pr_compliances:
       streams. The evidence in the description is therefore part of the change under
       review, and an unchecked box asserts verification that did not happen.
     success_criteria: >
-      A behaviour-changing PR names the symptom and the affected board, and shows
+      A PR that can alter an image names the symptom and the affected board, and shows
       before/after output — logs, dmesg, stream behaviour, or measurements — from a real
-      camera. Any checkbox under a test or verification heading is checked.
+      camera. Any checkbox under a test or verification heading is checked. A PR that
+      cannot reach an image says so plainly and gives the evidence its change class does
+      admit: a self-test, selector output, a parse run.
     failure_criteria: >
       The description leaves checkboxes unchecked under a test or verification heading,
       states the change was not tested on hardware, or hedges with "should work",
-      "untested but", or "in theory" in place of output from a board.
+      "untested but", or "in theory" in place of output from a board — and the diff can
+      change what the firmware does on a camera. Claiming hardware testing that did not happen
+      fails this gate whatever the diff touches.
+      "Can change what the firmware does on a camera" is the entire test, and it is about
+      behaviour, not bytes. Every build stamps the commit SHA, build id and a timestamp
+      into /usr/lib/os-release, so by a byte measure every commit alters every image and
+      this gate would be unsatisfiable again; those provenance stamps do not count. The
+      lists below are examples, not the definition, and a path fitting neither is not
+      exempt — the same fail-safe direction ci-matrix.py takes when an unrecognised path
+      widens the matrix rather than narrowing it.
+      Exempt: documentation; review configuration; repository metadata; the pull request
+      template; CODEOWNERS; and CI machinery that only selects, lints or tests, such as
+      ci-matrix.py, the test_ and lint- scripts, check_target_modules.sh, and the workflows
+      that run them.
+      Not exempt, though they look it. A defconfig CI does not build is still a real
+      image and needs more evidence than one CI builds, not less, because CI supplies none
+      for it — so a zero-board ci-matrix.py result is not proof a diff reaches no image.
+      A workflow that sets a build input changes image bytes. And the post-build machinery
+      — general/scripts/rootfs_script.sh with late-overlays.list,
+      late-post-build-hooks.list and the excludes lists — rewrites every rootfs the tree
+      builds.


### PR DESCRIPTION
## Problem

The "Hardware evidence is present and honest" gate has failure criteria broader than its own
objective.

The objective scopes it correctly, and this scoping is the whole reason the rule is right:

> CI proves an image builds; only the contributor's hardware can prove it boots and streams.

That presupposes the change reaches an image. The failure criteria then drop the scope:

> The description leaves checkboxes unchecked under a test or verification heading, **states
> the change was not tested on hardware**, or hedges with "should work"…

So every CI-only, workflow, documentation and repository-metadata change that honestly reports
no hardware testing is a violation, with no way to comply.

**Observed on #2330**, which changed `ci-matrix.py` and nothing else. The review returned
`Bugs (0), Rule violations (1)` and asked for "the affected board, observed symptom, and
before/after output from a real camera" — for a selector script that never runs on a camera.
The two available responses were to invent a dmesg paste or dismiss the finding by hand.

Inventing one is precisely what §5.2 and the honest half of this same gate exist to prevent.
As written, the gate pushed toward the failure it was meant to catch.

It also fires inconsistently. #2329 stated the same "no hardware, none needed" and drew zero
violations; the difference was the agent's own classification of it as documentation rather
than a behaviour change. So the current wording is neither satisfiable nor predictable.

## What this changes

The scope test is objective and readable straight off the diff: does it touch a package, a
defconfig, a kernel config, an overlay file, a build recipe, or a workflow that sets a build
input?

The exemption is deliberately narrow, because the two obvious ways to draw it are both wrong
— review caught both, and the first would have been a serious hole:

**A zero-board `ci-matrix.py` result does not mean a diff reaches no image.** The selector
returns zero for every defconfig outside its matrix, and several of those are real boards
excluded only for build cost:

```
$ echo 'br-ext-chip-fullhan/configs/fh8852v210_lite_defconfig' | python3 .github/scripts/ci-matrix.py --stdin
ci-matrix: 0/99 boards (needs_build=False) --- nothing that reaches a build
```

`fh8852v210_lite` is a real lite firmware; its exclusion reads "internal toolchain: builds
gcc+musl from source". An earlier draft anchored the rule to that selector result, which would
have exempted from hardware evidence exactly the boards CI covers least. The anchor is gone
rather than qualified — a mechanical test wrong in the dangerous direction is worse than none
— and the rule now says outright that such a defconfig needs *more* evidence, not less.

**A workflow is not automatically exempt.** `build.yml` sets `BUILD_ID` and `BUILD_SHA`, and
`general/scripts/rootfs_script.sh` writes both into `/usr/lib/os-release` in every rootfs. A
workflow feeding a build input changes image bytes, so it sits on the required side.

What remains exempt is documentation, review configuration, repository metadata, and the
board-selection logic — things that decide which boards build, not what goes in them.

**The honesty half does not move**, and is now stated as its own sentence so the narrowing
cannot be read as a loophole:

> Claiming hardware testing that did not happen fails this gate whatever the diff touches.

A no-image change is not excused from evidence, only from *camera* evidence — it still owes
what its class admits: a self-test, selector output, a parse run.

Applied to all four places that stated the unscoped form, so the review contract does not
disagree with itself:

| File | What it is |
| --- | --- |
| `pr_compliance_checklist.yaml` | the gate itself |
| `best_practices.md` §5.3 | the reasoning behind it |
| `.pr_agent.toml` | the reviewer guidelines, priority 6 |
| `.github/PULL_REQUEST_TEMPLATE.md` | what the contributor is asked for |

`CLAUDE.md` gains the same note in its "With a camera" section, for the same reason.

## Hardware tested on

No camera, and none can apply — which is the case this change is about. Nothing here is a
package, defconfig, kernel config, overlay file or build recipe; no image byte changes.

Under the wording this PR replaces, that sentence is itself a rule violation. Under the
wording it introduces, it is the correct answer.

## Evidence

Both machine-readable files still parse, and the reviewer config avoids the hardened
loader's forbidden-token trap that silently voided it once before:

```
$ python3 -c "import yaml; yaml.safe_load(open('pr_compliance_checklist.yaml')); print('yaml ok')"
yaml ok
$ python3 -c "import tomllib; tomllib.load(open('.pr_agent.toml','rb')); print('toml ok')"
toml ok
$ grep -inE 'ld_preload|@json|@format|@py|@import|@get' .pr_agent.toml
(no matches)
```

The selector gate is untouched, and this PR builds nothing:

```
$ python3 .github/scripts/ci-matrix.py --self-test
ci-matrix: self-test ok (99 boards, 132 packages, 56 cases)

$ git diff --name-only origin/master | python3 .github/scripts/ci-matrix.py --stdin
ci-matrix: 0/99 boards (needs_build=False) --- nothing that reaches a build
```

That zero is itself worth noting: it is exactly the classification the new wording keys on,
and `.pr_agent.toml` reaches it through the `REVIEW_CONFIG` rule while `.gitignore`-class
metadata reaches it through the `REPO_META` rule added in #2330.

## This PR cannot verify itself

PR-Agent reads its configuration from the **default branch**, not from the branch under
review — the same asymmetry recorded when #2268 shipped this system and its config load could
only be confirmed after merge. So the review on this PR will apply the **old**, unscoped rule,
and may well flag the "Hardware tested on" section above.

If it does, that is the bug being fixed, demonstrating itself. The fix takes effect for the
next CI-only pull request opened after this merges, which is where it should be confirmed.

## Scope

- [x] No kernel patches under `general/package/all-patches/linux/` (those go to [OpenIPC/linux](https://github.com/OpenIPC/linux))
- [x] No files specific to a single retail camera model (those go to [OpenIPC/builder](https://github.com/OpenIPC/builder))
- [x] No probing or bring-up tooling (that goes to [OpenIPC/ipctool](https://github.com/OpenIPC/ipctool))
- [x] Nothing under `general/overlay/` or in a shared `load_<vendor>` script hardcodes a value specific to my board
- [ ] Package sources come from an OpenIPC repository… — *not applicable, no package is added or changed*
- [x] No `LD_PRELOAD`, and no binaries that cannot be rebuilt from source
- [ ] New code is selected by a defconfig, so CI actually builds it — *not applicable, no code is added*
