### PR TITLE
cli: ask majestic to apply a setting, instead of only writing it down

### DIFF
--- a/general/overlay/usr/sbin/extutils
+++ b/general/overlay/usr/sbin/extutils
@@ -45,6 +45,28 @@ majestic_write_path() {
 	[ "$other" = 1 ] || echo "$wp"
 }
 
+# The majestic processes that can safely be told to reload.
+#
+# Process existence is not readiness. S95majestic starts it with
+# start-stop-daemon -b, which returns at the fork, so boot carries straight on
+# into the S98 scripts while majestic is still working its way down main()
+# towards the point where it installs a SIGHUP handler. Until it gets there the
+# default action for SIGHUP applies, and that is to terminate -- so a reload
+# asked for in that window does not reload the camera, it takes the streamer
+# away for the rest of the boot. Measured on a hi3516ev200: the process is
+# visible to pidof with SigCgt still 0000000000000000.
+#
+# /proc/<pid>/status answers the question exactly. SigCgt is the caught-signal
+# mask and SIGHUP is signal 1, so it is the lowest bit -- the mask ends in an
+# odd hex digit precisely when the handler is installed.
+majestic_reload_pids() {
+	for pid in $(pidof majestic 2>/dev/null); do
+		case "$(sed -n 's/^SigCgt:[[:space:]]*//p' "/proc/$pid/status" 2>/dev/null)" in
+			*[13579bdfBDF]) echo "$pid" ;;
+		esac
+	done
+}
+
 # A path yaml-cli will happily store and majestic will never read. The tree
 # ships one: t40_lite_movols-mo-805p's customizer.sh says
 # `cli -s .video0.bitrate: 4000`, and the trailing colon is why six of that
@@ -80,12 +102,14 @@ case "$CMD" in
 		# stream nothing for most settings. Repeated signals inside 3s collapse
 		# into one reload, so a burst of writes still reloads once.
 		#
-		# Deliberately conditional on majestic already running: at S30, where
-		# customizer.sh seeds a device's config, it is not, and provisioning must
-		# stay exactly as it was. This is the pattern wifibroadcast already
-		# applies by hand after its own writes.
-		if [ "$rc" = 0 ] && [ -n "$wpath" ] && pidof majestic >/dev/null 2>&1; then
-			killall -1 majestic
+		# Deliberately conditional on majestic being up AND ready to be signalled:
+		# at S30, where customizer.sh seeds a device's config, it is not running at
+		# all, and provisioning must stay exactly as it was. This is the pattern
+		# wifibroadcast already applies by hand after its own writes.
+		if [ "$rc" = 0 ] && [ -n "$wpath" ]; then
+			for pid in $(majestic_reload_pids); do
+				kill -1 "$pid"
+			done
 		fi
 		exit "$rc"
 		;;

--- a/general/overlay/usr/sbin/extutils
+++ b/general/overlay/usr/sbin/extutils
@@ -1,18 +1,93 @@
 #!/bin/sh
-CMD=$(echo "$0" | cut -d / -f 4)
+CMD=${0##*/}
 ARCH=$(uname -m)
 
 if echo "$ARCH" | grep -q mips; then
 	ARC="-mips32"
 fi
 
-case "$CMD" in
-	api)
-		curl -G 'http://localhost/api/v1/set' --data-urlencode "$@"
-		;;
+MAJESTIC_CFG=/etc/majestic.yaml
 
+# The path of a -s/-d call on majestic's own config, or empty when this call is
+# neither. yaml-cli takes its flags in any order and lets the last mode win
+# (src/input_data.c parse_args), so that is mirrored here rather than assuming
+# the mode is $1. An explicit -i/-o means some other file -- sensor_cli and the
+# wfb applet both rely on that -- and reports nothing.
+majestic_write_path() {
+	wp= other=0
+	while [ $# -gt 0 ]; do
+		case "$1" in
+			-s | --set)
+				[ $# -ge 3 ] || return
+				wp=$2
+				shift 3
+				;;
+			-d | --del)
+				[ $# -ge 2 ] || return
+				wp=$2
+				shift 2
+				;;
+			-g | --get)
+				[ $# -ge 2 ] || return
+				wp=
+				shift 2
+				;;
+			-i | --input | -o | --output)
+				[ $# -ge 2 ] || return
+				other=1
+				shift 2
+				;;
+			*)
+				shift
+				;;
+		esac
+	done
+	[ "$other" = 1 ] || echo "$wp"
+}
+
+# A path yaml-cli will happily store and majestic will never read. The tree
+# ships one: t40_lite_movols-mo-805p's customizer.sh says
+# `cli -s .video0.bitrate: 4000`, and the trailing colon is why six of that
+# device's settings have never applied. Nothing reported it, because writing
+# the file cannot fail. Checking the shape is cheap, needs no network, and
+# catches the whole class.
+majestic_bad_path() {
+	case "$1" in
+		*[!A-Za-z0-9_.-]*) return 0 ;;
+		*..* | *. | .) return 0 ;;
+	esac
+	return 1
+}
+
+case "$CMD" in
 	cli)
-		yaml-cli -i /etc/majestic.yaml "$@"
+		wpath=$(majestic_write_path "$@")
+		if [ -n "$wpath" ] && majestic_bad_path "$wpath"; then
+			echo "cli: '$wpath' is not a setting path, nothing written" >&2
+			exit 1
+		fi
+
+		yaml-cli -i "$MAJESTIC_CFG" "$@"
+		rc=$?
+
+		# Writing the file changes nothing that is already running, which is why
+		# `cli -s .video0.fps 20` used to report success and leave the camera
+		# streaming at the old rate until somebody worked out that a reload was
+		# needed. majestic re-reads the file on SIGHUP, diffs it against the tree
+		# in force and prices the difference on its own ladder -- a live key is
+		# pushed straight at the SDK, a service key restarts only that service,
+		# and only a pipeline key rebuilds -- so asking for it here costs the
+		# stream nothing for most settings. Repeated signals inside 3s collapse
+		# into one reload, so a burst of writes still reloads once.
+		#
+		# Deliberately conditional on majestic already running: at S30, where
+		# customizer.sh seeds a device's config, it is not, and provisioning must
+		# stay exactly as it was. This is the pattern wifibroadcast already
+		# applies by hand after its own writes.
+		if [ "$rc" = 0 ] && [ -n "$wpath" ] && pidof majestic >/dev/null 2>&1; then
+			killall -1 majestic
+		fi
+		exit "$rc"
 		;;
 
 	sensor_cli)


### PR DESCRIPTION
## Problem

`cli -s .video0.fps 20` edits `/etc/majestic.yaml`, prints nothing and exits 0 — and the
camera carries on streaming at the old rate. Nothing in the tool says a reload is needed,
and the wiki is not consistent about it either: of the pages that change a setting, ten say
nothing about restarting, four say restart, and one says reboot.

Writing the file also cannot fail, so a malformed setting path is stored rather than
reported. The tree ships one:
`builder/devices/t40_lite_movols-mo-805p/general/overlay/usr/share/openipc/customizer.sh:15-19,25`
says `cli -s .video0.bitrate: 4000`, and the trailing colon is why six of that device's
settings have never applied. Nobody noticed, because there was nothing to notice.

Shows on every board — `general/overlay/usr/sbin/extutils` is in the shared overlay.

## What this does

`cli -s` / `cli -d` still write the file, and then ask majestic to reload if it is running.
`signal_hup_cb` already parses before tearing anything down, diffs the file against the tree
in force, prices the difference on the `CFG_RELOAD_*` ladder — a live key goes straight at
the SDK, a service key restarts only that service, and only a pipeline key rebuilds — and
debounces repeat signals inside 3s into one reload. So most settings now apply without the
stream noticing. This is the pattern `wifibroadcast:82` and `:212` already use by hand;
it is only being made the default.

The signal is conditional on majestic already running, which is what keeps provisioning
untouched: `customizer.sh` seeds a device at S30 and majestic does not start until S95, so
those writes take exactly the path they always did, silently. Reads and an explicit `-i`/`-o`
are left alone, so `sensor_cli` and the `wifibroadcast cli` applet are unaffected.

Plus a key-shape check that refuses a malformed path before the write, `CMD` from `${0##*/}`
(`cut -d / -f 4` needs a path of exactly four fields, so `./cli` fell through to the silent
default), and removal of the dead `api)` applet — nothing creates `/usr/sbin/api`, and its
`--data-urlencode "$@"` only ever bound `$1`.

### Why not route the writes through the HTTP API

That was the first design, and it was measured on a lab camera before being abandoned.

Of the fourteen keys `wifibroadcast`'s `video_settings` seeds, **six answer 404** from
`/api/v1/set` — `outgoing.wfb`, `records.notime`, `fpv.noiseLevel`, `fpv.enabled`,
`isp.exposure`, `video0.noiseLevel`. They are read by majestic but never declared in its
schema. `.outgoing.wfb` gates the wfb relay, so this would have broken video on every
wifibroadcast camera. The file path is forward- and backward-compatible across a key rename;
the API path is not, and `wifibroadcast:183-188` says so in a comment.

It would also have had to guess whether majestic was up, and `S98wifibroadcast` and
`S98datalink` both run *after* `S95majestic`, where the honest answer is "starting".

## Hardware tested on

hi3516ev200 (lab camera, OpenIPC 2.6.04.16, majestic master+a805052). The new `extutils` was
copied over the shipped one, exercised, and the camera restored afterwards — `extutils` and
`majestic.yaml` md5s both back to their originals.

## Evidence

Before — the write lands in the file, the running camera ignores it, and a malformed path is
stored without complaint:

```
# cli -g .video0.bitrate
4096
# cli -s .video0.bitrate: 4000
# echo $?
0
```

After:

```
# cli -g .video0.fps
20
# cli -g .video0.bitrate
4096

--- the movols typo: refused, and the file is untouched ---
# md5sum /etc/majestic.yaml
981bfbaced4772c70259baa0844b9558  /etc/majestic.yaml
# cli -s .video0.bitrate: 4000
cli: '.video0.bitrate:' is not a setting path, nothing written
# echo $?
1
# md5sum /etc/majestic.yaml
981bfbaced4772c70259baa0844b9558  /etc/majestic.yaml

--- a real write now reaches the running streamer ---
# cli -s .video0.bitrate 2048
# echo $?
0
# grep -A6 '^video0:' /etc/majestic.yaml | grep bitrate
  bitrate: 2048
# curl -s http://127.0.0.1/api/v1/config.json | tr ',' '\n' | grep -o '"bitrate": *[0-9]*' | head -1
"bitrate": 2048
# pidof majestic        # same pid before and after: reloaded in place, not restarted
1055
# curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1/image.jpg
200

--- boot path unchanged: majestic down, silent, and the && chain still fires ---
# /etc/init.d/S95majestic stop
# pidof majestic || echo "not running"
not running
# cli -s .video0.fps 18
# echo $?
0
# grep -A3 '^video0:' /etc/majestic.yaml | grep fps
  fps: 18
# cli -s .isp.blkCnt 1 && echo "&& chain still fires"
&& chain still fires

--- reads and an explicit -i are untouched ---
# printf 'sensor:\n  width: 1280\n' > /tmp/t.yaml
# cli -i /tmp/t.yaml -s .sensor.width 1920 ; cat /tmp/t.yaml
sensor:
  width: 1920
```

Off-camera gates:

```
$ STRICT=1 bash .github/scripts/test_shell_parse.sh
checked 134 shell script(s)
all parsed clean under busybox ash

$ STRICT=1 bash .github/scripts/test_strip_shell_comments.sh
ok   stripping is idempotent
ok   134 shipped scripts parse identically after stripping (106670 bytes saved)
All strip-shell-comments checks passed.

$ git diff --name-only origin/master | python3 .github/scripts/ci-matrix.py --stdin
ci-matrix: 99/99 boards (needs_build=True) --- general/overlay/usr/sbin/extutils affects every board
```

## Follow-ups this turned up

- #2365 — `zoom.sh` sends `killall -10 majestic`, which is SIGUSR1, caught by the bundled
  thread pool's `thread_hold()` and never released. Those nine calls should be deleted rather
  than corrected, since `cli -s` now asks for the reload itself.
- The six undeclared keys above are worth declaring in majestic regardless of this PR.
- `builder`'s `t40_lite_movols-mo-805p` still has the six trailing colons; that is a fix for
  that repo, and this change is what makes them visible.

## Scope

- [x] No kernel patches under `general/package/all-patches/linux/`
- [x] No files specific to a single retail camera model
- [x] No probing or bring-up tooling
- [x] Nothing under `general/overlay/` or in a shared `load_<vendor>` script hardcodes a value specific to my board
- [x] No `LD_PRELOAD`, and no binaries that cannot be rebuilt from source
- [x] New code is selected by a defconfig, so CI actually builds it
