### PR TITLE
sysupgrade: verify TLS certificates on every fetch, and never exec an unverified download

### DIFF
--- a/.github/scripts/test_sysupgrade.sh
+++ b/.github/scripts/test_sysupgrade.sh
@@ -134,7 +134,7 @@ stub ipcinfo    'case "$1" in -v) echo "${STUB_VENDOR:-sigmastar}";; -F) echo no
 stub fw_printenv 'echo "${STUB_SOC:-ssc338q}"'
 stub killall    'exit 0'
 stub ntpd       'exit 0'
-stub curl       'exit 0'
+stub curl       'exit "${STUB_CURL_RC:-0}"'
 stub umount     'exit 0'
 # Logs so ordering can be asserted, and fails by default: an unprivileged test
 # host cannot really pivot, and the fallback is the safety property that matters
@@ -276,6 +276,7 @@ run() {
         STUB_IMG_VERSION="${STUB_IMG_VERSION:-2026.07.11}" \
         STUB_FLASHCP_FAIL="${STUB_FLASHCP_FAIL:-0}" \
         STUB_REMOUNT_RC="${STUB_REMOUNT_RC:-0}" \
+        STUB_CURL_RC="${STUB_CURL_RC:-0}" \
         sh "$SB/sysupgrade" "$@" 2>&1)
     RC=$?
 }
@@ -295,7 +296,7 @@ at() { printf '%s\n' "$OUT" | grep -n -- "$1" | head -1 | cut -d: -f1; }
 
 reset_env() {
     unset STUB_MOUNT STUB_VENDOR STUB_SOC STUB_IMG_SOC STUB_IMG_VERSION MOUNT_WAIT
-    unset STUB_FLASHCP_FAIL STUB_PIVOT_RC STUB_REMOUNT_RC
+    unset STUB_FLASHCP_FAIL STUB_PIVOT_RC STUB_REMOUNT_RC STUB_CURL_RC
     set_mounts
     rm -rf "$SB/ram"
     rm -f "$SB"/tmp/*.ssc338q "$SB"/tmp/firmware.bin.* "$SB"/tmp/*.tgz "$SB"/tmp/*.md5sum
@@ -892,6 +893,50 @@ else
 fi
 rm -f "$SB/bin/rmdir"
 
+# --- certificate verification (GHSA-fjf7-9x3v-6mj6) ------------------------
+# Every online fetch used to pass -k, so the network could hand the camera any
+# image -- and, through self_update, any script to exec as root. The probe
+# before the download is where a verification failure now surfaces. It must
+# abort before anything is written, and it must say "certificate" rather than
+# "Check your network!", because the two have different fixes. The sandbox's
+# GNU date has no -D, so the HTTP-Date fallback declines here and the failure
+# is final -- which is the path an NTP-blocked camera with no HTTP either sees.
+reset_env
+STUB_CURL_RC=60          # curl: the peer certificate cannot be authenticated
+run -z -r
+if [ "$RC" -ne 0 ] && nothing_wrote && printf '%s\n' "$OUT" | grep -q 'Certificate verification failed'; then
+    ok "a certificate failure aborts before the download and names the cause"
+else
+    bad "certificate failure -> expected an abort naming the certificate, rc=$RC out='$OUT'"
+fi
+printf '%s\n' "$OUT" | grep -q -- '--insecure' \
+    && ok "...and points at --insecure for a private mirror" \
+    || bad "the certificate message must mention --insecure"
+
+reset_env
+STUB_CURL_RC=77          # curl: the CA bundle cannot be read
+run -z -r
+if [ "$RC" -ne 0 ] && nothing_wrote && printf '%s\n' "$OUT" | grep -q 'CA bundle'; then
+    ok "an unreadable CA bundle is reported as such"
+else
+    bad "unreadable CA bundle -> expected an abort naming the bundle, rc=$RC out='$OUT'"
+fi
+
+reset_env
+STUB_CURL_RC=7           # curl: failed to connect
+run -z -r
+if [ "$RC" -ne 0 ] && nothing_wrote && printf '%s\n' "$OUT" | grep -q 'Check your network'; then
+    ok "an unreachable server is still a network problem, not a certificate one"
+else
+    bad "connect failure -> expected 'Check your network', rc=$RC out='$OUT'"
+fi
+
+reset_env
+run -z --insecure -r
+printf '%s\n' "$OUT" | grep -q 'NOT be verified' \
+    && ok "--insecure announces itself" \
+    || bad "--insecure must warn that verification is off, out='$OUT'"
+
 # ---------------------------------------------------------------------------
 echo
 echo "=== Part 2: invariants in $SRC ==="
@@ -900,7 +945,7 @@ echo "=== Part 2: invariants in $SRC ==="
 # --connect-timeout and --speed-limit/--speed-time are curl's, not ours.
 for opt in $(grep -oE '\-\-[a-z_]+' "$SRC" | sort -u); do
     case "$opt" in
-        --force_*|--wipe_overlay|--no_reboot|--no_update|--no_ramfs|--help|--web|--url|--archive|--kernel|--rootfs|--channel|--build|--list*|--connect*|--speed*) continue ;;
+        --force_*|--wipe_overlay|--no_reboot|--no_update|--no_ramfs|--help|--web|--url|--archive|--kernel|--rootfs|--channel|--build|--list*|--insecure|--connect*|--speed*|--proto*) continue ;;
     esac
     bad "message references '$opt', which the option parser does not accept"
 done
@@ -1121,6 +1166,28 @@ if grep -q '^CONFIG_TIMEOUT=y' general/package/busybox/busybox.config; then
 else
     bad "CONFIG_TIMEOUT was dropped from busybox.config -- the bounded mount degrades"
 fi
+
+# --- certificate verification invariants (GHSA-fjf7-9x3v-6mj6) -------------
+# -k may exist only as the value --insecure assigns to $curl_insecure. A literal
+# -k on a curl line turns verification off for every camera again.
+grep -qE 'curl[^|#]* -k( |$)' "$SRC" \
+    && bad "a curl call passes -k directly: certificate verification is off again" \
+    || ok "no curl call disables certificate verification on its own"
+grep -q '^\s*--insecure)' "$SRC" \
+    && ok "--insecure is the explicit, per-run opt-out" \
+    || bad "--insecure is gone; a private mirror with a self-signed certificate has no way in"
+awk '/^self_update\(\)/,/^}/' "$SRC" | grep -q -- '--proto =https' \
+    && ok "self_update fetches the script it will exec over https only" \
+    || bad "self_update must pin --proto/--proto-redir to https: a redirect to http hands root to the network"
+awk '/^self_update\(\)/,/^}/' "$SRC" | grep -qE 'mv [^ ]*sysupgrade\.part' \
+    && ok "self_update stages the download and renames it only when complete" \
+    || bad "self_update must not be able to exec a partially downloaded script"
+awk '/^probe_url\(\)/,/^}/' "$SRC" | grep -q 'clock_from_http' \
+    && ok "a date failure retries once with the clock taken from HTTP, not with -k" \
+    || bad "probe_url must fall back to clock_from_http, or an NTP-blocked camera can never upgrade"
+awk '/^clock_from_http\(\)/,/^}/' "$SRC" | grep -q '"\$web" -gt "\$now"' \
+    && ok "clock_from_http only ever moves the clock forward" \
+    || bad "clock_from_http must be forward-only: a spoofed Date header must not revive an expired certificate"
 
 # --- issue #2231 invariants ------------------------------------------------
 

--- a/.github/scripts/test_sysupgrade.sh
+++ b/.github/scripts/test_sysupgrade.sh
@@ -937,6 +937,24 @@ printf '%s\n' "$OUT" | grep -q 'NOT be verified' \
     && ok "--insecure announces itself" \
     || bad "--insecure must warn that verification is off, out='$OUT'"
 
+# self_update may only ever consider the copy THIS run fetched. A script left in
+# /tmp by an earlier run (one made with --insecure, say) used to be version-
+# compared and exec'd as root whenever the current fetch failed (Qodo, #2374).
+reset_env
+STUB_CURL_RC=7           # this run's fetch fails
+printf '#!/bin/sh\nscr_version=0.0.0\necho STALE SCRIPT RAN\nexit 42\n' > "$SB/tmp/sysupgrade"
+run -r                   # no -z: self_update runs
+if [ "$RC" -ne 42 ] && nothing_wrote && ! printf '%s\n' "$OUT" | grep -q 'STALE SCRIPT RAN' \
+   && printf '%s\n' "$OUT" | grep -q 'Version checking failed'; then
+    ok "a failed self-update fetch never falls through to a script left by an earlier run"
+else
+    bad "stale /tmp/sysupgrade was consulted after a failed fetch, rc=$RC out='$OUT'"
+fi
+[ -e "$SB/tmp/sysupgrade" ] \
+    && bad "the stale script survived the failed fetch and will be seen by the next run" \
+    || ok "...and the leftover is gone"
+rm -f "$SB/tmp/sysupgrade"
+
 # ---------------------------------------------------------------------------
 echo
 echo "=== Part 2: invariants in $SRC ==="
@@ -1182,6 +1200,9 @@ awk '/^self_update\(\)/,/^}/' "$SRC" | grep -q -- '--proto =https' \
 awk '/^self_update\(\)/,/^}/' "$SRC" | grep -qE 'mv [^ ]*sysupgrade\.part' \
     && ok "self_update stages the download and renames it only when complete" \
     || bad "self_update must not be able to exec a partially downloaded script"
+awk '/^self_update\(\)/,/^}/' "$SRC" | grep -qE 'rm -f [^ ]*/sysupgrade( |$)' \
+    && ok "self_update discards whatever an earlier run left before it fetches" \
+    || bad "self_update must remove any stale /tmp/sysupgrade first, or a failed fetch falls through to it"
 awk '/^probe_url\(\)/,/^}/' "$SRC" | grep -q 'clock_from_http' \
     && ok "a date failure retries once with the clock taken from HTTP, not with -k" \
     || bad "probe_url must fall back to clock_from_http, or an NTP-blocked camera can never upgrade"

--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -886,11 +886,16 @@ self_update() {
 		# verified TLS, https only (no redirect may step down to http), -f so an
 		# error page is not kept, and staged through a rename so a transfer that
 		# died half-way cannot leave a truncated script that still carries the
-		# shebang and a foreign scr_version.
-		curl -s -f -L --proto =https --proto-redir =https $curl_insecure -o /tmp/sysupgrade.part \
+		# shebang and a foreign scr_version. And only the copy THIS run fetched is
+		# ever looked at: whatever an earlier run left behind (one made with
+		# --insecure, say) is removed first, so a failed fetch cannot fall
+		# through to it. Removing the file the running shell may itself have
+		# been exec'd from is fine -- it keeps reading the unlinked inode.
+		rm -f /tmp/sysupgrade /tmp/sysupgrade.part
+		if curl -s -f -L --proto =https --proto-redir =https $curl_insecure -o /tmp/sysupgrade.part \
 			"https://raw.githubusercontent.com/OpenIPC/firmware/master/general/overlay/usr/sbin/sysupgrade" \
-			&& mv /tmp/sysupgrade.part /tmp/sysupgrade
-		if [ -f /tmp/sysupgrade ] && grep -q "#!/bin/sh" /tmp/sysupgrade; then
+			&& mv /tmp/sysupgrade.part /tmp/sysupgrade \
+			&& grep -q "#!/bin/sh" /tmp/sysupgrade; then
 			dstv=$(grep scr_version /tmp/sysupgrade | head -1 | cut -f 2 -d '=')
 			if ! [ "$scr_version" = "$dstv" ]; then
 				echo "A new version is available, trying to activate updated script..."
@@ -902,6 +907,7 @@ self_update() {
 				echo "Same version. No update required."
 			fi
 		else
+			rm -f /tmp/sysupgrade.part
 			echo -e "\nVersion checking failed, proceeding with the installed version."
 		fi
 	else

--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -1,6 +1,6 @@
 #!/bin/sh
 # OpenIPC.org | 2025
-scr_version=1.0.62
+scr_version=1.0.63
 
 args="$@"
 LOCK_FILE=/tmp/sysupgrade.lock
@@ -63,6 +63,11 @@ esac
 MANIFEST_URL=${MANIFEST_URL:-https://openipc.github.io/${_manifest_repo}/manifest.flat}
 MANIFEST_CACHE=/tmp/manifest.flat
 unset _osr _plat _manifest_repo
+# Every online fetch verifies the server's certificate against the bundle the
+# image ships at /etc/ssl/certs/ca-certificates.crt (libcurl's built-in default
+# here). --insecure puts -k back for one run, for a private mirror with a
+# self-signed certificate; nothing else ever sets it. GHSA-fjf7-9x3v-6mj6.
+curl_insecure=
 
 echo_c() {
 	# 31 red, 32 green, 33 yellow, 34 blue, 35 magenta, 36 cyan, 37 white, 38 grey
@@ -379,10 +384,58 @@ do_wipe_overlay() {
 	set_progress flash_eraseall $jffs2 "$(get_device "rootfs_data")"
 }
 
+# curl options for one URL. An https URL may redirect (a GitHub release asset
+# does), but never down to plain http: a verified connection that hands the
+# transfer to an unverified one has verified nothing.
+tls_opts() {
+	case "$1" in https://*) echo "--proto-redir =https" ;; esac
+	echo "$curl_insecure"
+}
+
+# The clock is part of certificate verification: a certificate is valid between
+# two dates, and a camera with no RTC boots at its build stamp (or fake-hwclock's
+# last checkpoint), so behind a network that blocks NTP the fetch fails with
+# BADCERT_FUTURE. That failure is what made `-k` look necessary (majestic-webui
+# #44, #121). Take the Date header of a plain-HTTP HEAD instead, as htpdate
+# does, and step the clock FORWARD only: a spoofed header can move the clock
+# ahead, which validates no certificate the bundle does not already trust.
+# Returns 0 only when the clock moved, so the caller knows a retry is worth it.
+clock_from_http() {
+	local hdr now web
+	hdr=$(curl -s -m 15 -I --proto =http "http://${MANIFEST_URL#*://}" 2>/dev/null \
+		| sed -n 's/^[Dd]ate: //p' | tr -d '\r')
+	web=$(TZ=UTC0 date -D '%a, %d %b %Y %H:%M:%S' -d "${hdr% GMT}" +%s 2>/dev/null)
+	now=$(date +%s)
+	[ -n "$web" ] && [ "$web" -gt "$now" ] || return 1
+	date -s "@$web" >/dev/null 2>&1 || return 1
+	echo_c 33 "Clock was behind; set from the HTTP Date header: $(date)"
+}
+
+# Reachability and trust, before anything is downloaded. Kept apart from the
+# download, which streams into tar where curl's exit status is lost in the
+# pipe, and because a certificate failure must not read as "Check your
+# network!" -- the two have different fixes.
+probe_url() {
+	local rc
+	curl --connect-timeout 30 -m 60 -s -o /dev/null $(tls_opts "$1") "$1"
+	rc=$?
+	if [ "$rc" -eq 60 ] && clock_from_http; then
+		curl --connect-timeout 30 -m 60 -s -o /dev/null $(tls_opts "$1") "$1"
+		rc=$?
+	fi
+	case "$rc" in
+		0) ;;
+		60) die "Certificate verification failed for $1
+The clock reads $(date). If that is wrong, fix it first (ntpd -Nnq, or date -s).
+For a private server with a self-signed certificate, add --insecure." ;;
+		77) die "Cannot read the CA bundle /etc/ssl/certs/ca-certificates.crt. Add --insecure to proceed without verification." ;;
+		*) die "Check your network!" ;;
+	esac
+}
+
 fetch_manifest() {
-	[ "$(curl -o /dev/null -s -k -w '%{http_code}\n' "$MANIFEST_URL")" = "000" ] \
-		&& die "Check your network!"
-	curl --connect-timeout 30 -s -k -m 60 -L "$MANIFEST_URL" -o "$MANIFEST_CACHE" \
+	probe_url "$MANIFEST_URL"
+	curl --connect-timeout 30 -s -m 60 -L $(tls_opts "$MANIFEST_URL") "$MANIFEST_URL" -o "$MANIFEST_CACHE" \
 		|| die "Cannot fetch manifest $MANIFEST_URL"
 }
 
@@ -446,7 +499,7 @@ download_firmware() {
 		fi
 		[ -z "$url" ] && url=$(fw_printenv -n upgrade || echo "https://github.com/OpenIPC/${repo:-builder}/releases/download/latest/openipc.$build.tgz")
 		echo "Download from $url"
-		[ "$(curl -o /dev/null -s -k -w '%{http_code}\n' "$url")" = "000" ] && die "Check your network!"
+		probe_url "$url"
 		# Show a transfer bar so the (silent, up-to-2-min) download doesn't look
 		# stuck — over /ws/upgrade this also gives the WebUI something to stream
 		# (issue #120). `-s` (silent_update) opts back out for a quiet console run.
@@ -460,8 +513,8 @@ download_firmware() {
 		# only once the transfer has genuinely stalled, so a slow-but-progressing
 		# link completes. -m stays as a far outer backstop against a trickle that
 		# never trips the stall check.
-		curl --connect-timeout 30 $dl_meter -k --speed-limit 1024 --speed-time 60 -m 1800 \
-			-L "$url" -o - | gzip -d | tar xf - -C /tmp && echo_c 32 "Received and unpacked" || die "Cannot retrieve $url"
+		curl --connect-timeout 30 $dl_meter --speed-limit 1024 --speed-time 60 -m 1800 \
+			-L $(tls_opts "$url") "$url" -o - | gzip -d | tar xf - -C /tmp && echo_c 32 "Received and unpacked" || die "Cannot retrieve $url"
 	fi
 	if [ "1" != "$skip_md5" ]; then
 		(cd /tmp && md5sum -s -c *.md5sum) || die "Wrong checksum!"
@@ -809,8 +862,11 @@ set_progress() {
 sync_time() {
 	echo_c 37 "\nSynchronizing time"
 	# Bound the sync: with no reachable NTP server `ntpd -q` can block for
-	# minutes and strand the upgrade at this step (WebUI issue #120). Everything
-	# after this fetches over `curl -k`, so an unsynced clock is not fatal.
+	# minutes and strand the upgrade at this step (WebUI issue #120). An
+	# unsynced clock is still not fatal: every fetch after this verifies the
+	# server certificate, and when that fails on the date probe_url falls back
+	# to the HTTP Date header (clock_from_http) rather than to skipping the
+	# verification.
 	if command -v timeout >/dev/null 2>&1; then
 		timeout 30 ntpd -Nnq
 	else
@@ -826,7 +882,14 @@ self_update() {
 		# pre-patch master copy would reject --web. Time is synced; carry on.
 		[ "1" = "$web_update" ] && return
 		echo -e "\nChecking for sysupgrade update..."
-		curl -s -k -L -o /tmp/sysupgrade "https://raw.githubusercontent.com/OpenIPC/firmware/master/general/overlay/usr/sbin/sysupgrade"
+		# What lands in /tmp/sysupgrade is exec'd as root a few lines down, so:
+		# verified TLS, https only (no redirect may step down to http), -f so an
+		# error page is not kept, and staged through a rename so a transfer that
+		# died half-way cannot leave a truncated script that still carries the
+		# shebang and a foreign scr_version.
+		curl -s -f -L --proto =https --proto-redir =https $curl_insecure -o /tmp/sysupgrade.part \
+			"https://raw.githubusercontent.com/OpenIPC/firmware/master/general/overlay/usr/sbin/sysupgrade" \
+			&& mv /tmp/sysupgrade.part /tmp/sysupgrade
 		if [ -f /tmp/sysupgrade ] && grep -q "#!/bin/sh" /tmp/sysupgrade; then
 			dstv=$(grep scr_version /tmp/sysupgrade | head -1 | cut -f 2 -d '=')
 			if ! [ "$scr_version" = "$dstv" ]; then
@@ -988,6 +1051,9 @@ Where:
                         rewrites the flash the camera is running from, which
                         no running system survives.
   -z, --no_update       Do not update self.
+      --insecure        Skip TLS certificate verification for this run: a
+                        private mirror with a self-signed certificate. Never
+                        needed for OpenIPC's own servers.
       --no_ramfs        Flash from the rootfs instead of moving into RAM first.
                         Reinstates the failure this guards against; for board
                         bring-up only.
@@ -1157,6 +1223,15 @@ for i in "$@"; do
 
 		-z | --no_update)
 			skip_selfupdate=1
+			shift
+			;;
+
+		--insecure)
+			# Only for a mirror whose certificate the bundle cannot verify. With
+			# this set a man-in-the-middle can hand the camera anything, including
+			# the script self_update execs, so say so where it cannot be missed.
+			curl_insecure=-k
+			echo_c 31 "--insecure: TLS certificates will NOT be verified this run"
 			shift
 			;;
 

--- a/general/package/comgt/files/mywifi_tg.sh
+++ b/general/package/comgt/files/mywifi_tg.sh
@@ -18,7 +18,7 @@ send() {
   #
   [ -z "${NOMER}" ] && NOMER="anonymouse"
   #
-  curl -k -o - --connect-timeout 30 --max-time 30 -X POST \
+  curl -o - --connect-timeout 30 --max-time 30 -X POST \
     https://api.telegram.org/bot${TOKEN}/sendMessage -d chat_id="${RUPOR}" -d disable_notification="true" -d text="${ALARM} ${NOMER} | ${SDATE}" >/dev/null 2>&1
   #
   logger -t ringer "${STAMP} Received ring from: ${NOMER} - ${MYWIFI}"


### PR DESCRIPTION
## Problem

Every online fetch in `sysupgrade` passes `curl -k`: the manifest probe and fetch, the firmware probe and download, and the self-update that pulls the current script from GitHub and `exec`s it as root after checking only for a `#!/bin/sh` line and a differing `scr_version`. The `.tgz` is checked only by the md5sum it carries inside itself. Anything on the path between a camera and GitHub can therefore hand it a firmware image or a script to run as root during any operator-triggered update, including the WebUI's. Reported privately as GHSA-fjf7-9x3v-6mj6, with a lab PoC that made `sysupgrade -k -r` exec an attacker-served script as uid 0.

The bundle needed to verify already ships: `general/overlay/etc/ssl/certs/ca-certificates.crt` has been in every image since 2021 and libcurl is built with it as its default, and it carries every root the GitHub hosts chain to. The `-k` dates from the stale-clock failures on cameras without an RTC (majestic-webui #44, #121): a camera booting at its build date rejects GitHub's certificate with `BADCERT_FUTURE`. Affects every board.

This change:

- drops `-k` from all five fetches; `--insecure` puts it back for one run, with a red warning, for a private mirror with a self-signed certificate
- an https URL never redirects down to plain http (`--proto-redir =https`; a GitHub release asset redirects over https, so this costs nothing)
- a certificate failure is reported as one, with the clock and the way out, instead of "Check your network!"
- when the failure is the clock and NTP is unreachable, the probe takes the `Date:` header of a plain-HTTP HEAD, steps the clock forward only, and retries once, so an NTP-blocked network and the WebUI path (which cannot pass flags) keep working without disabling verification
- `self_update` fetches https-only with `-f` and stages the download through a rename, so a transfer that died half-way can no longer be exec'd
- `comgt/files/mywifi_tg.sh` drops its `-k` too (it posted the Telegram bot token over an unverified connection)
- `test_sysupgrade.sh` gains five behaviour cases (curl exit 60/77/7, the `--insecure` warning) and six drift assertions, including one that fails on any literal `curl ... -k`

`scr_version` 1.0.62 -> 1.0.63. Signing of manifests and images, and dropping the exec of downloaded code, are a separate follow-up.

## Hardware tested on

hi3516ev300 (lab board, `BUILD_PLATFORM=hi3516ev300_lite_xm-85h50ai`, running nightly-20260904-605fa9d, curl 7.76.0 / mbedTLS 2.25.0).

Off-board: `bash .github/scripts/test_sysupgrade.sh` 119 ok / 0 fail; `STRICT=1 test_shell_parse.sh` and `STRICT=1 test_strip_shell_comments.sh` clean; `ci-matrix.py --stdin` selects every board (overlay change).

## Evidence

Before:

```
# the shipped curl, no -k, against every host sysupgrade fetches from: verification works with the shipped bundle
https://openipc.github.io/firmware/manifest.flat                    http=200 ssl_verify=0 bytes=1183117
https://raw.githubusercontent.com/.../general/overlay/usr/sbin/sysupgrade  http=200 ssl_verify=0 bytes=57073
https://github.com/OpenIPC/firmware/releases/download/latest/openipc.hi3516ev300-nor-lite.tgz (-L --proto-redir =https)
    http=206 final=https://release-assets.githubusercontent.com/... verify=0
https://self-signed.badssl.com/   curl: (60) Cert verify failed: BADCERT_NOT_TRUSTED   exit=60

# the failure that made -k look necessary, and sysupgrade's own sync_time repairing it
# date -s "2025-01-01 00:00:00"
clock=Wed Jan  1 00:00:00 UTC 2025  curl: (60) Cert verify failed: BADCERT_FUTURE   exit=60
ntpd: setting time to 2026-09-06 15:40:28.699531 (offset +53019626.675908s)
clock=Sun Sep  6 15:40:28 UTC 2026  http=200

# an https->http redirect: what -L alone does today vs. the pin
curl -L                       'https://httpbin.org/redirect-to?url=http://example.com/'  http=200 final=http://example.com/  exit=0
curl -L --proto-redir =https  'https://httpbin.org/redirect-to?url=http://example.com/'  curl: (1) Protocol "http" not supported or disabled in libcurl  exit=1
```

After (patched script copied to the board as /tmp/su):

```
# verified manifest path
# sh /tmp/su --list-builds=3
Available builds for hi3516ev300_lite_xm-85h50ai (newest first):
  * nightly-20260904-605fa9d
    nightly-20260903-605fa9d
    nightly-20260901-bac7c69

# clock set back to 2025-01-01, no NTP on this path: the HTTP Date fallback
# sh /tmp/su --list-builds=2
Clock was behind; set from the HTTP Date header: Sun Sep  6 15:53:37 UTC 2026
Available builds for hi3516ev300_lite_xm-85h50ai (newest first):
  * nightly-20260904-605fa9d
    nightly-20260903-605fa9d

# sh /tmp/su --insecure --list-builds=1
--insecure: TLS certificates will NOT be verified this run
Available builds for hi3516ev300_lite_xm-85h50ai (newest first):
  * nightly-20260904-605fa9d

# full run (copy's scr_version set equal to master's so the same-version check keeps this copy in control)
# sh /tmp/su62 --build=nightly-20260904-605fa9d
OpenIPC System Updater v1.0.62
Synchronizing time
Sun Sep  6 16:00:41 UTC 2026
Checking for sysupgrade update...
Same version. No update required.
Stop services, sync files, free up memory
...
Resolved nightly-20260904-605fa9d for hi3516ev300_lite_xm-85h50ai
Download from https://github.com/OpenIPC/builder/releases/download/nightly-20260904-605fa9d/hi3516ev300_lite_xm-85h50ai-nor.tgz
######################################################################## 100.0%
Received and unpacked
Protected: flashing continues even if this terminal disconnects.
Moving the flash phase into RAM
Flashing from RAM (pid 1160)
Verifying rootfs from /tmp/rootfs.squashfs.hi3516ev300
SoC OK
Same version, nothing to update
Update kernel from /tmp/uImage.hi3516ev300
SoC OK
Same version, nothing to update
Unconditional reboot

# after the reboot
 16:01:26 up 0 min,  load average: 0.49, 0.12, 0.04
BUILD_ID=nightly-20260904-605fa9d
majestic pid: 864

# Qodo's finding (second commit): a script left in /tmp by an earlier run must never be run when this
# run's fetch fails. Stale /tmp/sysupgrade planted (scr_version=0.0.0, prints STALE SCRIPT RAN, exit 42),
# raw.githubusercontent.com pinned to 127.0.0.1 in /etc/hosts so the fetch fails, nothing flashable given:
# sh /tmp/su --url=https://127.0.0.1:1/nothing.tgz
Checking for sysupgrade update...
Version checking failed, proceeding with the installed version.
Download from https://127.0.0.1:1/nothing.tgz
Check your network! Aborting.
stale file present after run: no  .part present: no
```

## Scope

- [x] No kernel patches under `general/package/all-patches/linux/` (those go to [OpenIPC/linux](https://github.com/OpenIPC/linux))
- [x] No files specific to a single retail camera model (those go to [OpenIPC/builder](https://github.com/OpenIPC/builder))
- [x] No probing or bring-up tooling (that goes to [OpenIPC/ipctool](https://github.com/OpenIPC/ipctool))
- [x] Nothing under `general/overlay/` or in a shared `load_<vendor>` script hardcodes a value specific to my board
- [x] Package sources come from an OpenIPC repository, and any version bump keeps at least the specificity of the pin it replaces (a new package should pin a full 40-character SHA)
- [x] No `LD_PRELOAD`, and no binaries that cannot be rebuilt from source
- [x] New code is selected by a defconfig, so CI actually builds it
