### PR TITLE
hisi cv200: load the cipher module, so /dev/cipher exists

### DIFF
--- a/general/package/hisilicon-osdrv-hi3516cv200/files/script/load_hisilicon
+++ b/general/package/hisilicon-osdrv-hi3516cv200/files/script/load_hisilicon
@@ -265,10 +265,28 @@ insert_ko() {
 
         insmod hi_mipi.ko
         insmod wdt.ko #nodeamon=1
+
+        # Cipher engine -> /dev/cipher. This package has always shipped the
+        # module in kmod/ and never inserted it, so the device node never
+        # appeared and userspace that can use the engine silently did without.
+        #
+        # The module is the vendor prebuilt already in kmod/, so it is
+        # hi_cipher rather than an open_* build, and insmod rather than
+        # modprobe like everything else in this script. Its only dependency is
+        # open_mmz, loaded by insert_mmz far above.
+        #
+        # Measured on an hi3518ev200 (27 MB of RAM): 180 kB of MemFree, 72 kB
+        # of MemAvailable, and MMZ untouched -- this is kernel memory.
+        # `|| true` because a camera whose image predates the module in kmod/
+        # has nothing to load, and that must not turn sensor bring-up into a
+        # failure.
+        insmod hi_cipher.ko 2>/dev/null || true
+
         echo "==== Your input Sensor type is $SENSOR ===="
 }
 
 remove_ko() {
+        rmmod -w hi_cipher 2>/dev/null
         rmmod -w open_wdt
         rmmod -w open_sys_config
         remove_audio


### PR DESCRIPTION
## Problem

`hisilicon-osdrv-hi3516cv200` has always shipped `hi_cipher.ko` in `files/kmod/` and never inserted it, so `/dev/cipher` never appeared on these boards. The hardware crypto engine was simply unavailable to userspace, on a camera where the module was sitting on the filesystem the whole time — the only missing piece was the line that loads it.

Gen 4 already does the equivalent with `modprobe open_cipher` in the ev200 script. This is the same idea reaching the same device node by the means this board already has.

## Hardware tested on

hi3518ev200 (jxf22 sensor), 27 MB of RAM. Both captures below are from a real boot at 21 s uptime, so they are directly comparable — stock script first, patched script second, nothing done by hand in either.

## Evidence

Before:

```
$ lsmod | grep -c cipher
0
$ ls /dev/cipher
ls: /dev/cipher: No such file or directory
$ free
              total        used        free      shared  buff/cache   available
Mem:          27496       12828        1424        1380       13244       10748
```

After:

```
$ lsmod | grep cipher
hi_cipher              75618  0
open_mmz               18808 11 hi_cipher,hi3518e_aenc,hi3518e_ao,...
$ ls -la /dev/cipher
crw-rw----    1 root     root       10,  52 Sep  7 15:15 /dev/cipher
$ free
              total        used        free      shared  buff/cache   available
Mem:          27496       12796        1316        1380       13384       10760
$ pgrep -l majestic
961 majestic
$ tail -1 /proc/media-mem
 total size=32768KB(32MB),used=468KB(0MB + 468KB),remain=32300KB(31MB + 556KB),zone_number=1,block_number=11
```

**Cost.** `MemAvailable` is unchanged within noise, 10748 → 10760 kB. `MemFree` costs about 108 kB; a separate isolated measurement (insmod with caches dropped) put it at 180 kB of `MemFree` and 72 kB of `MemAvailable`. MMZ is untouched — this is kernel memory, not media memory. The camera streams normally afterwards.

## Implementation notes

`insmod` rather than `modprobe` because every other load in this script is `insmod`, and the file is the vendor prebuilt already in `kmod/` rather than an `open_*` build — so neither half of the "insmod where the tree uses modprobe, or an OpenSDK module not named open_*" rule applies here. Its one dependency, `open_mmz`, is loaded by `insert_mmz` far above. `|| true` so a camera whose image predates the module in `kmod/` finds nothing and still brings its sensor up. Matching `rmmod -w hi_cipher` added at the top of `remove_ko`.

## Scope

- [x] No kernel patches under `general/package/all-patches/linux/`
- [x] No files specific to a single retail camera model
- [x] No probing or bring-up tooling
- [x] Nothing under `general/overlay/` or in a shared `load_<vendor>` script hardcodes a value specific to my board
- [x] Package sources come from an OpenIPC repository, and any version bump keeps at least the specificity of the pin it replaces
- [x] No `LD_PRELOAD`, and no binaries that cannot be rebuilt from source
- [x] New code is selected by a defconfig, so CI actually builds it
