### PR TITLE
usb-dual-role: an unreadable setting is not an off one, and 200 is not done

### DIFF
--- a/general/package/usb-dual-role/files/www/a/usb.js
+++ b/general/package/usb-dual-role/files/www/a/usb.js
@@ -101,15 +101,27 @@
 	// its own is not the answer: a port in host mode with nothing plugged into
 	// it and a port with a camera on it are the same role and different
 	// situations, and only one of them is worth doing anything about.
+	// You cannot change what you cannot read. One rule, decided before any of
+	// the early returns below, because there are two ways to be in the dark --
+	// the port endpoint failing and the settings failing -- and an earlier
+	// version only covered the second. With a role already selected from a
+	// refresh that worked, the first left a stale selection armed.
+	function setActionable(ok) {
+		if (apply) apply.disabled = !ok;
+	}
+
 	function render(st, cfg) {
-		if (!st || !st.ok) {
+		const portKnown = !!(st && st.ok);
+		const known = cfg !== null && cfg !== undefined;
+		setActionable(portKnown && known);
+
+		if (!portKnown) {
 			statusEl.innerHTML = mjNotice('warn',
 				'<b>Cannot read the port</b> &mdash; this camera may not have a ' +
 				'switchable USB port.');
 			return;
 		}
 
-		const known = cfg !== null;
 		const usbcam = known && String(mjGet(cfg, 'usbcam.enabled')) === 'true';
 		const gadget = known && String(mjGet(cfg, 'uvcgadget.enabled')) === 'true';
 		const onoff = v => (known ? (v ? 'on' : 'off') : 'cannot tell');
@@ -137,10 +149,8 @@
 				'<b>Cannot read this camera&rsquo;s settings</b> &mdash; the ' +
 				'port is shown above, but what is using it is unknown until ' +
 				'the camera answers again.');
-			if (apply) apply.disabled = true;
 			return;
 		}
-		if (apply) apply.disabled = false;
 
 		// The two states worth saying something about, because in both of them
 		// the camera looks configured and produces nothing.
@@ -213,7 +223,15 @@
 				const flagsOk = cfg !== null && cfg !== undefined &&
 					String(mjGet(cfg, 'usbcam.enabled')) === want.usbcam &&
 					String(mjGet(cfg, 'uvcgadget.enabled')) === want.uvcgadget;
-				text(msg, roleOk && flagsOk ? 'Done.'
+				// The role and the flags agreeing is not the webcam existing.
+				// A device-mode port can sit with the gadget never composed and
+				// no node behind it, which is the failure this page was built
+				// to make visible -- so it cannot be what "Done." papers over.
+				// Host asks for no such thing: a port with nothing plugged into
+				// it has no node and is working correctly.
+				const pipelineOk = role !== 'device' ||
+					(st.gadget === true && !!st.video);
+				text(msg, roleOk && flagsOk && pipelineOk ? 'Done.'
 					: 'Applied, but the camera does not report it yet.');
 			})
 			.catch(err => {
@@ -223,7 +241,11 @@
 					statusEl.innerHTML;
 				return refresh();
 			})
-			.then(() => { apply.disabled = false; });
+			// Deliberately not re-enabling here. Every path above ends in
+			// refresh(), and render() decides from what the camera actually
+			// answered; an unconditional re-enable at the end of the chain
+			// reversed that decision the moment it mattered.
+			;
 	});
 
 	refresh();

--- a/general/package/usb-dual-role/files/www/a/usb.js
+++ b/general/package/usb-dual-role/files/www/a/usb.js
@@ -58,12 +58,20 @@
 			.catch(() => ({ ok: false }));
 	}
 
+	// null, not {}, when the read fails.
+	//
+	// An empty object is not neutral here: every flag read off it comes back
+	// undefined, which compares as "off", which this page would then print as
+	// a fact and preselect "Nothing" from. Press Apply on that and it writes
+	// both flags false -- turning off a second camera that was working, because
+	// the page could not reach the daemon for a moment. Unknown has to stay
+	// unknown all the way to the screen.
 	function config() {
 		// Not mjConfig(): that memoises, and this page's whole job is to change
 		// the values it would be caching.
 		return apiFetch('/api/v1/config.json', { credentials: 'same-origin' })
-			.then(r => r.ok ? r.json() : {})
-			.catch(() => ({}));
+			.then(r => r.ok ? r.json() : null)
+			.catch(() => null);
 	}
 
 	// The node has to be written along with the flag, not left at whatever it
@@ -101,8 +109,10 @@
 			return;
 		}
 
-		const usbcam = String(mjGet(cfg, 'usbcam.enabled')) === 'true';
-		const gadget = String(mjGet(cfg, 'uvcgadget.enabled')) === 'true';
+		const known = cfg !== null;
+		const usbcam = known && String(mjGet(cfg, 'usbcam.enabled')) === 'true';
+		const gadget = known && String(mjGet(cfg, 'uvcgadget.enabled')) === 'true';
+		const onoff = v => (known ? (v ? 'on' : 'off') : 'cannot tell');
 		const attached = (st.attached || '').trim();
 
 		let rows = '';
@@ -110,13 +120,27 @@
 
 		if (st.role === 'device') {
 			row('Port', 'offered to a computer as a webcam');
-			row('Offering it', st.gadget && gadget ? 'yes' : 'not right now');
+			row('Offering it', known ? (st.gadget && gadget ? 'yes' : 'not right now')
+				: 'cannot tell');
 		} else {
 			row('Port', 'ready for a webcam to be plugged in');
 			row('Plugged in', attached ? esc(attached.split('\n')[0]) : 'nothing');
-			row('Second camera', usbcam ? 'on' : 'off');
+			row('Second camera', onoff(usbcam));
 		}
 		statusEl.innerHTML = rows;
+
+		// Say the settings are unreadable rather than reporting them as off,
+		// and take Apply away: writing a role from a page that cannot read the
+		// current one is how a working camera gets switched off by accident.
+		if (!known) {
+			statusEl.innerHTML += mjNotice('warn',
+				'<b>Cannot read this camera&rsquo;s settings</b> &mdash; the ' +
+				'port is shown above, but what is using it is unknown until ' +
+				'the camera answers again.');
+			if (apply) apply.disabled = true;
+			return;
+		}
+		if (apply) apply.disabled = false;
 
 		// The two states worth saying something about, because in both of them
 		// the camera looks configured and produces nothing.
@@ -135,7 +159,7 @@
 
 	function refresh() {
 		return Promise.all([usbStatus(), config()]).then(([st, cfg]) => {
-			if (st && st.ok && !checked()) {
+			if (st && st.ok && cfg !== null && !checked()) {
 				const usbcam = String(mjGet(cfg, 'usbcam.enabled')) === 'true';
 				const gadget = String(mjGet(cfg, 'uvcgadget.enabled')) === 'true';
 				// The role says what the port can do; the flags say whether
@@ -145,7 +169,7 @@
 					: (usbcam ? 'host' : 'off'));
 			}
 			render(st, cfg);
-			return st;
+			return { st: st, cfg: cfg };
 		});
 	}
 
@@ -172,8 +196,25 @@
 				return setFlags(role, st.video);
 			})
 			.then(saved => {
-				text(msg, saved ? 'Done.' : 'The port changed, the settings did not.');
+				if (!saved)
+					throw new Error('the port changed, but the settings did not save');
+				// Not "Done." yet. A 200 from the config write says the daemon
+				// accepted it, not that the pipeline came back in the new role
+				// -- and the rebuild is exactly the part that can lose a race
+				// with USB enumeration. Ask the camera before claiming.
+				text(msg, 'Applied, checking\u2026');
 				return refresh();
+			})
+			.then(res => {
+				const st = res && res.st, cfg = res && res.cfg;
+				const want = ROLE_KEYS[role] || ROLE_KEYS.off;
+				const roleOk = st && st.ok &&
+					st.role === (role === 'device' ? 'device' : 'host');
+				const flagsOk = cfg !== null && cfg !== undefined &&
+					String(mjGet(cfg, 'usbcam.enabled')) === want.usbcam &&
+					String(mjGet(cfg, 'uvcgadget.enabled')) === want.uvcgadget;
+				text(msg, roleOk && flagsOk ? 'Done.'
+					: 'Applied, but the camera does not report it yet.');
 			})
 			.catch(err => {
 				text(msg, '');


### PR DESCRIPTION
Two review findings raised against the USB page on OpenIPC/majestic-webui#371.
They landed while `usb.js` was moving into this package, so they were marked
"outdated" there against a path that no longer exists — but both are real, and
this is where the file lives now.

Both are the same mistake in two places: claiming to know something the page had
not established.

## An empty object is not a reading

```js
.then(r => r.ok ? r.json() : {})
.catch(() => ({}));
```

Nothing downstream could tell that from a real answer. Each flag read off it came
back `undefined`, compared as off, and was printed as fact — and `refresh()`
preselected **Nothing** from it. Press Apply on a page that had merely failed to
reach the daemon for a moment, and it wrote both flags `false`: a working second
camera switched off because the browser could not read.

It returns `null` now. The page says *"Cannot read this camera's settings"*,
reports the port (which comes from a different endpoint and was still known) and
leaves the rest as "cannot tell". Apply is disabled until a reading arrives —
writing a role from a page that cannot read the current one is the specific
accident worth preventing.

## 200 is not "Done."

"Done." was printed on the strength of the config write returning 200. That says
the daemon accepted the settings, not that the pipeline came back in the new
role — and that rebuild is precisely the step that can lose a race with USB
enumeration, which is why this page has the shape it does.

It now says *"Applied, checking…"*, re-reads, and claims Done only when the
camera itself reports the role and both flags it was asked for. Otherwise:
*"Applied, but the camera does not report it yet."*

`node --check` clean. No behaviour change on the path where everything works.