### PR TITLE
sigmastar: load the infinity6c imx335 with four lanes

### DIFF
--- a/general/package/sigmastar-osdrv-infinity6c/files/script/load_sigmastar
+++ b/general/package/sigmastar-osdrv-infinity6c/files/script/load_sigmastar
@@ -21,7 +21,29 @@ detect_sensor() {
 
 set_sensor() {
 	case $SENSOR in
-		gc4653|imx335|imx415|os04a10|sc4336p|sc401ai|sc501ai|sc830ai|sc850sl)
+		imx335)
+			# This driver reads lane_num, and drv_sensor_common.h defaults it
+			# to 2 -- at which point every mode above 30fps silently selects
+			# the 2-lane 30fps table and the camera serves 30fps while its
+			# mode list still advertises 60.
+			#
+			# Four is the default here because four is what the previous
+			# driver used unconditionally (it hardcoded the lane count and
+			# ignored this parameter), so every board that works today is
+			# already running four and keeps doing so. A board actually wired
+			# for two sets sensor_lanes=2 in U-Boot, as with sensor_mclk.
+			lanes="$(fw_printenv -n sensor_lanes 2>/dev/null)"
+			case "$lanes" in
+				2|4) ;;
+				"") lanes=4 ;;
+				*)
+					echo "sensor_lanes=$lanes is not 2 or 4; using 4" | logger -s -t OpenIPC
+					lanes=4
+					;;
+			esac
+			insmod $MODULE/sensor_${SENSOR}_mipi.ko chmap=1 lane_num=$lanes
+			;;
+		gc4653|imx415|os04a10|sc4336p|sc401ai|sc501ai|sc830ai|sc850sl)
 			insmod $MODULE/sensor_${SENSOR}_mipi.ko chmap=1
 			;;
 		gc8613ya|os03a10|os08a10|sc450ai|sc535hai|sc835hai|sp4329)


### PR DESCRIPTION
Companion to **OpenIPC/sensors#3**, which gives infinity6c its own imx335 driver instead of the symlink to the pudding one.

That driver reads the `lane_num` module parameter, and `drv_sensor_common.h` in `openipc/sensors` defaults it to **2**. At 2 every mode above 30 fps silently selects `pCus_init_mipi2lane_5m30fps_linear` — so the camera reports `2560x1920@60` in its mode table, answers 60 to anything that asks, and serves **30**. Nothing in the log says otherwise. The Sony datasheet is clear that all-pixel 60/50 fps is unavailable on two lanes at all.

Stated in the loader rather than by changing that default, because the default is shared: about twenty drivers across infinity6/6b0/6e read the same symbol and none of them can be tested here. **The other four families' copies of this script are deliberately untouched.**

## Safe in either order

This is inert against the driver in `openipc/sensors` today, which hardcodes `SENSOR_MIPI_LANE_NUM` to 4 and ignores the parameter. So it can land before or after the sensors change — neither ordering breaks anything, and the modes appear once both are in.

## Measured

SSC377QE + IMX335, **rebooting before every mode** (the driver assumes power-on register defaults, so hot-switching gives invalid numbers):

| mode | before | after |
| --- | --- | --- |
| 2592x1944@59 | *no such mode* | **59.2 fps** |
| 2560x1920@60 | 30.0 | **60.1** |
| 2208x1248@90 | ~3, no usable output | **89.5** |
| 1920x1080@120 | 114.6 | **116.1** |

No ISP or SoC overclocking, and no `dnrlevel` change, were needed.

Refs: #1953
