### PR TITLE
publish with an explicit release credential, and prove it before building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,6 +166,44 @@ jobs:
           echo "built_at=$BUILT_AT" >> "$GITHUB_OUTPUT"
           echo "webui_digest=$WEBUI" >> "$GITHUB_OUTPUT"
 
+      # Prove the release credential BEFORE the matrix runs.
+      #
+      # On 2026-08-29, run 33273333359 built all 102 boards over two hours and
+      # then died in `Publish releases` with "403 Resource not accessible by
+      # integration". Nothing earlier had any opinion about whether the run
+      # could publish, so the price of that misconfiguration was the entire
+      # matrix, and a night of cameras finding no new firmware behind the
+      # `latest` tag. The failure was invisible until the last job of the run.
+      #
+      # A draft release is not visible to anyone and creates no tag, so this
+      # costs two API calls and turns a two-hour failure into a ten-second one.
+      # Checking the secret is merely non-empty would not have caught that
+      # incident at all: the old token existed and was simply refused.
+      #
+      # Skipped on pull_request, which neither publishes nor has the secret.
+      - name: Prove the release credential can write
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::RELEASE_TOKEN is not set. The matrix would build for"\
+                 "two hours and then fail to publish. See the publish job."
+            exit 1
+          fi
+          probe="ci-release-credential-probe-${{ github.run_id }}"
+          if ! id=$(gh api -X POST "repos/${GH_REPO}/releases" \
+                      -f tag_name="$probe" -f name="$probe" -F draft=true \
+                      --jq .id); then
+            echo "::error::RELEASE_TOKEN cannot create releases in ${GH_REPO}."\
+                 "It needs Contents: read and write."
+            exit 1
+          fi
+          gh api -X DELETE "repos/${GH_REPO}/releases/$id"
+          echo "release credential OK"
+
   buildroot:
     name: Firmware
     needs: [preflight, select]
@@ -514,7 +552,18 @@ jobs:
       - name: Publish releases (paced, retry-aware)
         if: steps.collect.outputs.count != '0'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Not GITHUB_TOKEN. The default token's release-write depends on
+          # who triggered the run: a `schedule:` run executes as the repository's
+          # scheduling identity and could write releases, but a dispatched run
+          # executes as whoever dispatched it, and for an app/OAuth-backed
+          # identity the API answers "403 Resource not accessible by
+          # integration" even though the job declares `contents: write` and the
+          # run log confirms the token was granted it. Since the nightly is now
+          # dispatched by the release trigger rather than fired by cron, the
+          # default token is no longer sufficient here. An explicit credential
+          # also makes publishing independent of who or what starts the run,
+          # which is the property that was quietly missing before.
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           GH_REPO: ${{ github.repository }}
           BUILD_ID: ${{ needs.preflight.outputs.build_id }}
           HEAD_SHA: ${{ needs.preflight.outputs.head_sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,17 +223,41 @@ jobs:
           gh api "repos/${GH_REPO}/releases?per_page=10" \
             --jq '.[] | select(.draft and (.tag_name | startswith("ci-release-credential-probe-"))) | .id' \
             2>/dev/null | while read -r stale; do
+              # gh writes its error body to STDOUT, so a failed list feeds this
+              # loop lines of JSON rather than ids. Deleting them is harmless --
+              # the calls just fail -- but logging "removing stranded probe
+              # draft {"status": "401"}" is a confident lie in the log of a step
+              # whose whole job is to be believed. Only act on real ids.
+              case "$stale" in ''|*[!0-9]*) continue ;; esac
               echo "removing stranded probe draft $stale"
               gh api -X DELETE "repos/${GH_REPO}/releases/${stale}" >/dev/null 2>&1 || true
             done || true
 
-          if ! probe_id=$(gh api -X POST "repos/${GH_REPO}/releases" \
-                            -f tag_name="$PROBE_TAG" -f name="$PROBE_TAG" \
-                            -F draft=true --jq .id); then
-            echo "::error::RELEASE_TOKEN cannot create releases in ${GH_REPO}."\
-                 "It needs Contents: read and write."
-            exit 1
-          fi
+          # Retried, because a one-shot POST cannot tell a bad credential from
+          # a bad minute. GitHub answers 403 for secondary rate limiting as
+          # well as for refusal -- the publish step below retries six times for
+          # exactly that reason -- and these repos return 504 on ordinary
+          # release listings often enough to have been seen while writing this.
+          # Reporting a blip as "the token is wrong" would send whoever reads
+          # it to reissue a credential that was never the problem.
+          #
+          # Three attempts rather than the publish step's six: the value here is
+          # failing fast, and 5s + 10s of backoff still absorbs a transient
+          # while keeping a genuine misconfiguration well under a minute.
+          attempt=0
+          until probe_id=$(gh api -X POST "repos/${GH_REPO}/releases" \
+                             -f tag_name="$PROBE_TAG" -f name="$PROBE_TAG" \
+                             -F draft=true --jq .id); do
+            attempt=$((attempt + 1))
+            if [ "$attempt" -ge 3 ]; then
+              echo "::error::RELEASE_TOKEN could not create a release in"\
+                   "${GH_REPO} after 3 attempts. If this is not a transient API"\
+                   "error, the token needs Contents: read and write."
+              exit 1
+            fi
+            echo "attempt ${attempt} failed, retrying in $((attempt * 5))s"
+            sleep $((attempt * 5))
+          done
           echo "release credential OK"
 
   buildroot:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,9 +176,25 @@ jobs:
       # `latest` tag. The failure was invisible until the last job of the run.
       #
       # A draft release is not visible to anyone and creates no tag, so this
-      # costs two API calls and turns a two-hour failure into a ten-second one.
-      # Checking the secret is merely non-empty would not have caught that
-      # incident at all: the old token existed and was simply refused.
+      # costs a couple of API calls and turns a two-hour failure into a
+      # ten-second one. Checking the secret is merely non-empty would not have
+      # caught that incident at all: the old token existed and was simply
+      # refused, so the probe has to attempt the write.
+      #
+      # Three details keep the probe from becoming a problem of its own:
+      #
+      #   - The tag carries run_attempt as well as run_id. run_id is stable
+      #     across re-runs, so without the attempt a leftover draft from a
+      #     failed run would collide with its own re-run and report a valid
+      #     credential as broken -- a guard that fails wrongly is worse than no
+      #     guard, because it blocks good runs.
+      #   - Deletion happens from a trap, so an interrupted or cancelled job
+      #     still cleans up rather than leaving the draft behind.
+      #   - A best-effort sweep removes probe drafts stranded by earlier runs,
+      #     because cleanup.yml does not know this tag pattern. It is capped at
+      #     the 10 most recent releases and every failure is swallowed: listing
+      #     100 releases here returns HTTP 504 (each carries hundreds of
+      #     assets), and a housekeeping step must never be what fails a build.
       #
       # Skipped on pull_request, which neither publishes nor has the secret.
       - name: Prove the release credential can write
@@ -186,22 +202,38 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          PROBE_TAG: ci-release-credential-probe-${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           set -euo pipefail
+
           if [ -z "${GH_TOKEN:-}" ]; then
             echo "::error::RELEASE_TOKEN is not set. The matrix would build for"\
                  "two hours and then fail to publish. See the publish job."
             exit 1
           fi
-          probe="ci-release-credential-probe-${{ github.run_id }}"
-          if ! id=$(gh api -X POST "repos/${GH_REPO}/releases" \
-                      -f tag_name="$probe" -f name="$probe" -F draft=true \
-                      --jq .id); then
+
+          probe_id=""
+          cleanup() {
+            [ -n "$probe_id" ] || return 0
+            gh api -X DELETE "repos/${GH_REPO}/releases/${probe_id}" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          # Strand-clearing, entirely best effort.
+          gh api "repos/${GH_REPO}/releases?per_page=10" \
+            --jq '.[] | select(.draft and (.tag_name | startswith("ci-release-credential-probe-"))) | .id' \
+            2>/dev/null | while read -r stale; do
+              echo "removing stranded probe draft $stale"
+              gh api -X DELETE "repos/${GH_REPO}/releases/${stale}" >/dev/null 2>&1 || true
+            done || true
+
+          if ! probe_id=$(gh api -X POST "repos/${GH_REPO}/releases" \
+                            -f tag_name="$PROBE_TAG" -f name="$PROBE_TAG" \
+                            -F draft=true --jq .id); then
             echo "::error::RELEASE_TOKEN cannot create releases in ${GH_REPO}."\
                  "It needs Contents: read and write."
             exit 1
           fi
-          gh api -X DELETE "repos/${GH_REPO}/releases/$id"
           echo "release credential OK"
 
   buildroot:


### PR DESCRIPTION
Fixes the outage from run [33273333359](https://github.com/OpenIPC/firmware/actions/runs/33273333359): 102 boards built over two hours, then `Publish releases` 403'd, `latest` never moved, and every camera running `sysupgrade` found the version it already had.

## Root cause

Moving the nightly off `schedule:` onto a dispatch changed **the identity the run executes as**. A scheduled run executes as the repository's scheduling identity; a dispatched one as whoever dispatched it. For an app/OAuth-backed identity the releases API answers:

```
HTTP 403: Resource not accessible by integration
gh failed after 6 attempts: gh release create nightly-20260829-eca39ee ...
```

The trap is that **nothing in the workflow looks wrong**. The publish job declares `contents: write`, and the run log's `GITHUB_TOKEN Permissions` group confirms it was *granted* `Contents: write` — byte-identical to the last scheduled run that published fine. Declared permissions are not what fails.

Ruled out with evidence: repo default workflow permissions are `write`; no repo rulesets; no legacy tag protection; the target tag did not already exist; a re-run failed identically, so not a flake. The isolating test: the same identity's **user** token creates releases in this repo without complaint, so the block is specific to the `GITHUB_TOKEN` minted inside a run that identity dispatched.

## Changes

**1. `publish` uses `secrets.RELEASE_TOKEN`.** Needs `Contents: read and write`. Beyond fixing the symptom, this makes publishing independent of who or what starts the run — a property that was quietly missing rather than deliberately absent.

**2. `preflight` proves the credential before the matrix runs.** It creates a draft release and deletes it: invisible to users, creates no tag, two API calls. Turns a two-hour failure into a ten-second one.

Asserting the secret is merely non-empty would **not** have caught this incident — the token that failed existed and was simply refused, so the probe has to attempt the write. Skipped on `pull_request`, which neither publishes nor has the secret.

## Before merging

`RELEASE_TOKEN` must exist as a repo secret, or the next non-PR run fails fast in preflight (which is the intended behaviour, but it will be red rather than silently unpublished).

## Verification

- Workflow YAML parses; `.github/scripts/ci-matrix.py --self-test` passes (99 boards, 133 packages, 56 cases).
- Both probe failure paths exercised locally: unset token → `RELEASE_TOKEN is not set`, exit 1; refused API call → `cannot create releases`, exit 1. Neither passes silently.
- The draft-create-then-delete sequence was run by hand against this repo while diagnosing (release id 379202336, deleted), so the probe's mechanism is known to work here.

## Note

The failed build has already been republished by hand from its own artifacts, so `latest` now points at `eca39eeb` and cameras are updating again. This PR is about the next nightly, not that recovery.