### PR TITLE
build: expire the rolling majestic tarballs a day after they were fetched

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,17 @@ prepare:
 	@if test ! -e $(TARGET)/buildroot-$(BR_VER); then \
 		wget -c -q $(BR_LINK)/$(BR_VER).tar.gz -O $(BR_FILE); \
 		mkdir -p $(TARGET); tar -xf $(BR_FILE) -C $(TARGET); fi
+	@# The majestic and majestic-webui tarballs are rolling release assets:
+	@# a fixed filename, no hash, refreshed upstream whenever those repos
+	@# publish. Buildroot's dl cache keeps the first copy forever, so a
+	@# from-source build with an old cache pairs a majestic that expects the
+	@# setup page with a webui from before the page existed -- the browser
+	@# door then 404s while SSH works. Expire cached copies after a day;
+	@# fresh ones are kept, offline rebuilds inside that window still work,
+	@# and CI downloads into an empty cache every run and never gets here.
+	@find $(or $(BR2_DL_DIR),$(TARGET)/buildroot-$(BR_VER)/dl) -maxdepth 2 \
+		\( -name 'majestic.*.master.tar.bz2' -o -name 'majestic-webui-dist.tar.gz' \) \
+		-mmin +1440 -delete 2>/dev/null || true
 	@if test -f $(TARGET)/buildroot-$(BR_VER)/linux/Config.in; then \
 		sed -i '/source "$$(BR2_EXTERNAL_GENERAL_PATH)\/linux\/Config.ext.in"/d' \
 			$(TARGET)/buildroot-$(BR_VER)/linux/Config.in; \


### PR DESCRIPTION
## Problem

Field report from a from-source build (gk7205v200): the SSH claim door works, EULA and all,
but the browser door dead-ends —

```
majestic[925]: Not found: /setup.html
majestic[925]: Empty password for root is not allowed
```

while `cameras.html` from the same directory serves fine. That "Not found" line is
`send_file_to_user`'s `access()` failure: `/var/www/setup.html` genuinely is not in the image.
The `majestic-webui-dist.tar.gz` download is a rolling release asset — fixed filename, no
hash — so buildroot's dl cache keeps the first copy forever. A cache primed between
`cameras.html` (≤ Aug 21) and `setup.html` (Aug 30) reproduces the report exactly: a fresh
majestic that expects the setup page, paired with a webui from before the page existed. The
`majestic.*.master.tar.bz2` tarballs have the same trap. (Both `Empty password` lines are
`device_unclaimed()`'s debug heartbeat — the camera and the gate are fine.)

## What this does

`prepare` (runs before every build) deletes cached copies of the two rolling assets when
they are older than a day. Fresh copies are kept, so offline rebuilds inside that window
still work; CI downloads into an empty cache every run and never reaches the branch.

## Hardware tested on

Not a camera-behavior change in itself — it changes which bytes a stale-cache build fetches.
The failure it prevents was reproduced end to end today on a hi3516ev300 lab camera: a local
build with an Aug-21 cached dist produced exactly `Not found: /setup.html` on an unclaimed
camera; the same camera with the current dist serves `setup.html` 200 while unclaimed.

## Evidence

Before (stale cache, local build, unclaimed camera):

```
# curl -s -o /dev/null -w '%{http_code}' http://camera/setup.html
404        (majestic log: Not found: /setup.html)
```

After (expiry applied to a scratch dl dir with one 2-day-old copy of each asset and one
fresh majestic tarball):

```
$ find dltest -name '*.tar*'          # after `make BOARD=... prepare`
dltest/majestic/majestic.gk7205v200.lite.master.tar.bz2   # fresh copy kept
```

and with the current dist on the same camera, unclaimed:

```
setup.html: 200 bytes=15403
/: 302 -> http://10.216.128.68/setup.html
```

`ci-matrix.py --self-test` passes.

Immediate workaround for anyone already bitten, no rebuild of the cache needed:
`rm output/buildroot-*/dl/majestic*/majestic*` and rebuild.

## Scope

- [x] No kernel patches under `general/package/all-patches/linux/` (those go to [OpenIPC/linux](https://github.com/OpenIPC/linux))
- [x] No files specific to a single retail camera model (those go to [OpenIPC/builder](https://github.com/OpenIPC/builder))
- [x] No probing or bring-up tooling (that goes to [OpenIPC/ipctool](https://github.com/OpenIPC/ipctool))
- [x] Nothing under `general/overlay/` or in a shared `load_<vendor>` script hardcodes a value specific to my board
- [x] Package sources come from an OpenIPC repository, and any version bump keeps at least the specificity of the pin it replaces (a new package should pin a full 40-character SHA)
- [x] No `LD_PRELOAD`, and no binaries that cannot be rebuilt from source
- [x] New code is selected by a defconfig, so CI actually builds it
