### PR TITLE
overlay: ship no password, and let the first login set one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,40 @@ changes image bytes — `build.yml` sets `BUILD_ID` and `BUILD_SHA`, which land 
 `/usr/lib/os-release` in every rootfs. And the post-build machinery under `general/scripts/`
 rewrites every rootfs the tree builds.
 
+### First boot: the camera ships unclaimed
+
+`general/overlay/etc/shadow` gives root an **empty hash field**, not a password. A password
+committed to a public repository is not a credential, and the first-boot journey it produced
+asked the user to type a secret everyone already knows before letting them choose a real one.
+
+Until root has a password the camera is *unclaimed*: majestic streams nothing (RTSP 401, ONVIF
+unauthorized, HTTP 401 everywhere but the setup page) and there is no shell. Setting the
+password claims it. `/etc/shadow` is the only record of the state, read live, so whichever door
+sets the password the other sees it at once. `firstboot` — `sysupgrade -n`, which wipes the
+overlay — returns the camera to unclaimed for free.
+
+The two doors:
+
+- **Browser** — majestic serves `/setup.html` and `POST /setup` without authentication while
+  unclaimed, and 404/403s them the moment there is a password.
+- **SSH or serial** — `general/overlay/usr/sbin/openipc-claim` is root's login shell
+  (`general/overlay/etc/passwd`). It refuses anything non-interactive, runs `passwd`, then puts
+  `/bin/sh` back and steps aside. It is self-disabling — a camera claimed through the browser
+  finds it transparent and repairs `/etc/passwd` on the next login — so a broken gate cannot
+  lock anyone out of a camera that has an owner.
+
+**A login shell must be listed in `/etc/shells`.** dropbear checks it through `getusershell()`
+*before* running it, so an unlisted shell is refused at authentication and the gate never runs —
+and, worse, can never disable itself, because the self-heal happens at login. That file is built
+up by `TARGET_FINALIZE_HOOKS` (busybox appends `/bin/ash`, skeleton-init appends `/bin/sh`) and
+the rootfs overlay is rsynced over the target *after* those hooks, so shipping an
+`overlay/etc/shells` would silently freeze their list. `general/scripts/rootfs_script.sh`
+appends to it instead, which runs after both.
+
+This needs a majestic build carrying `/setup`. An image with the blank shadow and an older
+majestic gives a camera with wide-open RTSP and an unreachable WebUI, so the three repositories
+land in order: majestic, then majestic-webui's `setup.html`, then this.
+
 ### Flashing safety
 
 A bad rootfs is discovered after it has been written. Do not flash an untested image onto a

--- a/general/overlay/etc/passwd
+++ b/general/overlay/etc/passwd
@@ -1,0 +1,9 @@
+root:x:0:0:root:/root:/usr/sbin/openipc-claim
+daemon:x:1:1:daemon:/usr/sbin:/bin/false
+bin:x:2:2:bin:/bin:/bin/false
+sys:x:3:3:sys:/dev:/bin/false
+sync:x:4:100:sync:/bin:/bin/sync
+mail:x:8:8:mail:/var/spool/mail:/bin/false
+www-data:x:33:33:www-data:/var/www:/bin/false
+operator:x:37:37:Operator:/var:/bin/false
+nobody:x:65534:65534:nobody:/home:/bin/false

--- a/general/overlay/etc/shadow
+++ b/general/overlay/etc/shadow
@@ -1,4 +1,4 @@
-root:$1$jv4d1NpW$PpH6Xd79JR1JkUDLMJLch1:19477::::::
+root::19477::::::
 daemon:*:::::::
 bin:*:::::::
 sys:*:::::::

--- a/general/overlay/usr/sbin/openipc-claim
+++ b/general/overlay/usr/sbin/openipc-claim
@@ -1,0 +1,101 @@
+#!/bin/sh
+#
+# Root's login shell while the camera is unclaimed.
+#
+# The firmware ships with root's password field in /etc/shadow empty, rather
+# than with a password printed in a public repository for everyone to read. So
+# anyone who can reach a new camera can start a session on it -- dropbear runs
+# with -B, and the serial getty asks for nothing either. What they must not get
+# is a shell: the camera streams nothing and answers nothing until it has an
+# owner, and being able to claim it is not the same as owning it.
+#
+# This is root's login shell rather than a hook in /etc/profile because
+# /etc/profile is read by interactive login shells only. `ssh camera command`,
+# scp and sftp all run <shell> -c ... and would walk straight past it. The
+# login shell is the one place every door goes through: SSH interactive, SSH
+# command, scp/sftp, and the serial console by way of login.
+#
+# It disables itself. The first thing it asks is whether /etc/shadow says the
+# camera has been claimed, so a camera claimed through the web interface finds
+# this transparent on the next login and puts the stock shell back on its way
+# past. /etc/shadow stays the one place that records the state; /etc/passwd is
+# only ever a cache of it, and one that repairs itself. That also means a
+# broken or missing gate can never lock anyone out of a camera that has an
+# owner already.
+
+SHELL_REAL=/bin/sh
+ATTEMPTS=3
+
+# Field 2 of root's shadow line. Empty means no password has been set: not
+# "!" or "*", which are a locked account and very much a decision somebody
+# made, so those read as claimed.
+claimed() {
+	[ -n "$(awk -F: '$1 == "root" { print $2; exit }' /etc/shadow 2>/dev/null)" ]
+}
+
+# Put the stock shell back in /etc/passwd, so the steady state of a claimed
+# camera is the file buildroot shipped and nothing here is in the way of it.
+# Written through a temporary file and copied over the original rather than
+# moved onto it: `cat >` keeps the inode, mode and ownership that a mv would
+# replace with the temporary file's own. Failure is not fatal -- claimed()
+# above already makes this transparent from the next login on.
+release() {
+	tmp=/tmp/passwd.$$
+	if awk -F: -v OFS=: -v sh="$SHELL_REAL" \
+		'$1 == "root" { $7 = sh } 1' /etc/passwd >"$tmp" 2>/dev/null &&
+		[ -s "$tmp" ]; then
+		cat "$tmp" >/etc/passwd 2>/dev/null
+	fi
+	rm -f "$tmp"
+}
+
+# Already has an owner: get out of the way. A command execution is passed
+# through as it arrived; an interactive login is started as a login shell, so
+# it reads /etc/profile and looks exactly like the one it replaced.
+if claimed; then
+	release
+	[ "$1" = "-c" ] && exec "$SHELL_REAL" "$@"
+	exec "$SHELL_REAL" -l "$@"
+fi
+
+# No shell before there is a password, and a command execution, an scp or an
+# sftp has no way to be asked for one. Refuse, and say what to do instead --
+# a bare "permission denied" from a camera that has never been touched is the
+# kind of thing people re-flash over.
+if [ "$1" = "-c" ] || [ ! -t 0 ]; then
+	echo "This camera has not been set up yet, so it has no shell to offer." >&2
+	echo "Log in interactively (ssh root@$(hostname), or the serial console)," >&2
+	echo "or open http://$(hostname)/ in a browser, to set a root password." >&2
+	exit 1
+fi
+
+[ -f /etc/openipc_banner ] && cat /etc/openipc_banner
+cat <<'EOF'
+
+This camera has not been set up yet. It streams nothing and answers nothing
+until root has a password -- set one now to finish setting it up. The same
+password is used by the web interface, SSH, RTSP and ONVIF.
+
+EOF
+
+n=0
+while [ "$n" -lt "$ATTEMPTS" ]; do
+	n=$((n + 1))
+	passwd root && claimed && break
+	echo "Password was not set." >&2
+done
+
+# Judged on the camera rather than on what passwd said about itself: the
+# question is whether root has a password now, and that is a thing to read
+# back rather than infer from an exit status.
+if ! claimed; then
+	echo "Giving up after $ATTEMPTS attempts; the camera is still not set up." >&2
+	sleep 1 # the serial console respawns straight into this; do not spin
+	exit 1
+fi
+
+release
+echo
+echo "Done. This camera is set up and streaming again."
+echo
+exec "$SHELL_REAL" -l

--- a/general/overlay/usr/sbin/openipc-claim
+++ b/general/overlay/usr/sbin/openipc-claim
@@ -35,16 +35,24 @@ claimed() {
 
 # Put the stock shell back in /etc/passwd, so the steady state of a claimed
 # camera is the file buildroot shipped and nothing here is in the way of it.
-# Written through a temporary file and copied over the original rather than
-# moved onto it: `cat >` keeps the inode, mode and ownership that a mv would
-# replace with the temporary file's own. Failure is not fatal -- claimed()
-# above already makes this transparent from the next login on.
+# Staged in /etc and renamed into place, so a reader sees either the old file
+# or the new one and never a half-written one. The obvious `cat >/etc/passwd`
+# truncates before it writes: interrupted there -- a power cut, a full overlay
+# -- it leaves an empty account database on a camera that HAS been claimed, and
+# then nothing can authenticate at all. The temporary file has to be in /etc
+# rather than /tmp for the same reason the rename is used: /tmp is a different
+# filesystem, so mv across it would be a copy and truncate the target again.
+# Mode is set before the rename because the new file carries its own, where the
+# old copy-over inherited the original's.
+#
+# Failure is not fatal -- claimed() above already makes this transparent from
+# the next login on -- so every step is guarded and the stray is swept up.
 release() {
-	tmp=/tmp/passwd.$$
+	tmp=/etc/.passwd.claim.$$
 	if awk -F: -v OFS=: -v sh="$SHELL_REAL" \
 		'$1 == "root" { $7 = sh } 1' /etc/passwd >"$tmp" 2>/dev/null &&
 		[ -s "$tmp" ]; then
-		cat "$tmp" >/etc/passwd 2>/dev/null
+		chmod 644 "$tmp" 2>/dev/null && mv -f "$tmp" /etc/passwd 2>/dev/null
 	fi
 	rm -f "$tmp"
 }
@@ -78,17 +86,41 @@ password is used by the web interface, SSH, RTSP and ONVIF.
 
 EOF
 
+# `set_here` records that THIS session's passwd is the one that succeeded, and
+# nothing below settles for less. Reading the shadow file alone cannot answer
+# it: the browser and the other console are claiming the same camera through
+# the same file, so "root has a password now" is also true when somebody else
+# set it -- and the shell at the end of this must not be handed to a session
+# that authenticated with nothing and set nothing. Abandoning passwd three
+# times while the owner claimed the camera from a browser used to end exactly
+# there, because the giving-up test below asked the file rather than the run.
+set_here=
 n=0
 while [ "$n" -lt "$ATTEMPTS" ]; do
 	n=$((n + 1))
-	passwd root && claimed && break
+
+	# Asked before each attempt, because this prompt can sit unanswered for as
+	# long as somebody stands in front of it. Whoever claimed the camera in
+	# that time owns it, and this session does not get to write over their
+	# password. The window that stays open is the one where they claim it while
+	# the password is being typed -- narrowing that further would mean reading
+	# the password here rather than letting passwd do it, and a shell script
+	# that turns off terminal echo has its own ways to go wrong.
+	if claimed; then
+		echo >&2
+		echo "This camera was just set up from somewhere else." >&2
+		echo "Reconnect and sign in with the password that was set." >&2
+		exit 1
+	fi
+
+	if passwd root && claimed; then
+		set_here=1
+		break
+	fi
 	echo "Password was not set." >&2
 done
 
-# Judged on the camera rather than on what passwd said about itself: the
-# question is whether root has a password now, and that is a thing to read
-# back rather than infer from an exit status.
-if ! claimed; then
+if [ -z "$set_here" ]; then
 	echo "Giving up after $ATTEMPTS attempts; the camera is still not set up." >&2
 	sleep 1 # the serial console respawns straight into this; do not spin
 	exit 1

--- a/general/scripts/rootfs_script.sh
+++ b/general/scripts/rootfs_script.sh
@@ -85,6 +85,27 @@ if [ -f "${LATE_POST_BUILD_HOOKS}" ]; then
 	done < "${LATE_POST_BUILD_HOOKS}"
 fi
 
+# Root's login shell on an unclaimed camera is /usr/sbin/openipc-claim (see
+# overlay/etc/passwd), and dropbear checks a login shell against /etc/shells
+# through getusershell() BEFORE it ever runs -- an unlisted shell is rejected at
+# authentication with "Permission denied", so the gate would never get to run
+# and, worse, could never disable itself either: the self-heal that puts /bin/sh
+# back happens at login, and there is no login. Verified on hi3516ev300, where
+# key auth stopped working the moment the shell changed.
+#
+# Appended here rather than shipped as overlay/etc/shells because the file is
+# built up by TARGET_FINALIZE_HOOKS -- busybox adds /bin/ash, skeleton-init
+# adds /bin/sh -- and the overlay is rsynced over the target AFTER those hooks
+# have run. An overlay copy would replace their work with a hardcoded list that
+# goes quietly wrong the next time buildroot changes what it registers. The
+# post-build script runs after both, so appending composes with whatever they
+# decided. Same grep guard buildroot's own hooks use, so a re-run adds nothing.
+CLAIM_SHELL=/usr/sbin/openipc-claim
+if [ -x "${TARGET_DIR}${CLAIM_SHELL}" ]; then
+	grep -qsE "^${CLAIM_SHELL}\$" "${TARGET_DIR}/etc/shells" \
+		|| echo "${CLAIM_SHELL}" >> "${TARGET_DIR}/etc/shells"
+fi
+
 # Comments are worth writing and worth keeping in git; they are not worth
 # flashing. sysupgrade alone had grown to 52KB, 57% of it comment, and on
 # 2026-08-18 it pushed hi3519v101_lite 4KB past its 5120KB rootfs cap -- a board


### PR DESCRIPTION
> ### Requires a majestic that refuses an unclaimed camera
> `general/package/majestic/majestic.mk` fetches `majestic.$(FAMILY).$(VARIANT).master.tar.bz2` from S3, unpinned, so this lands only once **that tarball serves `/setup` and treats an empty root hash as unclaimed**. It does now: verified by pulling `majestic.hi3516ev200.lite.master.tar.bz2` and running it on a hi3516ev300 through the whole journey below.
>
> Out of order this is genuinely dangerous. An image with the blank shadow and an older majestic gives every new camera **wide-open RTSP and an unreachable WebUI at the same time** — an empty root password used to mean "authentication off", and inverting that is the daemon-side half of this change.
>
> Order: majestic → **[majestic-webui#234](https://github.com/OpenIPC/majestic-webui/pull/234)** (the setup page) → **this**.

---

`general/overlay/etc/shadow` gave root the hash of `12345`, committed in a public repository. A password everybody can read is not a credential, and the first-boot journey it produced asked the user to type that secret before letting them choose a real one — a step that proved nothing.

Root's hash field is now **empty**. Until somebody sets a password the camera is *unclaimed*: majestic streams nothing (RTSP 401, ONVIF unauthorized, HTTP 401 everywhere but the setup page) and there is no shell. Setting the password claims it. `/etc/shadow` is the only record and it is read live, so whichever door sets the password, the other sees it at once.

`firstboot` is `sysupgrade -n`, which wipes the overlay — so a factory reset returns the camera to unclaimed with **no new code**.

## The gate is root's login shell, not a hook in `/etc/profile`

dropbear already runs with `-B`, so a blank hash means anyone can start a session; what they must not get is a shell. `/etc/profile` is read by interactive login shells **only** — `ssh camera command`, `scp` and `sftp` all run `<shell> -c …` and walk straight past it. The login shell is the one chokepoint every door goes through, the serial getty included.

`openipc-claim`:

- refuses anything non-interactive, with a message saying what to do instead
- runs `passwd`, judging it by **reading the hash back** rather than by its exit status
- puts `/bin/sh` back in `/etc/passwd` and execs it as a login shell
- **disables itself** — the first thing it asks is whether the camera is already claimed, so one claimed through the browser finds it transparent and repairs `/etc/passwd` on the way past. A broken or missing gate therefore can never lock anyone out of a camera that has an owner.

## `/etc/shells`, and the part that bit

**dropbear validates a login shell through `getusershell()` before running it.** An unlisted shell is refused at *authentication* — key auth included, with nothing in the message pointing at the shell. Worse: the self-heal above happens at login, so it could never fire either. Recovery on the lab camera was over HTTP.

Registered from `general/scripts/rootfs_script.sh`, **not** shipped as `overlay/etc/shells`: that file is built up by `TARGET_FINALIZE_HOOKS` (busybox appends `/bin/ash`, skeleton-init appends `/bin/sh`) and the rootfs overlay is rsynced over the target *after* those hooks run — an overlay copy would replace their work with a hardcoded list that goes quietly wrong the next time buildroot changes what it registers. The post-build script runs after both, with the same `grep` guard buildroot's own hooks use.

## Breaking change

A camera deliberately running `passwd -d root` for open RTSP stops streaming. The migration is `system.unsafe: true` — the setting that has always meant this — deliberately **not** auto-applied, since silently keeping such a camera open would defeat the change. Worth a release note.

Also: any tooling that assumes `root:12345` on a fresh camera (flashing lines, CI, provisioning scripts, third-party docs) must claim the camera first.

## Verification

`test_shell_parse.sh` and `test_strip_shell_comments.sh` both cover the new script — 134 scripts, clean under busybox ash in tree form **and** as the comment stripper leaves it. `test_excludes_report.sh` unaffected. `check-merged-usr.sh` on the overlay is unchanged by these additions.

Hardware, hi3516ev300, restored to stock afterwards:

- unclaimed: `ssh cam 'id'` and `scp` refused without a shell; HTTP, RTSP and ONVIF all refused
- interactive login runs the gate, sets the password, and lands in a real login shell with `/etc/passwd` repaired
- **cross-door self-heal**: a camera claimed through the browser then lets `ssh cam 'id'` straight through, repairing `/etc/passwd` on the way

