### PR TITLE
gk7205v200: load the Cipher engine, and bump openhisilicon for the batched ioctl

### DIFF
--- a/general/package/goke-osdrv-gk7205v200/files/script/load_goke
+++ b/general/package/goke-osdrv-gk7205v200/files/script/load_goke
@@ -270,6 +270,31 @@ insert_ko() {
 	modprobe open_mipi_rx
 	# insmod gk7205v200_pm.ko                       # unused on OpenIPC
 	modprobe open_wdt
+
+	# Cipher engine -> /dev/cipher. majestic's native WebRTC takes AES-CTR
+	# for its SRTP transform from here, a burst of packets per ioctl: on a
+	# gk7205v200 with one viewer at 4 Mbit/s that is 20.0% of a core in
+	# software against 15.9% through the engine, and at 50 Mbit/s it is the
+	# difference between holding the configured bitrate at 20 fps and
+	# managing 40 Mbit/s at 11. See docs/hisi/cipher-engine.md in majestic.
+	#
+	# WORTH LOADING ONLY WITH A DRIVER THAT BATCHES. Driven one packet at a
+	# time the same engine saves nothing measurable — the ioctl, the DMA
+	# allocation and the sleep cost about what the AES does — so this line
+	# is paired with the openhisilicon bump that carries the batched
+	# command, not with the one that first built the module.
+	#
+	# Last, and after insert_osal: modprobe would otherwise pull osal in as
+	# a dependency at whatever point this ran, ahead of insert_osal's own
+	# arguments. Failure is not an error -- an image built before that
+	# openhisilicon bump simply has no module to find, and that must not
+	# abort sensor bring-up. Same shape as load_hisilicon's.
+	# `|| true` because this is the LAST statement of insert_ko, which is in
+	# turn the last statement of the script, so its status becomes the exit
+	# status S70vendor reports. Without it an image whose openhisilicon
+	# predates the module loads every driver correctly and still reports
+	# "Loading vendor modules..." as a failure.
+	modprobe open_cipher 2>/dev/null || true
 }
 
 remove_ko() {
@@ -279,6 +304,7 @@ remove_ko() {
 	# to satisfy load_goke's insmod-by-filename pattern). insmod uses the
 	# filename, but rmmod takes the in-kernel module name — so this list
 	# must be open_* to match what `lsmod` actually shows.
+	rmmod -w open_cipher 2>/dev/null
 	rmmod -w open_wdt
 	# rmmod -w open_pm                                 # unused on OpenIPC
 	remove_audio

--- a/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
+++ b/general/package/hisilicon-opensdk/hisilicon-opensdk.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HISILICON_OPENSDK_SITE = $(call github,openipc,openhisilicon,$(HISILICON_OPENSDK_VERSION))
-HISILICON_OPENSDK_VERSION = 001096aeb16ccc29c2b3ef3f391d277a719c43d3
+HISILICON_OPENSDK_VERSION = baf0af207f96551a64a59e16debc6e93f532d321
 
 HISILICON_OPENSDK_LICENSE = GPL-3.0
 HISILICON_OPENSDK_LICENSE_FILES = LICENSE

--- a/general/package/hisilicon-osdrv-hi3516cv500/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516cv500/files/script/load_hisilicon
@@ -189,7 +189,12 @@ insert_ko() {
     # dependency at whatever point this ran, ahead of insert_osal's own
     # arguments. Failure is not an error -- a kernel without the block simply
     # has no module to find, and that must not abort sensor bring-up.
-    modprobe open_cipher 2>/dev/null
+    # `|| true` because this is the LAST statement of insert_ko, which is
+    # in turn the last statement of the script, so its status becomes the
+    # exit status S70vendor reports. Without it an image whose
+    # openhisilicon predates the module loads every driver correctly and
+    # still reports "Loading vendor modules..." as a failure.
+    modprobe open_cipher 2>/dev/null || true
 }
 
 remove_ko() {

--- a/general/package/hisilicon-osdrv-hi3516ev200/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516ev200/files/script/load_hisilicon
@@ -226,7 +226,12 @@ insert_ko() {
 	# arguments. Failure is not an error -- an image built before that
 	# openhisilicon bump simply has no module to find, and that must not
 	# abort sensor bring-up.
-	modprobe open_cipher 2>/dev/null
+	# `|| true` because this is the LAST statement of insert_ko, which is
+	# in turn the last statement of the script, so its status becomes the
+	# exit status S70vendor reports. Without it an image whose
+	# openhisilicon predates the module loads every driver correctly and
+	# still reports "Loading vendor modules..." as a failure.
+	modprobe open_cipher 2>/dev/null || true
 }
 
 remove_ko() {


### PR DESCRIPTION
The Goke parts have had no `/dev/cipher` at all — openhisilicon built
`open_cipher.ko` only for the HiSilicon families. It builds one for gk7205v200
now (OpenIPC/openhisilicon#216), and #217 gives that driver a batched encrypt
carrying an IV per package, which is what makes loading it worthwhile.

## Why the modprobe and the pin bump arrive together

Driven **one packet at a time the engine saves nothing measurable**: the ioctl,
the DMA allocation, the hardware start and the sleep cost about what the AES
does. Whole-camera on a gk7205v200 with one WebRTC viewer:

| | software | engine, per-packet | engine, batched |
|---|---|---|---|
| 4 Mbit/s | 20.0% of a core | 20.1% | **15.9%** |
| 50 Mbit/s | 91.4% · 40.7 Mbit/s · 11 fps | 79.9% · 34.4 · 10 fps | **70.8% · 55.1 · 20 fps** |

At the ordinary rate that is about a fifth of majestic's CPU. At 50 Mbit/s the
batched arm is the only one that holds its configured bitrate at full frame
rate, and does it on less CPU than either other arm.

So this pins openhisilicon at the commit carrying the batch (`baf0af2`) rather
than at the one that first built the module. Pinning at the earlier one would
ship a module that costs flash and buys nothing.

The same shape holds on the HiSilicon families, measured on their own silicon
(hi3516ev300 18.0% → 13.0%, hi3516av300 16.4% → 13.6%), so the bump helps
those boards too — they already `modprobe open_cipher` via `load_hisilicon`.

## The load_goke line

`modprobe`, not `insmod`, and **last**: modprobe would otherwise pull osal in
as a dependency at whatever point it ran, ahead of `insert_osal`'s own
arguments. Failure is not an error — an image built against an older
openhisilicon simply has no module to find, and that must not abort sensor
bring-up. Same shape and same placement as `load_hisilicon`'s, which has done
this for the cv500 and ev200 families since #2321.

No install-side change is needed: `hisilicon-opensdk`'s gk7205v200 rules
rename only the heavy vendor-named modules into `goke/`, so `open_cipher.ko`
lands in `extra/` from the default kernel-module install — where modprobe finds
it — and it is not in the list the finalize hook wipes.

## Flash

`gk7205v200_lite`'s squashfs is **4864 KB of a 5120 KB partition**, so 256 KB
spare, and the module is **51.8 KB compressed**.

`hi3518ev300_lite` is the tight one and already ships this module; the batched
build is 172380 bytes against 168740, about a kilobyte once compressed.

## Consumer

majestic needs the matching userspace to use the batch — widgetii/majestic#532
— which probes for the ioctl and falls back to the per-packet path, and then
to software, so it is safe in any order. Until it ships, this change loads a
module that majestic will drive one packet at a time, i.e. the neutral case
above.
