### PR TITLE
osdrv: ship the VQE engines the microphone path loads by dlopen

### DIFF
--- a/general/package/hisilicon-osdrv-hi3516cv500/hisilicon-osdrv-hi3516cv500.mk
+++ b/general/package/hisilicon-osdrv-hi3516cv500/hisilicon-osdrv-hi3516cv500.mk
@@ -67,12 +67,34 @@ define HISILICON_OSDRV_HI3516CV500_INSTALL_COMMON
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib $(HISILICON_OSDRV_HI3516CV500_PKGDIR)/files/lib/libtde.so
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib $(HISILICON_OSDRV_HI3516CV500_PKGDIR)/files/lib/libupvqe.so
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib $(HISILICON_OSDRV_HI3516CV500_PKGDIR)/files/lib/libVoiceEngine.so
+	$(foreach lib,$(HISILICON_OSDRV_HI3516CV500_VQE_LIBS), \
+		$(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib $(HISILICON_OSDRV_HI3516CV500_PKGDIR)/files/lib/$(lib) ; \
+	)
 endef
 
 # opensdk provides .ko modules, sensor .so, libisp.so. osdrv provides
 # configs, load scripts, vendor-only userspace libs. The opensdk!=y
 # branch that bundled vendor prebuilt .ko files was dropped — every
 # modern OpenIPC build pairs osdrv with opensdk.
+# Voice quality enhancement engines for the microphone capture path
+# (OpenIPC/majestic#287). See hisilicon-osdrv-hi3516ev200.mk for the full
+# reasoning: libupvqe.so is only the framework and dlopen()s one shared
+# object per DSP stage when HI_MPI_AI_EnableVqe() runs, so without these that
+# call fails with 0xa0158041 and the microphone is passed through unprocessed.
+# AEC and EQ are not exposed by majestic, and the resampler lives inside
+# libupvqe.so, so neither libhive_AEC/EQ.so nor libhive_RES{,_ext}.so is
+# loaded.
+#
+# Ultimate only, matching the flavour majestic compiles VQE into. This family
+# has no ultimate defconfig today (every hi3516cv500/av300/dv300 config is
+# lite), so nothing changes for the images that exist — it is wired up so the
+# libraries arrive with the first ultimate config rather than being missed.
+ifeq ($(OPENIPC_MAJESTIC),ultimate)
+HISILICON_OSDRV_HI3516CV500_VQE_LIBS = \
+	libhive_common.so libhive_AGC.so libhive_ANR.so \
+	libhive_HPF.so libhive_record.so
+endif
+
 define HISILICON_OSDRV_HI3516CV500_INSTALL_TARGET_CMDS
 	$(call HISILICON_OSDRV_HI3516CV500_INSTALL_COMMON)
 	$(INSTALL) -m 755 -d $(HISILICON_OSDRV_HI3516CV500_KMOD_DST)

--- a/general/package/hisilicon-osdrv-hi3516ev200/hisilicon-osdrv-hi3516ev200.mk
+++ b/general/package/hisilicon-osdrv-hi3516ev200/hisilicon-osdrv-hi3516ev200.mk
@@ -9,6 +9,28 @@ HISILICON_OSDRV_HI3516EV200_SITE =
 HISILICON_OSDRV_HI3516EV200_LICENSE = MIT
 HISILICON_OSDRV_HI3516EV200_LICENSE_FILES = LICENSE
 
+# Voice quality enhancement engines for the microphone capture path
+# (OpenIPC/majestic#287). libupvqe.so is only the framework: it dlopen()s one
+# shared object per DSP stage when HI_MPI_AI_EnableVqe() runs, so an image
+# without these answers that call with 0xa0158041 and
+# "dlopen ... libhive_HPF.so failed", and the microphone is passed through
+# unprocessed however the attributes were set.
+#
+# Only the stages majestic can switch on: the high-pass filter, noise
+# reduction and automatic gain control that make up the 8/16 kHz talk engine,
+# plus the 48 kHz record engine. libhive_AEC.so (echo cancellation) and
+# libhive_EQ.so are not exposed, and the resampler is compiled into
+# libupvqe.so itself (RES_ReSampler_*), so libhive_RES.so is never loaded.
+# libhive_common.so is not a stage but is a NEEDED of AGC and ANR.
+#
+# Ultimate only, matching the flavour majestic compiles VQE into at all:
+# 268 KB that nothing in a lite image would ever dlopen().
+ifeq ($(OPENIPC_MAJESTIC),ultimate)
+HISILICON_OSDRV_HI3516EV200_VQE_LIBS = \
+	libhive_common.so libhive_AGC.so libhive_ANR.so \
+	libhive_HPF.so libhive_record.so
+endif
+
 define HISILICON_OSDRV_HI3516EV200_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/etc/sensors
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/etc/sensors $(HISILICON_OSDRV_HI3516EV200_PKGDIR)/files/sensor/config/*.ini
@@ -52,14 +74,6 @@ define HISILICON_OSDRV_HI3516EV200_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib/ $(HISILICON_OSDRV_HI3516EV200_PKGDIR)/files/lib/lib_hidrc.so
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib/ $(HISILICON_OSDRV_HI3516EV200_PKGDIR)/files/lib/lib_hiir_auto.so
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib/ $(HISILICON_OSDRV_HI3516EV200_PKGDIR)/files/lib/lib_hildci.so
-	# $(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib/ $(HISILICON_OSDRV_HI3516EV200_PKGDIR)/files/lib/libhive_AEC.so
-	# $(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib/ $(HISILICON_OSDRV_HI3516EV200_PKGDIR)/files/lib/libhive_AGC.so
-	# $(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib/ $(HISILICON_OSDRV_HI3516EV200_PKGDIR)/files/lib/libhive_ANR.so
-	# $(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib/ $(HISILICON_OSDRV_HI3516EV200_PKGDIR)/files/lib/libhive_common.so
-	# $(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib/ $(HISILICON_OSDRV_HI3516EV200_PKGDIR)/files/lib/libhive_EQ.so
-	# $(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib/ $(HISILICON_OSDRV_HI3516EV200_PKGDIR)/files/lib/libhive_HPF.so
-	# $(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib/ $(HISILICON_OSDRV_HI3516EV200_PKGDIR)/files/lib/libhive_record.so
-	# $(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib/ $(HISILICON_OSDRV_HI3516EV200_PKGDIR)/files/lib/libhive_RES.so
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib/ $(HISILICON_OSDRV_HI3516EV200_PKGDIR)/files/lib/libisp.so
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib/ $(HISILICON_OSDRV_HI3516EV200_PKGDIR)/files/lib/libive.so
 	# $(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib/ $(HISILICON_OSDRV_HI3516EV200_PKGDIR)/files/lib/libivp.so
@@ -69,6 +83,9 @@ define HISILICON_OSDRV_HI3516EV200_INSTALL_TARGET_CMDS
 	# $(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib/ $(HISILICON_OSDRV_HI3516EV200_PKGDIR)/files/lib/libtde.so
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib/ $(HISILICON_OSDRV_HI3516EV200_PKGDIR)/files/lib/libupvqe.so
 	$(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib/ $(HISILICON_OSDRV_HI3516EV200_PKGDIR)/files/lib/libVoiceEngine.so
+	$(foreach lib,$(HISILICON_OSDRV_HI3516EV200_VQE_LIBS), \
+		$(INSTALL) -m 644 -t $(TARGET_DIR)/usr/lib/ $(HISILICON_OSDRV_HI3516EV200_PKGDIR)/files/lib/$(lib) ; \
+	)
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
Companion to a majestic change that turns on the SoC's noise reduction, AGC and high-pass filter on the microphone channel.

**Scope narrowed after review:** this is now HiSilicon only. The Goke half moved to #2362 as a draft — see the bottom of this description.

## The problem

Our images ship `libupvqe.so`, `libdnvqe.so` and `libVoiceEngine.so`, so the VQE feature *looks* present. But `libupvqe.so` is only the framework — it `dlopen`s one shared object per DSP stage when `HI_MPI_AI_EnableVqe()` runs, and none of those objects are installed:

* `hisilicon-osdrv-hi3516ev200` — the `libhive_*.so` install lines are all commented out
* `hisilicon-osdrv-hi3516cv500` — never had them

In both cases **the files are already in the package tree.** This PR adds no binaries; only install lines change.

On a stock image the enable call fails and the microphone is passed through unprocessed:

```
dlopen libsecurec.so or libhive_HPF.so failed
[Func]:HI_MPI_AI_EnableVqe [Line]:3535 [Info]:Ai dev: 0, ai chn:0, create vqe fail.
returned 0xa0158041
```

Confirmed on hi3516ev300 (3516E200) and hi3516av300 (3516C500) — it fails **cleanly**, no crash, audio keeps flowing. So this has only ever cost the feature, never stability.

## What this installs

Only the stages majestic can switch on: `libhive_HPF`, `libhive_ANR`, `libhive_AGC` for the 8/16 kHz talk engine, `libhive_common` (a `NEEDED` of ANR and AGC, not a stage), and `libhive_record` for the 48 kHz path.

Echo cancellation and the equaliser are not exposed by majestic, and the resampler is compiled into `libupvqe.so` itself (`RES_ReSampler_*` are defined there), so `libhive_RES.so` is never loaded and is left out.

## Gating

`ifeq ($(OPENIPC_MAJESTIC),ultimate)`, matching the only flavour majestic compiles VQE into — 268 KB that nothing in a lite image would ever `dlopen`. Verified the expansion is empty for lite and installs all five for ultimate.

Note **hi3516cv500 has no ultimate defconfig today** (every config in that family is lite), so this changes nothing for the images that exist. It is wired up so the libraries arrive with the first ultimate config rather than being missed.

## Verification

Not by inspection — the libraries were placed on both lab cameras and majestic run against them. The enable call succeeds with no `dlopen` diagnostic, and six seconds of the same quiet room at 8 kHz, VQE off then on, comparing the high-pass filter's stopband against the speech band it must leave alone:

| board | 20–80 Hz (stopband) | 300–1000 Hz (speech) |
|---|---|---|
| hi3516ev300 (3516E200) | **0.03x** | 0.98x |
| hi3516av300 (3516C500) | **0.01x** | 1.38x |

A 30x–100x cut in the stopband with the passband untouched is the filter's own shape; it cannot come from the room drifting.

## Goke

Originally in this PR, now #2362, held as a draft. Review was right that it is a different risk: it is the only part that would add binaries to the tree, and there is no GK7205V200 on the bench to show they run. That PR carries the provenance evidence and the exact test someone with the hardware should run.

