### PR TITLE
waybeam: do not SIGKILL the encoder when a graceful stop times out

### DIFF
--- a/general/package/waybeam/files/S95waybeam
+++ b/general/package/waybeam/files/S95waybeam
@@ -6,6 +6,12 @@ WATCHDOG="waybeam-wd"
 DAEMON_PATH="/usr/bin/waybeam"
 LOG_PATH="/tmp/waybeam.log"
 
+# Seconds to wait for a graceful exit. waybeam's teardown releases SigmaStar
+# kernel state and can legitimately take ~12s when the MI flush is slow, so
+# this needs real headroom -- a short window turns a slow shutdown into a
+# reported failure.
+STOP_TIMEOUT_S=30
+
 # waybeam forks a respawn child (comm "waybeam-resp") on an API restart and a
 # watchdog ("waybeam-wd"). pidof and killall match by comm, so every restart
 # path must cover all three names, otherwise stop() returns while a helper is
@@ -16,7 +22,7 @@ still_running() {
 
 wait_exit() {
 	i=0
-	while [ $i -lt 30 ]; do
+	while [ $i -lt $((STOP_TIMEOUT_S * 2)) ]; do
 		still_running || return 0
 		sleep 0.5
 		i=$((i + 1))
@@ -49,16 +55,21 @@ stop() {
 		echo "OK"
 		return 0
 	fi
-	# 15s of SIGTERM was not enough. Escalate rather than report a stop that
-	# did not happen: restart would then run start() against a survivor, which
-	# trips the duplicate-instance check and returns 0 having done nothing --
-	# the requested restart silently never happens.
-	killall -9 "$DAEMON" "$RESPAWN" "$WATCHDOG" 2>/dev/null
-	if wait_exit; then
-		echo "OK (forced)"
-		return 0
-	fi
-	echo "FAILED ($DAEMON survived SIGKILL)"
+	# Deliberately no SIGKILL escalation. waybeam releases SigmaStar kernel
+	# state on its way out (MI_SYS_Exit / MI_VENC_DestroyChn); SIGKILL skips
+	# that and leaves the MI channel and binding slots occupied, and nothing
+	# in userspace can reclaim them. The next start then binds a half-open
+	# channel whose symptom is "no encoder data received" until the board is
+	# power-cycled -- a bad place for an init script to leave a camera, since
+	# restart is what people run when they cannot reach the hardware.
+	#
+	# Reporting the failure instead keeps the still-running instance
+	# streaming, and "restart) stop && start" stops a second instance from
+	# being started on top of wedged state. If the daemon is genuinely hung
+	# the SDK is already stuck, and a reboot -- which waybeam's own teardown
+	# watchdog performs when its MI flush wedges -- is the recovery that
+	# returns the board to a known state.
+	echo "FAILED (still running after ${STOP_TIMEOUT_S}s; not forcing, SIGKILL wedges the SigmaStar MI state)"
 	return 1
 }
 


### PR DESCRIPTION
Follow-up to #2332, on the `stop()` escalation added in `2f85ed2d`.

## What and why

That commit fixes a real bug and I am not proposing to undo it. A stop that did not happen must not report `OK`, because `restart` then runs `start()` against a survivor, trips the duplicate-instance check, returns 0, and the requested restart silently never happens. Keeping the honest failure report and `restart) stop && start` is right.

What this PR changes is the escalation it reaches for. **`killall -9` is the one thing that must not be done to this daemon on SigmaStar.**

waybeam releases kernel-side state on its way out, through `MI_SYS_Exit` / `MI_VENC_DestroyChn`. SIGKILL skips that path, so the MI channel and binding slots stay occupied and nothing in userspace can reclaim them. The next `start` binds a half-open channel: snapshots time out, and the log fills with `waiting for encoder data...`. In our experience only a power cycle clears it. That is a bad state for an init script to be able to create, because `restart` is precisely what someone runs remotely when they cannot get to the hardware — the command most likely to be used is the one that can require physical access to undo.

This is not theoretical. We lost a Star6E bench to exactly this on 2026-05-14: a `killall -9` on the encoder left the board so that a fresh start logged its init as OK while every snapshot timed out and the main stream sat at `waiting for encoder data...`, and power-cycling was the only way back. The encoder's own source carries the same warning from another angle, in `star6e_audio.c`, describing a teardown hang "with the watchdog SIGKILL'ing us before MI_SYS_Exit could run" as the thing to avoid.

There is a second-order cost too, which is what prompted me to send a patch rather than just a comment. The `OK (forced)` path reports success and lets `restart` proceed into `start()` against poisoned kernel state, so the resulting symptom is `no encoder data received`. That is the **same** signature a board with a mismatched device tree produces. I spent a long session this week separating those two causes on Infinity6C hardware, and an init script that can manufacture the symptom makes that diagnosis harder for whoever hits it next.

So: keep the fix that mattered, drop the kill. A stop that times out reports the failure and returns 1, which leaves the still-running instance streaming instead of starting a second one on top of wedged state. If the daemon is genuinely hung then the SDK is already stuck, and a reboot is the recovery that returns the board to a known state rather than an unknown one — waybeam's own teardown watchdog already does exactly that when its MI flush wedges, logging `teardown wedged for 12s (MI flush D-state) — forcing reboot for deterministic recovery`. The daemon has a deterministic escape; the init script's job is to not pre-empt it.

The window also goes from 15s to 30s. waybeam's teardown can legitimately take ~12s when the MI flush is slow, so the old window could fire on a shutdown that was going to succeed. `STOP_TIMEOUT_S` drives both the loop and the message so the two cannot drift apart.

## Evidence

SSC338Q + IMX415, running an image built from `master` with this package selected (Majestic off, `BR2_PACKAGE_WAYBEAM=y`). The modified script was run against the live daemon.

**Graceful stop — completes in 2s, well inside even the old window, and releases the kernel-side state that SIGKILL would have skipped:**

```
=== pre-state: pid=810
=== stop (timed):
Stopping waybeam: OK
rc=0 elapsed=2s
post-stop pid: none

dmesg:
[CMDQ]Release CMDQ(2) service
client [810] disconnected, module:sensor
client [810] disconnected, module:sys
```

Those `client [810] disconnected` lines are the point of the change: that is the MI teardown a SIGKILL never gets to run.

**Start after a graceful stop — binds cleanly, no half-open channel:**

```
=== start:
Starting waybeam: OK
rc=0
pid=2846
encoder errors: 0
```

**Restart — the path the original bug made silently no-op — and idempotent start:**

```
=== restart (timed):
Stopping waybeam: OK
Starting waybeam: OK
rc=0 elapsed=2s
pid=3033
encoder errors: 0

=== start when already running:
waybeam already running
rc=0
```

**Stream verified after the restart**, at the mode the config selects, via `/api/v1/snapshot.jpg`:

```
1920x1080  mean luma 87.64  stddev 14.12
```

which matches the pre-test reading of 87.84 on the same scene, so the board came back exactly as it was.

`sh -n` passes on the script.

## What I did not test

I have **not** exercised the timeout branch itself on hardware, because producing a genuinely wedged teardown on demand means deliberately wedging a board, and I did not want to do that to a working one to prove a negative. The graceful path above is what I can demonstrate. The claim behind the change — that SIGKILL leaves unreclaimable MI state — rests on the 2026-05-14 incident and on the encoder's own source comment, not on a reproduction in this PR. If you would rather see the failure branch exercised directly I am happy to do it on a spare board and post what the SIGKILL path actually leaves behind; say the word.
