### PR TITLE
majestic-webui: the FPV page is wfb.cgi now, and both names are stripped

### DIFF
--- a/general/package/majestic-webui/majestic-webui.mk
+++ b/general/package/majestic-webui/majestic-webui.mk
@@ -33,13 +33,17 @@ endef
 # -f throughout: which files the WebUI ships is decided in another repo, so a
 # fixup that hard-fails on a missing one turns any deletion there into a broken
 # build here -- for every platform at once, and only visible on the next PR,
-# because master has no push trigger. j/locale_fpv.cgi and p/header_fpv.cgi went
-# in OpenIPC/majestic-webui#141; fpv-wfb.cgi and p/fpv_common.cgi still ship, and
-# are still unwanted in a standard build.
+# because master has no push trigger.
+#
+# The WebUI renamed every page after the word its menu uses, so the FPV page is
+# wfb.cgi now. Both spellings are listed and both must stay for a while: the
+# dist tarball is a rolling release off that repo's master, so an image built
+# today gets the new name and one rebuilt from an older tag gets the old one,
+# and a standard build must not ship the page either way. j/locale_fpv.cgi and
+# p/header_fpv.cgi went in OpenIPC/majestic-webui#141 and are dropped here.
 define MAJESTIC_WEBUI_STANDARD_FIXUP
+	rm -f $(TARGET_DIR)/var/www/cgi-bin/wfb.cgi
 	rm -f $(TARGET_DIR)/var/www/cgi-bin/fpv-wfb.cgi
-	rm -f $(TARGET_DIR)/var/www/cgi-bin/j/locale_fpv.cgi
-	rm -f $(TARGET_DIR)/var/www/cgi-bin/p/header_fpv.cgi
 	rm -f $(TARGET_DIR)/var/www/cgi-bin/p/fpv_common.cgi
 endef
 


### PR DESCRIPTION
The WebUI has renamed every page after the word its own menu uses, so
`fpv-wfb.cgi` became `wfb.cgi` (the OpenIPC/majestic-webui PR follows this one).
This recipe strips the FPV pages from a standard build **by name**, so without
the new one a standard image would start shipping a WFB settings page nobody
wants and nothing links to.

**This wants to merge before the WebUI rename does.** `rm -f` is idempotent and
silent on a missing file, so listing the new name early costs nothing and closes
the window in which a standard build would carry the page.

Both spellings stay listed, and have to. The package fetches a rolling `dist`
release built off that repo's master, so an image built today gets `wfb.cgi`
while one rebuilt from an older tag still gets `fpv-wfb.cgi` — and a standard
build must not carry it either way. That is already the stated reason `rm -f` is
used throughout here: which files the WebUI ships is decided in another repo, so
a fixup that hard-fails on a missing one turns any deletion there into a broken
build here.

The two lines for `j/locale_fpv.cgi` and `p/header_fpv.cgi` go at the same time.
Those files were deleted upstream in OpenIPC/majestic-webui#141, and the comment
directly above them has said so ever since; the `rm -f` pair was the last thing
still pretending they might turn up.

An FPV build is unaffected. A standard build loses one file it should never have
had.


---

### Hardware evidence

Tested on **`hi3516ev300` / imx335, `BUILD_OPTION=lite`** — a standard build, which is the case this fixup governs. The WebUI tree is OpenIPC/majestic-webui#319, installed with `updatewebui`, whose variant lists mirror this recipe.

After install, on that lite build:

```
/var/www/cgi-bin/wfb.cgi                 absent      GET /cgi-bin/wfb.cgi      404
/var/www/cgi-bin/fpv-wfb.cgi             absent      GET /cgi-bin/fpv-wfb.cgi  404
/var/www/cgi-bin/p/fpv_common.cgi        absent
```

Before/after on the new name is not hypothetical — the failure was measured first. On the run before the installer knew `wfb.cgi`, it was installed onto that lite build (`-rwxr-xr-x 19834 /var/www/cgi-bin/wfb.cgi`, answering 200); with the name listed it is absent and 404s.

The rest of the WebUI is undisturbed: all 22 pages the lite build ships answer 200, and every internal `href` on every one resolves. The camera is up and encoding — `majestic` running, `venc0_rcvd_bytes` advancing between scrapes, RTSP challenging on 554.

An FPV build is untouched by this diff: it never runs `MAJESTIC_WEBUI_STANDARD_FIXUP`, and the FPV fixup is unchanged.
