### PR TITLE
gpio-motors: read the pin list from ptz_gpio, keep gpio_motors working

### DIFF
--- a/general/package/gpio-motors/Readme.md
+++ b/general/package/gpio-motors/Readme.md
@@ -7,8 +7,11 @@ This package is created and intended for unification and use in all firmware and
 
 #### Basic Example
 ```
-fw_setenv gpio_motors 'H1 H2 H3 H4 V1 V2 V3 V4'
+fw_setenv ptz_gpio 'H1 H2 H3 H4 V1 V2 V3 V4'
 ```
+`ptz_gpio` is the current name for the pin list; `gpio_motors`, used in the
+examples below and on cameras configured before the rename, keeps working as
+a fallback.
 First, the GPIOs responsible for Horizontal rotation are added, and next then the GPIOs responsible for Vertical rotation are added, a total of 8 characters.
 
 #### GK7205V200 (unknown model)

--- a/general/package/gpio-motors/src/gpio-motors.c
+++ b/general/package/gpio-motors/src/gpio-motors.c
@@ -117,7 +117,12 @@ void gpio_set(int fd, int pin, int value) {
 }
 
 void gpio_config() {
-	FILE *fp = popen("fw_printenv -n gpio_motors", "r");
+	/* ptz_gpio is the documented name (majestic-webui#227); gpio_motors is
+	 * every camera configured before the rename, so it stays as the
+	 * fallback. `grep .` turns an empty first answer into a failure so the
+	 * || actually falls through. */
+	FILE *fp = popen(
+		"fw_printenv -n ptz_gpio 2>/dev/null | grep . || fw_printenv -n gpio_motors", "r");
 	if (fp == NULL) {
 		printf("Unable to run fw_printenv\n");
 		exit(EXIT_FAILURE);
@@ -148,7 +153,7 @@ void gpio_config() {
 			exit(EXIT_FAILURE);
 		}
 	} else {
-		printf("Error: Unable to read gpio_motors from fw_printenv\n");
+		printf("Error: Unable to read ptz_gpio or gpio_motors from fw_printenv\n");
 		exit(EXIT_FAILURE);
 	}
 


### PR DESCRIPTION
Completes the PTZ variable rename from OpenIPC/majestic-webui#227 on the utility side.

The WebUI now uses explicit `ptz_*` names (`ptz_control` picks the method; `ptz_gpio` is the documented pin list) and already accepts either name for detection — but `gpio-motors` itself was the one place still demanding `gpio_motors`, forcing every new setup to use the legacy name and leaving the rename half-done.

- `ptz_gpio` is read first; `gpio_motors` remains the fallback (every camera configured before the rename has it, including the published recipes).
- `grep .` turns an empty first answer into a failure so the `||` genuinely falls through instead of handing an empty line to the parser.
- Error message and the package Readme name both variables; the Readme's per-device examples keep the legacy name they were published with.

cc @flyrouter — this is the "one hunk in the firmware repo" from the #227 reply.