### PR TITLE
ci: make the lint and shell-test gates block a merge

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -91,3 +91,41 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check the annotation grammars still match the workflow
         run: python3 .github/scripts/build-summary.py --self-test
+
+  # Everything above reported advisory contexts, and advisory means a pull
+  # request can merge straight through them. #2351 did: it landed with "build
+  # summariser agrees with build.yml" red, which left master failing its own
+  # drift gate, and every branch cut from master then showed the same red check
+  # until #2353 repaired it. Nothing was broken about the check -- it was simply
+  # not something anyone had to satisfy.
+  #
+  # One umbrella context per workflow, the same shape build.yml's CI Gate uses,
+  # for the same reason given there: branch protection then names a single
+  # stable context, and adding a lint job later needs no settings change to be
+  # covered by it.
+  lint-gate:
+    name: Lint Gate
+    needs: [workflow-shell, build-summary]
+    # always() so the gate still reports when a needed job fails -- but not on a
+    # run whose jobs the guard above deliberately skipped. Upstream the added
+    # disjunct is true, so this reduces to always().
+    if: >-
+      always() && (github.repository == 'OpenIPC/firmware' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !github.event.repository.private))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Require every lint job to succeed
+        run: |
+          echo "workflow-shell=${{ needs.workflow-shell.result }} build-summary=${{ needs.build-summary.result }}"
+          # 'skipped' is not accepted. Upstream the guard on those jobs is a
+          # tautology, so a skipped one means the guard changed or the job was
+          # dropped from `needs` -- either way this context would go green
+          # having checked nothing, which is the failure it exists to prevent.
+          if [ "${{ needs.workflow-shell.result }}" != "success" ]; then
+            echo "::error::workflow run blocks parse did not succeed"; exit 1
+          fi
+          if [ "${{ needs.build-summary.result }}" != "success" ]; then
+            echo "::error::build summariser drift gate did not succeed"; exit 1
+          fi

--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -108,3 +108,46 @@ jobs:
         env:
           STRICT: 1
         run: bash .github/scripts/test_strip_shell_comments.sh
+
+  # Advisory until now, like lint.yml's jobs, and #2351 showed what that is
+  # worth: it merged with a red lint check and broke master. These four are the
+  # only thing standing between a syntax error in a shipped script and a camera
+  # that runs it, so being able to merge past them is worse here than there.
+  #
+  # One umbrella context, matching build.yml's CI Gate and lint.yml's Lint Gate,
+  # so branch protection names a stable check and a fifth job added below is
+  # covered without a settings change.
+  shell-tests-gate:
+    name: Shell Tests Gate
+    needs:
+      - load-hisilicon-parsing
+      - sysupgrade-verify
+      - excludes-report
+      - shipped-shell-parse
+    # always() so the gate reports when a needed job fails, but not on a run
+    # whose jobs the guard above deliberately skipped. Upstream the added
+    # disjunct is true, so this reduces to always().
+    if: >-
+      always() && (github.repository == 'OpenIPC/firmware' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !github.event.repository.private))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Require every shell test to succeed
+        run: |
+          echo "load-hisilicon=${{ needs.load-hisilicon-parsing.result }} sysupgrade=${{ needs.sysupgrade-verify.result }} excludes=${{ needs.excludes-report.result }} shell-parse=${{ needs.shipped-shell-parse.result }}"
+          # 'skipped' is not accepted, for the reason given in lint.yml: a
+          # skipped job would take this context green having checked nothing.
+          if [ "${{ needs.load-hisilicon-parsing.result }}" != "success" ]; then
+            echo "::error::load_hisilicon os_mem_size derivation did not succeed"; exit 1
+          fi
+          if [ "${{ needs.sysupgrade-verify.result }}" != "success" ]; then
+            echo "::error::sysupgrade rootfs verification did not succeed"; exit 1
+          fi
+          if [ "${{ needs.excludes-report.result }}" != "success" ]; then
+            echo "::error::excludes lists report did not succeed"; exit 1
+          fi
+          if [ "${{ needs.shipped-shell-parse.result }}" != "success" ]; then
+            echo "::error::shipped shell scripts parse did not succeed"; exit 1
+          fi


### PR DESCRIPTION
## Problem

#2351 was merged while `build summariser agrees with build.yml` was failing. Nothing malfunctioned —
that check simply was not required. `master`'s protection names exactly three contexts:

```
$ gh api repos/OpenIPC/firmware/branches/master/protection --jq '.required_status_checks.contexts'
["CI Gate", "qodo-gate", "GCC Gate"]
```

Everything `lint.yml` and `shell-tests.yml` report is therefore advisory, and a pull request can
merge straight through a red one:

| context | workflow | required before this PR |
| --- | --- | --- |
| `workflow run blocks parse` | lint | no |
| `build summariser agrees with build.yml` | lint | no |
| `load_hisilicon os_mem_size derivation` | shell-tests | no |
| `sysupgrade rootfs verification` | shell-tests | no |
| `excludes lists report what they no longer prune` | shell-tests | no |
| `shipped shell scripts parse` | shell-tests | no |

The consequence was not local to #2351. `build-summary.py --self-test` then failed **on master**, so
every branch cut from it carried the same red check until #2353 repaired it. The shell-tests side is
worse if it ever happens there: those four are the only thing between a syntax error in a shipped
script and a camera that runs it.

## What this does

One umbrella job per workflow — `Lint Gate` and `Shell Tests Gate` — in the shape `build.yml`'s
`CI Gate` and `gcc-compat.yml`'s `GCC Gate` already use. Branch protection then names a single
stable context per workflow, and a job added later is covered without a settings change. That is the
same argument `build.yml` makes for not listing ~99 per-board contexts individually.

Both refuse `skipped` as well as failure. Upstream the per-job guard is a tautology, so a skipped job
means the guard changed or the job left `needs` — either way the context would go green having
checked nothing, which is the failure it exists to prevent.

## The settings change this needs

No file in the tree can make a context required. Once this is on master, `CI Gate`, `qodo-gate`,
`GCC Gate`, `Lint Gate` and `Shell Tests Gate` become the required set.

The five open pull requests are all already behind master, and `strict = true` means they need a
rebase before they can merge regardless; the rebase runs the new jobs, so this costs them nothing
they did not already owe.

## Verification

```
$ python3 .github/scripts/lint-workflow-shell.py --self-test
self-test passed

$ python3 .github/scripts/lint-workflow-shell.py
checked 56 run block(s)
all run blocks parse clean
```

Both new run blocks are picked up by the linter (`lint.yml:120`, `shell-tests.yml:138`), and both
workflows still load as YAML with the expected job lists.

## Scope

CI gating only. `ci-matrix.py --stdin` selects **0 boards** for these paths — no image bytes change
and no camera is reached, so there is no hardware evidence to give.
