### PR TITLE
ntpd: put /etc/ntp.conf back when something has deleted it

### DIFF
--- a/general/overlay/etc/init.d/S49ntpd
+++ b/general/overlay/etc/init.d/S49ntpd
@@ -36,16 +36,27 @@ DAEMON_ARGS="-n -S /usr/sbin/ntpd-script"
 restore_conf() {
 	[ -f "$CONF" ] && return 1
 	[ -f "$ROM_CONF" ] || return 1
-	# Written beside the target and renamed in, so an interrupted boot leaves
-	# either no file - which is what we already had - or the whole list, never
-	# half a hostname that would read as configured and resolve to nothing.
+	tmp="$CONF.$$"
+	# Written beside the target and published as one step, so an interrupted
+	# boot leaves either no file - which is what we already had - or the whole
+	# list, never half a hostname that would read as configured and resolve to
+	# nothing.
+	#
+	# `ln` and not `mv`, because the intent is create-if-absent and link() is
+	# the only primitive that says exactly that: it fails with EEXIST instead
+	# of overwriting. The test above cannot stand in for it - boot is
+	# single-threaded, but this script is run by hand too, and a `restart`
+	# racing a WebUI save that has just written its own list would otherwise
+	# replace it with the defaults. The pid in the temporary name keeps two
+	# such runs off each other as well.
+	#
 	# The mode is set rather than inherited: busybox cp takes the source mode
-	# through open(), so it comes out masked by whatever umask the caller had,
-	# and this script is run by hand as often as it is run by init.
-	if cp "$ROM_CONF" "$CONF.new" && chmod 644 "$CONF.new" && mv "$CONF.new" "$CONF"; then
+	# through open(), so it comes out masked by whatever umask the caller had.
+	if cp "$ROM_CONF" "$tmp" && chmod 644 "$tmp" && ln "$tmp" "$CONF"; then
+		rm -f "$tmp"
 		return 0
 	fi
-	rm -f "$CONF.new"
+	rm -f "$tmp"
 	return 1
 }
 

--- a/general/overlay/etc/init.d/S49ntpd
+++ b/general/overlay/etc/init.d/S49ntpd
@@ -1,10 +1,53 @@
 #!/bin/sh
 
 DAEMON="ntpd"
+CONF="/etc/ntp.conf"
+# The copy the image shipped. general/overlay/init pivots the read-only rootfs
+# to /rom before mounting the overlay over it, so on a flash root - and on an
+# nfs root mounted ro - this is the original, underneath whatever the overlay
+# has since done to $CONF. On a plain rw rootfs it does not exist, and nothing
+# can have masked $CONF there either.
+ROM_CONF="/rom$CONF"
 # -S feeds sync events (step, stratum, periodic, unsync) to the software
 # RTC so a fresh sync is checkpointed at once instead of waiting for the
 # next periodic save - see /usr/sbin/fake-hwclock.
 DAEMON_ARGS="-n -S /usr/sbin/ntpd-script"
+
+# busybox ntpd carries no built-in peers: it reads $CONF and, with the file
+# absent, prints its usage and exits 1. A camera that loses that file therefore
+# loses its clock at every boot from then on - and losing it is one `rm` away
+# and permanent, because deleting a file that lives in the read-only lower
+# layer frees nothing and writes a whiteout over it instead, which survives
+# both reboot and sysupgrade. The WebUI's time page did exactly that whenever
+# its server boxes were submitted empty (majestic-webui#403); a lab ssc30kq ran
+# 863 minutes behind for a fortnight, ntpd exiting seconds after every boot,
+# with a badge on the dashboard the only thing anywhere that said so.
+#
+# Put the file back rather than pass -p peers on the command line. -p would
+# start this daemon and leave the file missing, so `ntpd -q` in
+# udhcpc/default.script and in sysupgrade's sync_time would go on failing, the
+# WebUI would go on reporting no NTP configuration, and the camera would sit
+# one bug away from the same fault forever. Restoring heals it once, and every
+# reader of the file agrees again afterwards.
+#
+# Only start() calls this, which is after S45setupenv on an nfs root: a build
+# or DHCP-supplied server written there is already in place and is left alone.
+# Returns 0 only when it actually put the file back, so start() can say so.
+restore_conf() {
+	[ -f "$CONF" ] && return 1
+	[ -f "$ROM_CONF" ] || return 1
+	# Written beside the target and renamed in, so an interrupted boot leaves
+	# either no file - which is what we already had - or the whole list, never
+	# half a hostname that would read as configured and resolve to nothing.
+	# The mode is set rather than inherited: busybox cp takes the source mode
+	# through open(), so it comes out masked by whatever umask the caller had,
+	# and this script is run by hand as often as it is run by init.
+	if cp "$ROM_CONF" "$CONF.new" && chmod 644 "$CONF.new" && mv "$CONF.new" "$CONF"; then
+		return 0
+	fi
+	rm -f "$CONF.new"
+	return 1
+}
 
 # Find the daemon by name, never through a pidfile. Given -p, busybox
 # start-stop-daemon inspects only the pid that file holds and never scans
@@ -18,6 +61,7 @@ running() {
 }
 
 start() {
+	restore_conf && echo "Restored $CONF from $ROM_CONF"
 	echo -n "Starting $DAEMON: "
 	start-stop-daemon -b -S -q -x "$DAEMON" -- $DAEMON_ARGS
 	case $? in


### PR DESCRIPTION
## Problem

A lab **ssc30kq** had been showing `⚠ camera -863m` on the WebUI dashboard. Its clock was 14 h 23 m behind, and had been since 24 August. The rate was fine — 61 s advanced over 60 host seconds — so it was a pure offset that nothing was correcting.

`ntpd` was not running, and starting it by hand said `OK` and then it was gone:

```
# ntpd -n -d -S /usr/sbin/ntpd-script
ntpd: /etc/ntp.conf: No such file or directory
<usage>                                       exit=1
```

busybox ntpd carries no built-in peers. `S49ntpd` runs it as `-n -S /usr/sbin/ntpd-script`, with no `-p`, so `/etc/ntp.conf` is its only source of servers — and with the file gone **every** sync path on the camera is dead at once: this daemon, the `timeout -k 2 10 ntpd -q -N -n` step in `udhcpc/default.script`, and `sync_time`'s `ntpd -Nnq` in `sysupgrade`. These boards have no battery-backed RTC, so `fake-hwclock` then restored the already-wrong checkpoint at the next boot and the error compounded instead of healing.

`/rom/etc/ntp.conf` was intact the whole time. The overlay said what had happened:

```
/overlay/root/etc/ntp.conf   c--------- 1 root root  0, 0  Aug 24 11:48
```

A `c 0,0` char device is an overlayfs whiteout. `general/overlay/init` pivots the read-only squashfs to `/rom` and mounts jffs2 over it, so deleting a file that lives in the lower layer frees nothing — it masks it, permanently, through reboots and through `sysupgrade`, which does not touch the overlay. `firstboot` is the only thing that clears one.

The WebUI's time page wrote it: `time.cgi` did an unconditional `rm -f /etc/ntp.conf` before rebuilding the file from its form, so any save with the server boxes empty destroyed it. That half is fixed in **OpenIPC/majestic-webui#403**. This is the other half — so that no future bug of that shape can cost a camera its clock, and so the cameras already out there repair themselves on their next boot.

## The change

`start()` restores `/etc/ntp.conf` from `/rom` before launching the daemon, and says so when it does.

**Restoring the file rather than passing `-p` peers.** `-p` would start this daemon and leave the file missing, so `ntpd -q` in `udhcpc/default.script` and in `sysupgrade` would go on failing, the WebUI would go on reporting no NTP configuration, and the camera would sit one bug away from the same fault forever. Restoring heals it once and every reader of the file agrees again afterwards.

It is a **no-op whenever the file exists**, so it never overwrites a server list an operator set — or the one `S45setupenv` writes from `@NTP_SERVER@`/DHCP on an nfs root, which runs at S45, before this. Written to `$CONF.new` and renamed in, so an interrupted boot leaves either no file (what it already had) or the whole list, never half a hostname that reads as configured and resolves to nothing. `/rom` does not exist on a plain rw rootfs, and nothing can have masked the file there either, so the `-f` guard is the whole story for that case.

The first boot after a loss still misses the early `ntpd -q` in `udhcpc`, which runs inside `ifup` in S40network — before this. That costs clock accuracy at boot on that one boot and nothing else: the query fails instantly rather than blocking (it never gets as far as resolving), S49ntpd restores the file seconds later, and the daemon syncs. Every boot after is entirely normal.

## Hardware tested on

**ssc30kq** (SigmaStar infinity6e, IMX335), `ssc30kq_lite`, build `nightly-20260907-238812e` — the board that had the fault, put back into it deliberately.
**hi3516av300** (HiSilicon, IMX415), `hi3516av300_lite` — a second vendor tree and a healthy board, to check the no-op path.

Checks that need no build or camera, on the final file: `test_shell_parse.sh` and `test_strip_shell_comments.sh` (STRICT=1) pass over all 138 shipped scripts, `ci-matrix.py --self-test` ok. The selector reports `general/overlay/etc/init.d/S49ntpd affects every board` — 99 platforms, which is right for a shared overlay file.

## Evidence

Before — ssc30kq as found, 6 minutes after a boot:

```
# ps w | grep [n]tpd
# ls -la /overlay/root/etc/ntp.conf
c---------    1 root     root        0,   0 Aug 24 11:48 /overlay/root/etc/ntp.conf
# ls /etc/ntp.conf
ls: /etc/ntp.conf: No such file or directory
# date -u
Mon Sep  7 22:39:09 UTC 2026        <- host: Tue Sep  8 13:02:15 UTC 2026 (863 min)
```

After — same board, fault recreated (`rm /etc/ntp.conf` through the merged path, clock wound back 863 min, wrong time checkpointed to the software RTC), then rebooted. Nothing else touched, no SSH intervention:

```
uptime:        74s
/etc/ntp.conf: -rw-r--r--    1 root     root           116 Sep  8 13:36 /etc/ntp.conf
upper entry:   -rw-r--r--    1 root     root           116 Sep  8 13:36 /overlay/root/etc/ntp.conf
ntpd:          running (pid 686)
cam clock:     Tue Sep  8 13:37:25 UTC 2026
host clock:    Tue Sep  8 13:37:25 UTC 2026
```

The whiteout is gone — a regular 644 file stamped at boot — and the daemon is up.

The `start` path, printed:

```
# rm -f /etc/ntp.conf
# ls -la /overlay/root/etc/ntp.conf
c---------    1 root     root        0,   0 Sep  8 13:34 /overlay/root/etc/ntp.conf
# /etc/init.d/S49ntpd start
Restored /etc/ntp.conf from /rom/etc/ntp.conf
Starting ntpd: OK
# ls -la /overlay/root/etc/ntp.conf
-rw-r--r--    1 root     root           116 Sep  8 13:34 /overlay/root/etc/ntp.conf
```

No-op on a camera that has the file — both boards:

```
ssc30kq       --- healthy: start is a no-op on the file
              Starting ntpd: OK
                unchanged: yes
hi3516av300   --- healthy: start is a no-op on the file
              Starting ntpd: OK
                unchanged: yes
```

hi3516av300, same fault, same repair:

```
  upper: c---------    1 root     root        0,   0 Sep  8 13:37 /overlay/root/etc/ntp.conf
Restored /etc/ntp.conf from /rom/etc/ntp.conf
Starting ntpd: OK
  upper: -rw-r--r--    1 root     root           116 Sep  8 13:37 /overlay/root/etc/ntp.conf
  ntpd:  running
  clock: Tue Sep  8 13:37:42 UTC 2026     <- host: Tue Sep  8 13:37:42 UTC 2026
```

Both boards were left on the stock four `pool.ntp.org` servers, in sync, with the test copy of the script unlinked from the overlay's upper directory so `/etc/init.d/S49ntpd` reads from `/rom` again (md5 verified against `/rom`).

## Scope

- [x] No kernel patches under `general/package/all-patches/linux/` (those go to [OpenIPC/linux](https://github.com/OpenIPC/linux))
- [x] No files specific to a single retail camera model (those go to [OpenIPC/builder](https://github.com/OpenIPC/builder))
- [x] No probing or bring-up tooling (that goes to [OpenIPC/ipctool](https://github.com/OpenIPC/ipctool))
- [x] Nothing under `general/overlay/` or in a shared `load_<vendor>` script hardcodes a value specific to my board
- [x] Package sources come from an OpenIPC repository, and any version bump keeps at least the specificity of the pin it replaces (a new package should pin a full 40-character SHA)
- [x] No `LD_PRELOAD`, and no binaries that cannot be rebuilt from source
- [x] New code is selected by a defconfig, so CI actually builds it
