### PR TITLE
ci: account for the telegram warning in the build summariser

### DIFF
--- a/.github/scripts/build-summary.py
+++ b/.github/scripts/build-summary.py
@@ -116,14 +116,18 @@ GRAMMARS = [
      "-- headroom warning: "),
 ]
 
-# Annotations build.yml emits that are deliberately NOT summarised: they are
-# sidecar-generation hiccups that cost a size report or a kconfig graph and
-# nothing that reaches an image. Listed rather than ignored silently so the
-# floor check below still accounts for every annotation in the job.
+# Annotations build.yml emits that are deliberately NOT summarised: they cost a
+# size report, a kconfig graph or a notification, and nothing that reaches an
+# image. Listed rather than ignored silently so the floor check below still
+# accounts for every annotation in the job.
 IGNORED_ANCHORS = [
     "size-report failed for ",
     "kconfiglib install failed for ",
     "kconfig-graph failed for ",
+    # The image this one announces went to `publish` a step earlier, so an
+    # unsent Telegram notification says nothing about the board and belongs in
+    # no cause bucket. It is a warning precisely so it cannot fail the run.
+    "Telegram upload of ",
 ]
 
 PASS, FAIL, ABSENT = "✓", "✗", "·"


### PR DESCRIPTION
## Problem

`master` is red on a merge gate. #2351 added a `::warning::` annotation for a Telegram upload
that failed all three attempts, and landed while `lint.yml`'s **build summariser agrees with
build.yml** check was failing:

```
$ python3 .github/scripts/build-summary.py --self-test
build-summary: build.yml emits an annotation nothing here reads: 'Telegram upload of ${NORFW}
  failed after 3 attempts (last result: ${HTTP}). The image itself is unaffected -- it went to
  the publish job in the previous step."'
build-summary: build.yml's matrix job emits 8 annotations, 7 are classified
exit 1
```

That check is not in branch protection's required contexts, so nothing stopped the merge. It
now fails on `master` and on every branch cut from it.

## Why the gate fired

`--self-test`'s drift check requires every `::error::`/`::warning::` in build.yml's `buildroot`
job to map either to a grammar or to an explicit ignore. It exists so that rewording an
annotation fails a merge gate instead of silently reducing the nightly Build summary to
reporting nothing. It was working as designed — the annotation is new and genuinely unclassified.

## The change

The anchor goes in `IGNORED_ANCHORS`, not `GRAMMARS`. The image the notification announces
reached the `publish` job a step earlier, so a failure to send says nothing about the board that
emitted it and belongs in no cause bucket — the same reason the size-report and kconfig-graph
hiccups already listed there are not summarised. `parse_annotations` drops it, so the report is
unchanged; only the floor check's accounting moves, 7 classified to 8.

## Verification

```
$ python3 .github/scripts/build-summary.py --self-test
build-summary: self-test ok (4 grammars, 8 annotations in build.yml, 99 fixture boards)

$ python3 .github/scripts/lint-workflow-shell.py --self-test
self-test passed

$ python3 .github/scripts/ci-matrix.py --self-test
ci-matrix: self-test ok (99 boards, 133 packages, 56 cases)
```

## Scope

CI reporting only. `ci-matrix.py --stdin` selects **0 boards** for this path — it changes no
image bytes and reaches no camera, so there is no hardware evidence to give.
