### PR TITLE
overlay: keep plausible time across reboots without an RTC

### DIFF
--- a/general/overlay/etc/init.d/S02fakehwclock
+++ b/general/overlay/etc/init.d/S02fakehwclock
@@ -1,0 +1,54 @@
+#!/bin/sh
+DAEMON="fake-hwclock"
+PIDFILE="/var/run/$DAEMON.pid"
+
+# S02 so every later boot message already carries a plausible timestamp;
+# rcK stops it near-last, which makes the shutdown checkpoint the freshest
+# one possible. Restoring before S30customizer is safe: both are
+# forward-only, so whichever of the checkpoint and the build stamp is
+# newer wins.
+#
+# fake-hwclock is a shell script, so the start-stop-daemon name matching
+# the other init scripts use cannot see it: argv[0] is /bin/sh and
+# /proc/PID/exe is busybox (see #2326). The daemon writes its own pidfile
+# instead, and running() re-checks the pid's cmdline before anything
+# trusts it, so a stale file never points a kill at a bystander.
+running() {
+	PID=$(cat "$PIDFILE" 2> /dev/null)
+	[ -n "$PID" ] && grep -q "$DAEMON" "/proc/$PID/cmdline" 2> /dev/null
+}
+
+start() {
+	echo -n "Starting $DAEMON: "
+	"$DAEMON" load
+	if running; then
+		echo "OK (already running)"
+		return 0
+	fi
+	"$DAEMON" daemon &
+	echo "OK"
+}
+
+stop() {
+	echo -n "Stopping $DAEMON: "
+	if running; then
+		kill "$PID"
+		rm -f "$PIDFILE"
+	fi
+	"$DAEMON" save
+	echo "OK"
+}
+
+case "$1" in
+	start | stop)
+		$1
+		;;
+	restart | reload)
+		stop
+		start
+		;;
+	*)
+		echo "Usage: $0 {start|stop|restart|reload}"
+		exit 1
+		;;
+esac

--- a/general/overlay/etc/init.d/S02fakehwclock
+++ b/general/overlay/etc/init.d/S02fakehwclock
@@ -26,6 +26,10 @@ start() {
 		return 0
 	fi
 	"$DAEMON" daemon &
+	# The daemon writes this same pid itself, but not before the shell has
+	# forked and re-executed; writing it here too closes the window where a
+	# stop right after this start would find no pidfile and miss the child.
+	echo $! > "$PIDFILE"
 	echo "OK"
 }
 

--- a/general/overlay/etc/init.d/S49ntpd
+++ b/general/overlay/etc/init.d/S49ntpd
@@ -1,7 +1,10 @@
 #!/bin/sh
 
 DAEMON="ntpd"
-DAEMON_ARGS="-n"
+# -S feeds sync events (step, stratum, periodic, unsync) to the software
+# RTC so a fresh sync is checkpointed at once instead of waiting for the
+# next periodic save - see /usr/sbin/fake-hwclock.
+DAEMON_ARGS="-n -S /usr/sbin/ntpd-script"
 
 # Find the daemon by name, never through a pidfile. Given -p, busybox
 # start-stop-daemon inspects only the pid that file holds and never scans

--- a/general/overlay/usr/sbin/fake-hwclock
+++ b/general/overlay/usr/sbin/fake-hwclock
@@ -1,0 +1,161 @@
+#!/bin/sh
+# Software RTC for cameras that have no battery-backed clock (#1886).
+# Without it every boot starts at the firmware build stamp, so an offline
+# camera writes each session's recordings over the same timestamps.
+#
+# A checkpoint of the current time is kept in /etc, which lives on the
+# writable overlay - jffs2 on NOR, ubifs on NAND - so every save is a
+# flash write. The save cadence is therefore chosen per medium below:
+# a NOR overlay is a handful of 64 KB erase blocks with ~100k cycles
+# and jffs2 only wear-levels inside that partition, while UBI levels
+# across the whole NAND and eMMC/SD controllers level internally.
+# Hourly is ~9k writes a year; the 5-second loop this replaces was ~6.3M.
+#
+# Restore is forward-only and also takes the newest mtime under /etc as a
+# floor, the way OpenWrt's sysfixtime does: cameras are usually powered
+# off by cutting power, so a shutdown hook cannot be the mechanism, but
+# organic config writes keep advancing that floor for free.
+
+FILE="/etc/fake-hwclock.data"
+LOCK="/var/run/fake-hwclock.lock"
+PIDFILE="/var/run/fake-hwclock.pid"
+
+# Optional override: INTERVAL=<seconds> (0 disables periodic saves).
+[ -r /etc/default/fake-hwclock ] && . /etc/default/fake-hwclock
+
+build_epoch() {
+	epoch=$(grep TIME_STAMP /etc/os-release | cut -d= -f2)
+	case "$epoch" in
+		'' | *[!0-9]*) echo 0 ;;
+		*) echo "$epoch" ;;
+	esac
+}
+
+saved_epoch() {
+	epoch=$(cat "$FILE" 2> /dev/null)
+	case "$epoch" in
+		'' | *[!0-9]*) echo 0 ;;
+		*) echo "$epoch" ;;
+	esac
+}
+
+interval() {
+	if [ -n "$INTERVAL" ]; then
+		echo "$INTERVAL"
+		return
+	fi
+	case "$(awk '$2 == "/overlay" { print $3; exit }' /proc/mounts)" in
+		ubifs)
+			echo 900
+			;;
+		ext4 | f2fs | vfat | exfat)
+			echo 600
+			;;
+		tmpfs)
+			# NFS or RAM root: nothing persists, saving is pointless.
+			echo 0
+			;;
+		*)
+			# jffs2, and anything unrecognised treated as the worst
+			# medium we ship on: a small NOR partition.
+			echo 3600
+			;;
+	esac
+}
+
+# save [periodic] - checkpoint the clock. Serialised with flock because the
+# ntpd hook and the fallback daemon can fire together. Never persists a
+# clock at or below the build stamp (nothing has set it yet, checkpointing
+# it would only launder garbage - same guard Debian's fake-hwclock uses)
+# and never moves the checkpoint backwards.
+do_save() {
+	exec 9> "$LOCK"
+	flock 9
+	now=$(date +%s)
+	[ "$now" -gt "$(build_epoch)" ] || return 1
+	last=$(saved_epoch)
+	if [ "$1" = "periodic" ]; then
+		every=$(interval)
+		[ "$every" -gt 0 ] || return 0
+		[ $((now - last)) -ge "$every" ] || return 0
+	fi
+	[ "$now" -gt "$last" ] || return 0
+	echo "$now" > "$FILE"
+	[ -e /dev/rtc0 ] && hwclock -w -u -f /dev/rtc0 2> /dev/null
+	return 0
+}
+
+# Forward-only restore, taking the best of three candidates: the checkpoint,
+# the newest mtime under /etc (one scan covers the checkpoint's own mtime
+# too), and the RTC where the SoC has one. The RTC is read through sysfs
+# rather than applied with hwclock -s: it ticks while the board is powered
+# but usually has no battery, and hwclock -s would happily yank a synced
+# clock backwards to a stale RTC when this runs again on a restart.
+do_load() {
+	best=$(saved_epoch)
+	rtc=$(cat /sys/class/rtc/rtc0/since_epoch 2> /dev/null)
+	case "$rtc" in
+		'' | *[!0-9]*) ;;
+		*) [ "$rtc" -gt "$best" ] && best=$rtc ;;
+	esac
+	newest=$(find /etc -type f -exec date -r {} +%s \; 2> /dev/null | sort -n | tail -1)
+	case "$newest" in
+		'' | *[!0-9]*) ;;
+		*) [ "$newest" -gt "$best" ] && best=$newest ;;
+	esac
+	if [ "$best" -gt "$(date +%s)" ]; then
+		date -s "@$best" > /dev/null 2>&1 &&
+			logger -t fake-hwclock "clock restored to $(date -u '+%Y-%m-%d %H:%M:%S') UTC"
+	fi
+	return 0
+}
+
+# Fallback for cameras ntpd never syncs - the case #1886 was written for.
+# An unsynced busybox ntpd fires no -S events at all, so without this loop
+# an offline camera would checkpoint nothing. A sleep that returns far too
+# late means the clock was stepped under us (first sync, manual date -s):
+# worth checkpointing immediately, the guards in do_save keep it safe.
+do_daemon() {
+	echo $$ > "$PIDFILE"
+	[ "$(interval)" -gt 0 ] || exit 0
+	last=$(date +%s)
+	while :; do
+		sleep 60
+		now=$(date +%s)
+		if [ "$now" -gt $((last + 90)) ] || [ "$now" -lt "$last" ]; then
+			do_save
+		else
+			do_save periodic
+		fi
+		last=$now
+	done
+}
+
+# Invoked by busybox ntpd -S via /usr/sbin/ntpd-script. "stratum" marks the
+# first successful sync and "step" a correction - the highest-value moments
+# to persist. "periodic" comes every 11 minutes while synced and is rate
+# limited by the medium interval. "unsync" carries no better time, skip it.
+do_ntp_event() {
+	case "$1" in
+		step | stratum)
+			do_save
+			;;
+		periodic)
+			do_save periodic
+			;;
+	esac
+	return 0
+}
+
+case "$1" in
+	load | save | daemon)
+		do_$1
+		;;
+	ntp-event)
+		do_ntp_event "$2"
+		;;
+	*)
+		echo "Usage: $0 {load|save|daemon|ntp-event <type>}"
+		exit 1
+		;;
+esac

--- a/general/overlay/usr/sbin/fake-hwclock
+++ b/general/overlay/usr/sbin/fake-hwclock
@@ -64,25 +64,29 @@ interval() {
 }
 
 # save [periodic] - checkpoint the clock. Serialised with flock because the
-# ntpd hook and the fallback daemon can fire together. Never persists a
-# clock at or below the build stamp (nothing has set it yet, checkpointing
-# it would only launder garbage - same guard Debian's fake-hwclock uses)
-# and never moves the checkpoint backwards.
+# ntpd hook and the fallback daemon can fire together; the lock lives in a
+# subshell so it is released the moment the write is done - an exec-opened
+# descriptor would stay locked in the daemon across its whole next sleep
+# and stall the first-sync checkpoint the hook exists to persist. Never
+# persists a clock at or below the build stamp (nothing has set it yet,
+# checkpointing it would only launder garbage - same guard Debian's
+# fake-hwclock uses) and never moves the checkpoint backwards.
 do_save() {
-	exec 9> "$LOCK"
-	flock 9
-	now=$(date +%s)
-	[ "$now" -gt "$(build_epoch)" ] || return 1
-	last=$(saved_epoch)
-	if [ "$1" = "periodic" ]; then
-		every=$(interval)
-		[ "$every" -gt 0 ] || return 0
-		[ $((now - last)) -ge "$every" ] || return 0
-	fi
-	[ "$now" -gt "$last" ] || return 0
-	echo "$now" > "$FILE"
-	[ -e /dev/rtc0 ] && hwclock -w -u -f /dev/rtc0 2> /dev/null
-	return 0
+	(
+		flock 9
+		now=$(date +%s)
+		[ "$now" -gt "$(build_epoch)" ] || exit 1
+		last=$(saved_epoch)
+		if [ "$1" = "periodic" ]; then
+			every=$(interval)
+			[ "$every" -gt 0 ] || exit 0
+			[ $((now - last)) -ge "$every" ] || exit 0
+		fi
+		[ "$now" -gt "$last" ] || exit 0
+		echo "$now" > "$FILE"
+		[ -e /dev/rtc0 ] && hwclock -w -u -f /dev/rtc0 2> /dev/null
+		exit 0
+	) 9> "$LOCK"
 }
 
 # Forward-only restore, taking the best of three candidates: the checkpoint,

--- a/general/overlay/usr/sbin/ntpd-script
+++ b/general/overlay/usr/sbin/ntpd-script
@@ -1,0 +1,5 @@
+#!/bin/sh
+# busybox ntpd -S hook (see S49ntpd): called detached with step, stratum,
+# periodic or unsync in $1. Single consumer today; fan out here if more
+# subscribers ever appear rather than chaining -S flags.
+exec fake-hwclock ntp-event "$1"

--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -483,6 +483,11 @@ free_resources() {
 	/etc/init.d/S60crond stop
 	/etc/init.d/S49ntpd stop
 	/etc/init.d/S02klogd stop
+	# fake-hwclock writes /etc periodically; left running it would be a live
+	# overlay writer during the erase that quiesce_overlay() exists to fence
+	# off. Its stop also takes a final checkpoint, so the camera comes back
+	# from the post-flash reboot with the freshest time it can have.
+	/etc/init.d/S02fakehwclock stop
 	/etc/init.d/S01syslogd stop
 	services_stopped=1
 	sleep 1
@@ -501,7 +506,8 @@ free_resources() {
 #
 # free_resources runs before the download, because dropping the page cache is
 # how a small camera finds the RAM to unpack the image -- so by the time a
-# download or checksum fails, syslog, klogd, ntpd and cron are already stopped.
+# download or checksum fails, syslog, klogd, ntpd, fake-hwclock and cron are
+# already stopped.
 # The reboot used to hide that: everything came back on the way up. Now that a
 # pre-flash failure leaves the camera running, it has to be undone explicitly,
 # or a refused upgrade silently costs the user their logging and their cron jobs
@@ -512,7 +518,7 @@ restore_resources() {
 	[ "1" = "$services_stopped" ] || return 0
 	echo_c 37 "\nRestarting the services stopped for the upgrade"
 	local s
-	for s in S01syslogd S02klogd S49ntpd S60crond S99rc.local; do
+	for s in S01syslogd S02fakehwclock S02klogd S49ntpd S60crond S99rc.local; do
 		[ -x /etc/init.d/$s ] && /etc/init.d/$s start >/dev/null 2>&1
 	done
 	# majestic needs restarting, not starting: it is still running, just gutted.


### PR DESCRIPTION
## What this solves

A camera without a battery-backed clock boots at the firmware build stamp (`TIME_STAMP` in `/etc/os-release`, applied by `S30customizer`). On a camera with no network, every session therefore starts at the same moment: recordings collide with earlier ones, log timestamps repeat, and TLS validation trips over certificate validity windows. #1886 (@danielbanar) diagnosed this and proposed a fake-hwclock package; this PR supersedes it — the redesign below is why it is a new PR rather than a rework of that branch, and Daniel is credited as co-author.

## Why not #1886 as it stood

- Its daemon wrote `/etc/fake-hwclock.data` every 5 seconds. `/etc` lives on the overlay — jffs2 on NOR, where the partition is a handful of 64 KB erase blocks (as small as 704 KB) that jffs2 can only wear-level *within*. That is ~6.3M writes a year against a ~100k-cycle budget.
- Its init script used the pidfile `start-stop-daemon` pattern the tree removed in #2326.
- It shipped as an opt-in package; time that is only plausible on cameras whose owner found a hidden knob does not fix the out-of-the-box recording behaviour. This PR enables it for every board — deliberately revisiting the "not by default" position from the #1886 discussion, with the wear numbers below as the argument that default-on is now safe.

## Design

Surveyed OpenWrt `sysfixtime`, Debian/RPi `fake-hwclock`, systemd-timesyncd, and OpenRC `swclock` (mechanisms verified in their sources). This is a combination of the pieces that fit a hard-power-cut camera:

**Restore (boot, `S02`)** — forward-only, from the best of three candidates:
- the checkpoint file `/etc/fake-hwclock.data`;
- the newest file mtime under `/etc` (OpenWrt's trick: organic config writes keep this floor advancing for free, so even a camera that never checkpoints resumes from its last config write);
- the SoC RTC via `/sys/class/rtc/rtc0/since_epoch` where one exists — read through sysfs rather than `hwclock -s`, because a stale battery-less RTC must lose to a newer checkpoint, never yank the clock backwards.

The clock is only ever moved forward, so this composes with `S30customizer`'s build-stamp guard in either order.

**Checkpoint (write to flash)** — cadence bounded by what the overlay actually sits on:

| medium | interval | writes/year |
| --- | --- | --- |
| jffs2 (NOR) | 3600 s | ~8.8k |
| ubifs (NAND, UBI levels across the whole chip) | 900 s | ~35k |
| ext4/f2fs/vfat (eMMC/SD) | 600 s | ~53k |
| tmpfs (NFS/RAM root) | never | 0 |

Overridable via `/etc/default/fake-hwclock` (`INTERVAL=`, 0 disables). Each save also refuses to persist a clock at or below the build stamp (a clock nothing set yet would only launder garbage into the file), never moves the checkpoint backwards, and writes the RTC forward where present.

Three triggers share that one guarded path:
- **busybox ntpd's `-S` hook** (`S49ntpd` now passes `-S /usr/sbin/ntpd-script`): `stratum`/`step` — the first real sync — checkpoints immediately; `periodic` (every 11 min while synced) is rate-limited to the medium interval; `unsync` is ignored.
- **a fallback loop** for the offline camera #1886 was actually about — an unsynced ntpd fires no events at all;
- **clean shutdown** (`rcK`), as a bonus, never as the mechanism.

## Evidence (hi3516av300, NOR flash, jffs2 overlay, IMX415)

Method: the camera ran today's master build (`2.6.08.29`, `master+fc923b7`) with the four files from this branch copied onto its overlay — they are plain shell, so the copies are exactly what the image would ship (an `hi3516av300_lite` image was also built from this branch to verify installation and size, but was not flashed). NTP was made unreachable by pointing `/etc/ntp.conf` at 192.0.2.1 (TEST-NET). The camera was returned to stock afterwards and verified over a final reboot.

**Hard reset with a stale RTC and no NTP** — power-cut simulation (`reboot -f`, so no shutdown hook ran; RTC deliberately written back to the build era first):

```
== pre-reset:  checkpoint=1788038583  real=1788038583 (Sat Aug 29 21:23:03 UTC 2026)
   cold state: sys=1787975900 rtc=1787975900   ntp.conf: server 192.0.2.1
== after boot (uptime 51s):
   date: Sat Aug 29 21:23:51 UTC 2026   (wall-clock real time: 21:24:10)
   Aug 29 21:23:03 ... user.notice fake-hwclock: clock restored to 2026-08-29 21:23:03 UTC
```

Boot came up ~19 s behind real time — the checkpoint's age. Stock behaviour for this state is the build stamp, ~17.6 h behind.

**Guards** (ntpd stopped):

```
date -s @1787974800            # below the build stamp
fake-hwclock save              # -> rc=1, checkpoint untouched
fake-hwclock load              # 03:40 -> 21:11:44, forward to the checkpoint
```

Backwards-set never observed; a `load` with a correct clock is a no-op (delta 0 s), including with a deliberately stale RTC present.

**ntpd hook**: after `S49ntpd restart` with the `-S` flag, the stratum event checkpointed within 5 s of sync; `periodic` events did not write again before the interval elapsed (rate-limit observed).

**Daemon**: with `INTERVAL=5` override, periodic saves observed; `stop` kills the pid (verified against `/proc/<pid>/cmdline`, not blindly) and writes a final checkpoint.

**Image**: `hi3516av300_lite` builds clean; rootfs 7624/8192 KB. The three scripts cost ~2.8 KB comment-stripped.

Not tested on NAND/ubifs or eMMC boards — the medium detection is a `/proc/mounts` fstype match and falls back to the most conservative (hourly) cadence for anything unrecognised.

Supersedes #1886.

Co-authored-by: Daniel Banar <daniel.banar5@gmail.com>
