### PR TITLE
hisilicon-opensdk: pick up the ev200 sensor symbol fix

### DIFF
--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = 5ccb5e9a276d0d4514551fbe69c7a423de2d09d2
+HISILICON_OPENSDK_VERSION = 001096aeb16ccc29c2b3ef3f391d277a719c43d3
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Fixes #2338.

Eight of the thirty sensor drivers this package builds for `hi3516ev200` cannot be loaded on the images it ships them in. They name Goke SDK entry points, nothing in a HiSilicon rootfs defines those, and ld.so refuses the library at relocation time — so a camera with one of these sensors comes up with no video at all:

```
dlopen "/usr/lib/sensors/libsns_gc2053.so" error: Error relocating
/usr/lib/sensors/libsns_gc2053.so: GK_API_ISP_GetModParam: symbol not found
```

**Affected: gc2053, f37, sc2231, sc500ai, gc4023, gc5603, os02g10, sp2308.** The other twenty-two are fine, which is why this went unnoticed for so long — the sensors in the images most people run are all in that group.

Any camera can be checked in one line:

```sh
for f in /usr/lib/sensors/*.so; do echo "$(strings $f | grep -c ^GK_API) $f"; done | sort -rn
```

Any nonzero count is a driver that will not load.

## The change

One line: the commit this package pins. The fix itself is openipc/openhisilicon#215, which completes the `GK_API_*` → `HI_MPI_*` mapping the tree already carried in `hicompat.h` — one name was never mapped, and four drivers never included the header at all.

## Verification

Checked at the pin rather than assumed from the tag. The tarball buildroot actually fetches for `001096a` carries the mapping and the include in all nine affected files:

```
hicompat.h:24  #define GK_API_ISP_GetModParam HI_MPI_ISP_GetModParam
hicompat.h:47  GK_S32 GK_API_ISP_GetModParam(ISP_MOD_PARAM_S *pstModParam);
gc2053_sensor_ctl.c, gc4023_cmos.c, gc5603_cmos.c, gc5603_sensor_ctl.c,
os02g10_cmos.c, sc2231_sensor_ctl.c, sc500ai_sensor_ctl.c,
f37_sensor_ctl.c, sp2308_cmos.c            -> all include hicompat.h
```

Upstream built the whole tree both ways from the same sources, which is the regression check that matters — only the HiSilicon build may be remapped:

| `SDK_CODE` | drivers built | still naming `GK_API_*` |
| --- | --- | --- |
| `0x3516E200` (HiSilicon) | 30 | **0** |
| `0x7205200` (Goke) | 30 | **29** |

and openipc/openhisilicon#215 went in with 35/35 checks green, including the `gk7205v200` SDK build and its QEMU boot.

On hardware — a `hi3516ev300` on the 2026-08-29 nightly, swapping only the rebuilt `libsns_gc2053.so`:

| | shipped | rebuilt |
| --- | --- | --- |
| relocation error | yes | **no** |
| `Sensor driver loaded` | no | **yes** |
| `Cannot start SDK` | yes | **no** |

That board carries an imx335, so the stream then times out for want of a gc2053 on the bus — loading the driver is what was testable here, and no lab board has any of the eight affected sensors to take it further.

I could not run a full board build locally to confirm end to end: this checkout's per-package `linux` toolchain is incomplete (`arm-openipc-linux-musleabi-gcc` not found during the kernel `olddefconfig`), which is unrelated to this one-line change. CI covers that.
