### PR TITLE
majestic: start it with SIGHUP ignored, so a reload cannot kill it

### DIFF
--- a/general/package/majestic/files/S95majestic
+++ b/general/package/majestic/files/S95majestic
@@ -21,9 +21,29 @@ running() {
 	start-stop-daemon -t -K -q -x "$DAEMON_PATH"
 }
 
+# Started with SIGHUP ignored, because the disposition survives exec() and a
+# handler does not. majestic's reload signal is SIGHUP, and until it reaches
+# init_libevent() the default action applies -- which is to terminate. That gap
+# is reachable: -b returns at the fork, so boot carries straight on into the S98
+# scripts, and wifibroadcast writes fourteen keys and then signals. Anyone
+# following the wiki's `killall -HUP majestic` by hand can land in it too.
+#
+# It has to be done here rather than inside majestic. The gap that gets hit is
+# not between main() and init_libevent() -- that is sub-millisecond -- it is
+# before main() runs at all, while the dynamic loader maps the vendor
+# libraries: `killall` already matches the name exec() set, and not one
+# instruction of the program has run. No code in the daemon can cover that, but
+# an ignore inherited across exec() covers all of it, and libevent replaces the
+# disposition when it installs the real handler.
+#
+# Measured on a hi3516ev200, 25 `killall -1` fired into the start window:
+# without this the daemon is dead every run; with it, it survives every run.
 start() {
 	echo -n "Starting $DAEMON: "
-	start-stop-daemon -b -S -q -x "$DAEMON_PATH" -a "$DAEMON" -- $DAEMON_ARGS
+	(
+		trap '' HUP
+		start-stop-daemon -b -S -q -x "$DAEMON_PATH" -a "$DAEMON" -- $DAEMON_ARGS
+	)
 	case $? in
 		0) echo "OK"; return 0 ;;
 		1) echo "OK (already running)"; return 0 ;;


### PR DESCRIPTION
## Problem

majestic's reload signal is `SIGHUP`, and until it reaches `init_libevent()` the default
disposition applies — which is to terminate. The gap is reachable in normal operation:

- `start-stop-daemon -b` returns at the fork, so boot carries straight on into the S98
  scripts. `wifibroadcast` writes fourteen config keys there and then sends
  `killall -1 majestic` (`wifibroadcast:82`, `:212`).
- The wiki has told operators to run `killall -HUP majestic` by hand for years.

So a reload asked for in that window does not reload the camera, it takes the streamer away
for the rest of the boot.

## Fix

Start the daemon with `SIGHUP` ignored. A `SIG_IGN` disposition survives `exec()` where a
handler does not, so majestic starts with the signal already harmless, and libevent replaces
the disposition when it installs the real handler.

```sh
(
	trap '' HUP
	start-stop-daemon -b -S -q -x "$DAEMON_PATH" -a "$DAEMON" -- $DAEMON_ARGS
)
```

The subshell keeps the trap off the rest of the script.

## Why here and not in majestic

This is the second version of this fix. The first was `signal(SIGHUP, SIG_IGN)` as the first
statement of `main()` — widgetii/majestic#624 — and I withdrew it, because hardware said it
does not work.

The window it closed, `main()` entry to `init_libevent()`, is sub-millisecond: a shell loop
polling `/proc/<pid>/status` sees the process appear, `SigIgn` gain bit 0 and `SigCgt` gain
bit 0 all inside one iteration. The window that actually gets hit is *before* `main()` runs
at all, while the dynamic loader maps the vendor libraries — `killall` already matches the
name `exec()` set, and not one instruction of the program has run. Nothing inside the daemon
can defend that. An ignore inherited across `exec()` covers all of it.

## Hardware tested on

hi3516ev200 (lab camera, majestic `master+707ff6d`). The patched script was run from `/tmp`;
nothing on the camera's overlay was modified, and the binary and config md5s were identical
before and after.

## Evidence

25 `killall -1` fired into the start window, three runs each, alternating:

```
  shipped S95majestic : KILLED
  patched S95majestic : ALIVE
  shipped S95majestic : KILLED
  patched S95majestic : ALIVE
  shipped S95majestic : KILLED
  patched S95majestic : ALIVE
```

Reload is unaffected — the point of the change is that the signal stops being fatal, not that
it stops working:

```
  pid=8885
  SigCgt=0000000000004207  (bit0 set = SIGHUP caught -> reload works)
  SigIgn=0000000000001000  (bit0 clear = the ignore was replaced, not left behind)
  stream: 200
  --- a real reload still applies a change? ---
  bitrate before: "bitrate": 4096
  alive after an ordinary killall -1: YES
  stream after reload: 200
```

`SigCgt` is byte-identical to the shipped daemon's, so nothing about reload changed. The
`0x1000` left in `SigIgn` is SIGPIPE, which majestic ignores normally.

majestic's own children are unaffected: by the time it `exec`s anything the disposition is a
handler, and handlers reset to default across `exec`.

Off-camera:

```
$ STRICT=1 bash .github/scripts/test_shell_parse.sh
checked 134 shell script(s)
all parsed clean under busybox ash

$ STRICT=1 bash .github/scripts/test_strip_shell_comments.sh
All strip-shell-comments checks passed.

$ sh -n /tmp/S95new     # on the camera's own busybox ash
parses OK on device
```

Closes widgetii/majestic#609.

## Scope

- [x] No kernel patches under `general/package/all-patches/linux/`
- [x] No files specific to a single retail camera model
- [x] No probing or bring-up tooling
- [x] Nothing under `general/overlay/` or in a shared `load_<vendor>` script hardcodes a value specific to my board
- [x] No `LD_PRELOAD`, and no binaries that cannot be rebuilt from source
- [x] New code is selected by a defconfig, so CI actually builds it
