### PR TITLE
review: teach the gates what a broken cli line looks like

### DIFF
--- a/best_practices.md
+++ b/best_practices.md
@@ -435,9 +435,18 @@ can therefore take the streamer away for the rest of the boot. `cli -s` asks for
 reload itself, and checks readiness before it does, so a new script should not add its own
 `killall`.
 
-Raise both against files under `general/overlay/` and `general/package/*/files/`. Neither
-is a compliance gate: a dynamic path (`cli -g ".$1"`) is legitimate and undecidable from
-the diff, and there are reasons to signal by hand.
+Raise both against files under `general/overlay/` and anywhere under
+`general/package/` — including nested layouts such as
+`general/package/legacy/datalink/files/`.
+
+The narrow, decidable half of each is a compliance gate ("cli writes address a real
+setting, and reloads use SIGHUP" in `pr_compliance_checklist.yaml`): a literal path with a
+stray character, and a reload asked for with something other than SIGHUP. What stays a
+judgement call here is everything the diff cannot settle — whether a well-formed key is one
+the target build actually declares, whether a path assembled at runtime is right, and
+whether a script has a good reason to signal by hand. Lifecycle signalling is neither:
+sysupgrade's SIGQUIT, and SIGTERM to stop the daemon, are not reload attempts and are not
+in scope for either.
 
 ---
 

--- a/best_practices.md
+++ b/best_practices.md
@@ -406,6 +406,39 @@ Flag a genuinely unsupported construct in a script under `general/overlay/` or
 `general/package/*/files/`. Do not flag style, and do not flag anything under `.github/`
 or `contrib/`, which run under bash away from the device.
 
+
+### 7.2 A `cli` setting path is unvalidated, and signalling majestic has one right signal
+
+Two mistakes around `cli` are silent on the camera and cheap to catch in review.
+
+**The path.** `cli -s` writes into `/etc/majestic.yaml` through yaml-cli, which stores
+whatever dotted path it is handed — creating the intermediate mappings as it goes — and
+exits 0. majestic then ignores a key it does not recognise. So a mistyped path applies
+nothing and reports nothing, for the life of the device.
+`OpenIPC/builder`'s `t40_lite_movols-mo-805p` shipped six of them behind a trailing colon
+(`cli -s .video0.bitrate: 4000`), and bitrate, rate-control mode, profile, GOP size, GOP
+mode and OSD size never applied on that camera. Read the path, not just the value:
+every component should look like a YAML key, with no trailing separator and no empty
+component. OpenIPC/builder now lints exactly this in CI.
+
+**The signal.** majestic reloads on `SIGHUP`, which is `killall -1 majestic` or
+`/etc/init.d/S95majestic reload`. `infinity6e`'s `zoom.sh` sends `killall -10` in nine
+places; signal 10 is `SIGUSR1`, which majestic's bundled thread pool catches to park a
+thread and never resumes (OpenIPC/firmware#2365), so those crops were never applied.
+
+And a signal is only safe once majestic can catch it. `S95majestic` starts it with
+`start-stop-daemon -b`, which returns at the fork, so the process is visible to `pidof`
+well before `main()` installs a `SIGHUP` handler — and until then the default action for
+`SIGHUP` is to terminate. Measured on a hi3516ev200, the process appears with `SigCgt`
+still `0000000000000000`. A boot-time script that writes config and signals immediately
+can therefore take the streamer away for the rest of the boot. `cli -s` asks for the
+reload itself, and checks readiness before it does, so a new script should not add its own
+`killall`.
+
+Raise both against files under `general/overlay/` and `general/package/*/files/`. Neither
+is a compliance gate: a dynamic path (`cli -g ".$1"`) is legitimate and undecidable from
+the diff, and there are reasons to signal by hand.
+
 ---
 
 ## 8. Things that must not reach `master`

--- a/pr_compliance_checklist.yaml
+++ b/pr_compliance_checklist.yaml
@@ -189,19 +189,27 @@ pr_compliances:
       shape of mistake: majestic reloads on SIGHUP and on nothing else.
     success_criteria: >
       Every literal path passed to cli/yaml-cli/sensor_cli -s, -g or -d looks like a YAML
-      key path — components of letters, digits, underscore, dot or dash, no trailing
-      separator, no empty component. A path built at runtime, such as `cli -g ".$1"`, is
-      fine and is not judged here. Where a script asks majestic to reload, it does so with
-      SIGHUP — `killall -1 majestic` or `/etc/init.d/S95majestic reload`.
+      key path. A single leading dot is the conventional spelling and is correct —
+      `.video0.size` is a well-formed two-component path, not one with an empty first
+      component. After that optional dot, each component is letters, digits, underscore or
+      dash, separated by single dots, with no trailing dot. A path built at runtime, such
+      as `cli -g ".$1"`, is fine and is not judged here. Where a script asks majestic to
+      re-read its configuration, it does so with SIGHUP — `killall -1 majestic` or
+      `/etc/init.d/S95majestic reload`.
     failure_criteria: >
       The diff adds a cli path carrying a stray character — a trailing colon or equals is
-      the shipped case — or an empty component, in general/overlay/ or
-      general/package/*/files/. Or it signals majestic with anything other than SIGHUP:
-      signal 10 is SIGUSR1, which the bundled thread pool catches to park a thread and
-      never resumes, so `killall -10 majestic` reloads nothing. Do not raise this for a
-      path containing a variable or command substitution, for anything under .github/ or
-      contrib/, or for `cli` used against a file other than /etc/majestic.yaml through an
-      explicit -i.
+      the shipped case — a doubled dot, or a trailing dot, in general/overlay/ or anywhere
+      under general/package/, including nested layouts such as
+      general/package/legacy/datalink/files/. Or it asks majestic to re-read its
+      configuration with a signal that is not SIGHUP: signal 10 is SIGUSR1, which the
+      bundled thread pool catches to park a thread and never resumes, so
+      `killall -10 majestic` reloads nothing.
+      This is about reload intent only. Lifecycle signalling is untouched and must not be
+      raised: sysupgrade sends SIGQUIT (`killall -q -3 majestic`) to make majestic release
+      the SDK while staying alive, and SIGTERM or SIGKILL to stop it are ordinary. Nor
+      raise it for a path containing a variable or command substitution, for anything
+      under .github/ or contrib/, or for `cli` used against a file other than
+      /etc/majestic.yaml through an explicit -i.
 
   - title: "Hardware evidence is present and honest"
     compliance_label: true

--- a/pr_compliance_checklist.yaml
+++ b/pr_compliance_checklist.yaml
@@ -178,6 +178,31 @@ pr_compliances:
       busybox sets CONFIG_ASH_BASH_COMPAT=y, so constructs a portability linter would
       reject are valid in the field. That judgement lives in best_practices.md §7.1.
 
+  - title: "cli writes address a real setting, and reloads use SIGHUP"
+    compliance_label: true
+    objective: >
+      `cli -s` cannot fail. yaml-cli stores whatever dotted path it is handed, creating
+      the intermediate mappings as it goes, and exits 0; majestic then ignores a key it
+      does not recognise. A mistyped setting path therefore applies nothing and reports
+      nothing for the life of the device — OpenIPC/builder shipped six of them on
+      t40_lite_movols-mo-805p behind a trailing colon. The reload signal is the same
+      shape of mistake: majestic reloads on SIGHUP and on nothing else.
+    success_criteria: >
+      Every literal path passed to cli/yaml-cli/sensor_cli -s, -g or -d looks like a YAML
+      key path — components of letters, digits, underscore, dot or dash, no trailing
+      separator, no empty component. A path built at runtime, such as `cli -g ".$1"`, is
+      fine and is not judged here. Where a script asks majestic to reload, it does so with
+      SIGHUP — `killall -1 majestic` or `/etc/init.d/S95majestic reload`.
+    failure_criteria: >
+      The diff adds a cli path carrying a stray character — a trailing colon or equals is
+      the shipped case — or an empty component, in general/overlay/ or
+      general/package/*/files/. Or it signals majestic with anything other than SIGHUP:
+      signal 10 is SIGUSR1, which the bundled thread pool catches to park a thread and
+      never resumes, so `killall -10 majestic` reloads nothing. Do not raise this for a
+      path containing a variable or command substitution, for anything under .github/ or
+      contrib/, or for `cli` used against a file other than /etc/majestic.yaml through an
+      explicit -i.
+
   - title: "Hardware evidence is present and honest"
     compliance_label: true
     objective: >


### PR DESCRIPTION
## Problem

Two mistakes around `cli` are completely silent on a camera, and neither the compliance
gates nor `best_practices.md` had anything to say about either. Both have shipped.

**The path.** `cli -s` cannot fail. yaml-cli stores whatever dotted path it is handed,
creating the intermediate mappings as it goes, and exits 0; majestic then ignores a key it
does not recognise. So a typo applies nothing and reports nothing, for the life of the
device. `OpenIPC/builder`'s `t40_lite_movols-mo-805p` has been shipping six of them behind
a trailing colon:

```sh
cli -s .video0.bitrate: 4000
cli -s .video0.rcMode: avbr
```

Bitrate, rate-control mode, profile, GOP size, GOP mode and OSD size have never applied on
that camera.

**The signal.** majestic reloads on `SIGHUP` and on nothing else.
`general/package/sigmastar-osdrv-infinity6e/files/script/zoom.sh` sends `killall -10` in
nine places. Signal 10 is `SIGUSR1`, which majestic's bundled thread pool catches to park a
thread and never resumes (#2365) — so those crops were written to the file and never
applied.

And a signal is only safe once majestic can catch it. `S95majestic` starts it with
`start-stop-daemon -b`, which returns at the fork, so it is visible to `pidof` long before
`main()` installs a handler — and until then `SIGHUP`'s default action is to terminate.
Measured on a lab hi3516ev200:

```
process visible, SigCgt=0000000000000000 -> SIGHUP would KILL it
SIGHUP handler installed, SigCgt=0000000000004007
```

## What this adds

- **`pr_compliance_checklist.yaml`** — one rule taking the binary half: a literal path
  carrying a stray character or an empty component, and a signal that is not SIGHUP. It
  explicitly exempts a path built at runtime (`cli -g ".$1"` in builder's
  `uvc-gadget-setup` is correct and undecidable from a diff), anything under `.github/` or
  `contrib/`, and `cli` used against another file through an explicit `-i`.
- **`best_practices.md` §7.2** — the judgement half and the reasoning, next to §7.1's
  existing note on shell portability.

## Why a rule rather than only a linter

Both. `OpenIPC/builder#146` lints the path half mechanically, over the tree where the 709
shipped `cli -s` lines actually live — that is the deterministic, free check, and it found
the six bad lines immediately. What a linter cannot judge is whether a *well-formed* key is
one a given majestic build declares (it varies by vendor and flavour), or whether adding a
`killall` to a boot-time script is safe. That is what the review rule is for.

## Evidence

This is review configuration: it reaches no image, and the selector agrees.

```
$ git diff --name-only origin/master | python3 .github/scripts/ci-matrix.py --stdin
ci-matrix: 0/99 boards (needs_build=False) --- nothing that reaches a build
needs-build=false

$ python3 .github/scripts/ci-matrix.py --self-test
ci-matrix: self-test ok (99 boards, 134 packages, 56 cases)

$ python3 -c "import yaml; d=yaml.safe_load(open('pr_compliance_checklist.yaml')); print(len(d['pr_compliances']), 'rules')"
13 rules
```

## Hardware tested on

Not applicable, and the template says so: this is review configuration and cannot alter
what the firmware does on a camera. The `SigCgt` measurement quoted above comes from the
work in #2366, on a lab hi3516ev200; nothing in *this* diff runs anywhere but Qodo.

## Scope

- [x] No kernel patches under `general/package/all-patches/linux/`
- [x] No files specific to a single retail camera model
- [x] No probing or bring-up tooling
- [x] Nothing under `general/overlay/` or in a shared `load_<vendor>` script hardcodes a value specific to my board
- [x] No `LD_PRELOAD`, and no binaries that cannot be rebuilt from source
