### PR TITLE
ci: point the dl cache at the directory buildroot actually uses

### DIFF
--- a/.github/workflows/build-one.yml
+++ b/.github/workflows/build-one.yml
@@ -59,8 +59,14 @@ jobs:
           path: /tmp/ccache
           key: ${{inputs.platform}}-${{env.CACHE_DATE}}
 
-      - name: Setup dl cache
-        uses: actions/cache@v4
+      # Restore-only, deliberately. `dl-<month>` is one key shared with the
+      # whole build.yml matrix, and actions/cache saves only on a key miss, so
+      # whoever writes it first freezes that month's snapshot. This workflow
+      # builds a single board on manual dispatch; letting it win that race would
+      # pin the shared cache to one board's dependencies for the rest of the
+      # month. It consumes the cache, it does not get to define it.
+      - name: Restore dl cache
+        uses: actions/cache/restore@v4
         with:
           path: output/dl
           key: dl-${{env.CACHE_DATE}}

--- a/.github/workflows/build-one.yml
+++ b/.github/workflows/build-one.yml
@@ -48,6 +48,10 @@ jobs:
         run: |
           echo "nameserver 8.8.8.8" | sudo tee /etc/resolv.conf
           echo CACHE_DATE=$(date +%m) >> ${GITHUB_ENV}
+          # Same fix, and the same reason, as build.yml's: buildroot's DL_DIR
+          # defaults to output/buildroot-$(BR_VER)/dl, so the output/dl this
+          # workflow caches and prunes never existed. See the comment there.
+          echo "BR2_DL_DIR=${GITHUB_WORKSPACE}/output/dl" >> ${GITHUB_ENV}
 
       - name: Setup ccache
         uses: actions/cache@v4
@@ -76,9 +80,16 @@ jobs:
           # The dot form is majestic's S3 tarball — it LOOKS S3-pinned but is a moving
           # `master` build re-uploaded every majestic CI run, with no .hash to force a
           # refetch. Only genuinely content-addressed tarballs (semver / SHA) keep cache.
-          find output/dl -type f -regextype posix-extended \
-            -regex '.*[-.](HEAD|master|main|dist)\.tar\.(gz|bz2|xz)' \
-            -print -delete 2>/dev/null || true
+          #
+          # Not silenced, for the reason given in build.yml: the suppression is
+          # what let this run against a missing directory unnoticed.
+          if [ -d "${BR2_DL_DIR}" ]; then
+            find "${BR2_DL_DIR}" -type f -regextype posix-extended \
+              -regex '.*[-.](HEAD|master|main|dist)\.tar\.(gz|bz2|xz)' \
+              -print -delete
+          else
+            echo "dl cache is cold (${BR2_DL_DIR} absent) -- nothing to refresh."
+          fi
 
       - name: Build firmware
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -284,6 +284,22 @@ jobs:
         run: |
           echo "nameserver 8.8.8.8" | sudo tee /etc/resolv.conf
           echo CACHE_DATE=$(date +%m) >> ${GITHUB_ENV}
+          # The dl cache below and the refresh step after it both work on
+          # output/dl. Buildroot did not: DL_DIR defaults to $(TOPDIR)/dl, and
+          # TOPDIR is the source tree the Makefile hands to -C, so downloads
+          # landed in output/buildroot-$(BR_VER)/dl and output/dl never existed.
+          # actions/cache only archives paths that exist, so nothing was ever
+          # saved and nothing ever restored; the refresh find matched nothing.
+          # Both failures were silent, and they cancelled out to "every board
+          # re-downloads every tarball, every run" -- which is also why CI
+          # escaped the stale-tarball trap that bit local builds in #2352.
+          #
+          # Point buildroot at the directory the cache keys on. Buildroot reads
+          # BR2_DL_DIR from the environment ahead of .config, by design ("To
+          # make sure that the environment variable overrides the .config
+          # option, set this before including .config"), and the Makefile's own
+          # expiry from #2352 already prefers $(BR2_DL_DIR) when it is set.
+          echo "BR2_DL_DIR=${GITHUB_WORKSPACE}/output/dl" >> ${GITHUB_ENV}
 
       - name: Setup ccache
         if: github.event_name != 'pull_request'
@@ -329,9 +345,18 @@ jobs:
           # The dot form is majestic's S3 tarball — it LOOKS S3-pinned but is a moving
           # `master` build re-uploaded every majestic CI run, with no .hash to force a
           # refetch. Only genuinely content-addressed tarballs (semver / SHA) keep cache.
-          find output/dl -type f -regextype posix-extended \
-            -regex '.*[-.](HEAD|master|main|dist)\.tar\.(gz|bz2|xz)' \
-            -print -delete 2>/dev/null || true
+          #
+          # Not silenced. `2>/dev/null || true` is how this step reported
+          # nothing for months while pointed at a directory that did not exist;
+          # a cold cache is a legitimate state and now says so out loud, and
+          # anything else is a real error that reaches the log.
+          if [ -d "${BR2_DL_DIR}" ]; then
+            find "${BR2_DL_DIR}" -type f -regextype posix-extended \
+              -regex '.*[-.](HEAD|master|main|dist)\.tar\.(gz|bz2|xz)' \
+              -print -delete
+          else
+            echo "dl cache is cold (${BR2_DL_DIR} absent) -- nothing to refresh."
+          fi
 
       - name: Build firmware
         run: |


### PR DESCRIPTION
## Problem

`build.yml` and `build-one.yml` cache `output/dl` and prune moving-ref tarballs from it. Buildroot
has never written there. `DL_DIR` defaults to `$(TOPDIR)/dl`, and `TOPDIR` is the *source* tree the
Makefile hands to `-C`, not `O=`:

```
$ make -C output/buildroot-2024.02.10 O=$PWD/output BR2_EXTERNAL=$PWD/general -p | grep '^DL_DIR'
DL_DIR := /home/dima/git/firmware/output/buildroot-2024.02.10/dl
```

So `output/dl` never existed. Two things followed, both silent:

- **`actions/cache` saved nothing.** It only archives paths that exist, so the `dl-<month>` key was
  never populated and never restored. Every board has been re-downloading every source tarball,
  every run.
- **The refresh step matched nothing.** `find output/dl … 2>/dev/null || true` swallowed the missing
  directory, so the moving-ref protection it exists to provide has never once run.

The two cancel out to "CI is correct but pays a full download for every board on every run" — which
is also why CI escaped the stale rolling tarball that bit local from-source builds in #2352. Correct
by accident, and only while both halves stayed broken.

## What this does

Sets `BR2_DL_DIR` in the environment so buildroot writes to the directory the cache already keys on,
rather than teaching three more call sites to spell `output/buildroot-$(BR_VER)/dl` and keep it in
step with `BR_VER`. Buildroot reads it ahead of `.config` by design — *"To make sure that the
environment variable overrides the .config option, set this before including .config"* — and the
Makefile's expiry from #2352 already prefers `$(BR2_DL_DIR)` when set:

```
$ BR2_DL_DIR=$PWD/output/dl make -C output/buildroot-2024.02.10 O=$PWD/output ... -p | grep '^DL_DIR'
DL_DIR := /home/dima/git/firmware/output/dl
```

Both workflows are fixed; `build-one.yml` carries the same two steps and the same bug.

## Why turning the cache on is safe

Restoring the cache also makes the refresh step live for the first time, and that is the half that
keeps it safe — **neither should be restored without the other.** Its regex covers the moving-ref
class this tree actually produces:

| form | example | matched |
| --- | --- | --- |
| `_VERSION = HEAD` (24 packages) | `ipctool-HEAD.tar.gz` | yes |
| majestic-webui rolling asset | `majestic-webui-dist.tar.gz` | yes |
| majestic S3 tarball | `majestic.hi3516cv500.lite.master.tar.bz2` | yes |
| vendor SDKs | `hisilicon-opensdk-<sha>.tar.gz` | immutable |
| everything else | semver-named | immutable |

Measured against a real 201-file `dl` from local builds: 9 files are moving-ref and get re-fetched,
192 are content-addressed and cache correctly. No `_VERSION` in the tree pins a branch outside
`HEAD`/`master`/`main`/`dist`, so nothing moving escapes the regex.

## The suppression goes too

`2>/dev/null || true` is *how* this hid for months. A cold cache is a legitimate state and now says
so out loud; anything else is a real error that reaches the log.

## Verification

```
$ python3 .github/scripts/lint-workflow-shell.py
checked 56 run block(s)
all run blocks parse clean

$ python3 .github/scripts/build-summary.py --self-test
build-summary: self-test ok (4 grammars, 8 annotations in build.yml, 99 fixture boards)
```

The `DL_DIR` values above are the real check: buildroot itself, asked before and after, reporting the
directory it will use.

## Scope

CI plumbing. `ci-matrix.py --stdin` selects the smoke set for `build.yml`; no image content changes —
the same sources are built, they are merely fetched once instead of every run.
