### PR TITLE
overlay: point the locked-out visitor at an address, not a hostname

### DIFF
--- a/general/overlay/usr/sbin/openipc-claim
+++ b/general/overlay/usr/sbin/openipc-claim
@@ -70,10 +70,22 @@ fi
 # sftp has no way to be asked for one. Refuse, and say what to do instead --
 # a bare "permission denied" from a camera that has never been touched is the
 # kind of thing people re-flash over.
+#
+# The address, not the hostname: a hostname only the camera itself resolves
+# made http://$(hostname)/ go nowhere when pasted into a browser (#2346).
+# SSH_CONNECTION's third field is the address the client actually reached;
+# hostname stays as the no-connection fallback. Brackets on the URL only --
+# a browser needs them around an IPv6 literal, ssh refuses them.
 if [ "$1" = "-c" ] || [ ! -t 0 ]; then
+	set -- $SSH_CONNECTION
+	addr=${3:-$(hostname)}
+	url=$addr
+	case "$url" in
+	*:*) url="[$url]" ;;
+	esac
 	echo "This camera has not been set up yet, so it has no shell to offer." >&2
-	echo "Log in interactively (ssh root@$(hostname), or the serial console)," >&2
-	echo "or open http://$(hostname)/ in a browser, to set a root password." >&2
+	echo "Log in interactively (ssh root@$addr, or the serial console)," >&2
+	echo "or open http://$url/ in a browser, to set a root password." >&2
 	exit 1
 fi
 


### PR DESCRIPTION
## Problem

Post-merge review on #2346: a non-interactive SSH attempt against an unclaimed camera is
refused with a pointer at `http://<hostname>/` — a name only the camera itself resolves, so
pasting it into a browser on the user's machine goes nowhere:

```
zig@futurae:~$ ssh root@172.17.32.100 'I agree'
This camera has not been set up yet, so it has no shell to offer.
Log in interactively (ssh root@gk7205v200-imx307, or the serial console),
or open http://gk7205v200-imx307/ in a browser, to set a root password.
```

## What this does

Whoever hit this refusal reached the camera over SSH, and dropbear records the address they
used in `SSH_CONNECTION` ("client-ip port server-ip port") — the one address their network
provably routes. The refusal now names that address for both the `ssh root@…` hint and the
URL. The hostname stays only as the fallback for a local exec with no connection to read,
and an IPv6 literal gets brackets in the URL alone (a browser wants them, ssh refuses them).

## Hardware tested on

hi3516ev300, imx335 lab bench camera (dlab), running the merged #2346 bits with this
script installed and root's shadow/passwd reset to the unclaimed state.

## Evidence

Before — the review paste above (and identical on this camera).

After, reaching the camera by IP and by DNS name — both print the address the client used:

```
$ ssh root@10.216.128.68 'id'
This camera has not been set up yet, so it has no shell to offer.
Log in interactively (ssh root@10.216.128.68, or the serial console),
or open http://10.216.128.68/ in a browser, to set a root password.

$ ssh root@hi3516ev300-imx335.dlab.torturelabs.com 'I agree'
This camera has not been set up yet, so it has no shell to offer.
Log in interactively (ssh root@10.216.128.68, or the serial console),
or open http://10.216.128.68/ in a browser, to set a root password.
```

The same session then also exercised, on the merged majestic, the browser door end to end:
`POST /setup` without `eula` → 400 with the enforcement sentence; with
`eula=accepted&eula_lang=ru` → 200, `/etc/eula-accepted` = `1.0 ru web 2026-09-01T20:11:23Z`,
and the next SSH login walked the (updated) claim shell transparently and repaired
`/etc/passwd` — the claimed-camera path of the edited script.

`test_shell_parse.sh` (134 scripts) and `STRICT=1 test_strip_shell_comments.sh` pass.

## Scope

- [x] No kernel patches under `general/package/all-patches/linux/` (those go to [OpenIPC/linux](https://github.com/OpenIPC/linux))
- [x] No files specific to a single retail camera model (those go to [OpenIPC/builder](https://github.com/OpenIPC/builder))
- [x] No probing or bring-up tooling (that goes to [OpenIPC/ipctool](https://github.com/OpenIPC/ipctool))
- [x] Nothing under `general/overlay/` or in a shared `load_<vendor>` script hardcodes a value specific to my board
- [x] Package sources come from an OpenIPC repository, and any version bump keeps at least the specificity of the pin it replaces (a new package should pin a full 40-character SHA)
- [x] No `LD_PRELOAD`, and no binaries that cannot be rebuilt from source
- [x] New code is selected by a defconfig, so CI actually builds it
