### PR TITLE
usb-dual-role: the video node is a per-boot fact, so re-derive it each boot

### DIFF
--- a/general/package/usb-dual-role/files/S72usbmode
+++ b/general/package/usb-dual-role/files/S72usbmode
@@ -14,6 +14,40 @@
 # Runs after S70vendor so the vendor modules are up first, and after S29debugfs
 # so the role file exists to be read.
 
+# The node of a given kind, once it exists. The gadget's is the one whose sysfs
+# parent is the UDC; anything else is a capture device, which in host mode is
+# the webcam. Bounded, because a port with nothing on it never produces one and
+# that is a perfectly ordinary way to boot.
+video_node() {
+	_i=0
+	while [ $_i -lt 20 ]; do
+		for _v in /sys/class/video4linux/video*; do
+			[ -e "$_v" ] || continue
+			case "$(readlink "$_v" 2>/dev/null)" in
+				*/gadget/*) _kind=gadget ;;
+				*)          _kind=capture ;;
+			esac
+			if [ "$_kind" = "$1" ]; then
+				echo "/dev/${_v##*/}"
+				return 0
+			fi
+		done
+		_i=$((_i + 1))
+		usleep 100000 2>/dev/null || sleep 1
+	done
+	return 1
+}
+
+# Only writes when it differs, so an unchanged camera does not rewrite its
+# configuration on every boot.
+sync_node() {
+	_n=$(video_node "$1") || return 0
+	[ -n "$_n" ] || return 0
+	[ "$(cli -g ".$2" 2>/dev/null)" = "$_n" ] && return 0
+	echo "Pointing $2 at $_n"
+	cli -s ".$2" "$_n"
+}
+
 case "$1" in
 	start)
 		# Selecting the package says the board is meant to switch roles;
@@ -35,6 +69,26 @@ case "$1" in
 		esac
 		echo "Setting USB role to $mode..."
 		/usr/sbin/usb-mode "$mode" || echo "usb-mode $mode failed"
+
+		# Re-point majestic at the node this boot actually produced.
+		#
+		# The number is a per-boot fact and majestic is told a path. A switch
+		# made from the web UI discovers the node it got and saves it, which is
+		# right for that boot and wrong for the next one: a gadget composed
+		# behind a webcam still holding /dev/video0 lands on video1 and is
+		# saved as video1, then comes back on video0 when nothing races it.
+		# majestic opens the saved path, does not find it, and logs "gadget not
+		# started" once -- a webcam a PC enumerates and never receives a frame
+		# from. Measured on gk7205v200 after a reboot in device mode.
+		#
+		# Here is the one place that always runs, knows the role, and runs
+		# before majestic starts, so cli writing the file directly is exactly
+		# right: there is no daemon to ask yet.
+		if [ "$mode" = device ]; then
+			sync_node gadget uvcgadget.device
+		else
+			sync_node capture usbcam.device
+		fi
 		;;
 
 	stop)


### PR DESCRIPTION
Found by upgrading a camera to the built image and using it — this one does not
show up any other way.

## What breaks

Set the port to *webcam for a PC*, reboot, and the camera comes back with the
gadget composed and nothing feeding it. A PC sees the webcam enumerate and
receives no video. majestic says so exactly once, at boot:

```
/dev/video1 unavailable (No such file or directory), gadget not started
```

```
config says:  uvcgadget.device = /dev/video1
gadget is on: /dev/video0
holder:       (nothing)
```

## Why

The kernel does not reuse a v4l2 minor freed earlier in the same boot. A gadget
composed while the outgoing webcam still holds `/dev/video0` therefore lands on
`/dev/video1`, and the web UI — correctly, for that moment — discovers that and
saves it so majestic opens the right node.

But the next boot has no webcam to race: the gadget takes `video0` again, while
the configuration still names `video1`. Durable configuration was holding a fact
that only survives one boot. My mistake in
OpenIPC/majestic-webui#371: I fixed "don't assume the node" by persisting a
discovered one.

## The fix

`S72usbmode` already knows the role, already composes the gadget, and runs
*before* majestic starts. It now re-points majestic at the node this boot
actually produced, for whichever role is in effect. `cli` writes the file
directly, which is exactly right here — there is no daemon up to ask yet — and
it only writes when the value differs, so an unchanged camera does not rewrite
its configuration on every boot.

## Verified on hardware, both directions, from deliberately broken state

gk7205v200-gc2053 running the CI build of OpenIPC/builder `2a26e86`:

| | before reboot | after reboot |
| --- | --- | --- |
| **device** | `uvcgadget.device` left stale at `/dev/video1` | corrected to `/dev/video0`; `started on /dev/video0 as MJPEG 1280x720@5`, gadget composed and held |
| **host** | `usbcam.device` set by hand to `/dev/video7` | corrected to `/dev/video0`; webcam enumerated, `/image.jpg?channel=1` serving 111 KB |

0 kernel warnings or oopses across both.

## Also observed on that image, not fixed here

`x-groups` on the shipped schema is `image video events records network system` —
no `usb`, so the per-role tuning is still unreachable in Settings. The sections
are present but ungrouped because the majestic S3 artifact for this SoC predates
widgetii/majestic#630. It resolves itself on the next majestic build.