### PR TITLE
CI: the kernel is a moving ref too, so stop serving it from a month-old cache

### DIFF
--- a/.github/workflows/build-one.yml
+++ b/.github/workflows/build-one.yml
@@ -93,6 +93,21 @@ jobs:
             find "${BR2_DL_DIR}" -type f -regextype posix-extended \
               -regex '.*[-.](HEAD|master|main|dist)\.tar\.(gz|bz2|xz)' \
               -print -delete
+            # And the kernel, which the pattern above cannot see. Every board
+            # fetches it from openipc/linux/archive/<branch>.tar.gz -- 122 of the
+            # defconfigs -- so the filename is the BRANCH name, hisilicon-hi3516cv500
+            # .tar.gz or ingenic-t31.tar.gz. That is a moving ref with a constant
+            # name and no .hash, exactly the case this step exists for, but it
+            # ends in none of the four words above. A kernel fix merged today
+            # would otherwise wait for the monthly cache key to roll over before
+            # any nightly built it. Buildroot keeps custom kernel tarballs in the
+            # package's own dl subdirectory, so this reaches them and nothing else.
+            if [ -d "${BR2_DL_DIR}/linux" ]; then
+              find "${BR2_DL_DIR}/linux" -maxdepth 1 -type f -name '*.tar.gz' \
+                -print -delete
+            else
+              echo "no kernel archive cached yet -- nothing to refresh."
+            fi
           else
             echo "dl cache is cold (${BR2_DL_DIR} absent) -- nothing to refresh."
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -354,6 +354,21 @@ jobs:
             find "${BR2_DL_DIR}" -type f -regextype posix-extended \
               -regex '.*[-.](HEAD|master|main|dist)\.tar\.(gz|bz2|xz)' \
               -print -delete
+            # And the kernel, which the pattern above cannot see. Every board
+            # fetches it from openipc/linux/archive/<branch>.tar.gz -- 122 of the
+            # defconfigs -- so the filename is the BRANCH name, hisilicon-hi3516cv500
+            # .tar.gz or ingenic-t31.tar.gz. That is a moving ref with a constant
+            # name and no .hash, exactly the case this step exists for, but it
+            # ends in none of the four words above. A kernel fix merged today
+            # would otherwise wait for the monthly cache key to roll over before
+            # any nightly built it. Buildroot keeps custom kernel tarballs in the
+            # package's own dl subdirectory, so this reaches them and nothing else.
+            if [ -d "${BR2_DL_DIR}/linux" ]; then
+              find "${BR2_DL_DIR}/linux" -maxdepth 1 -type f -name '*.tar.gz' \
+                -print -delete
+            else
+              echo "no kernel archive cached yet -- nothing to refresh."
+            fi
           else
             echo "dl cache is cold (${BR2_DL_DIR} absent) -- nothing to refresh."
           fi


### PR DESCRIPTION
Merging a kernel fix (OpenIPC/linux#55 — the `himci` unbind oops, from #2384) and then asking what would have to happen for a nightly to actually contain it. The answer was **"wait until October"**.

## The gap

Every board fetches its kernel as a branch archive — 122 defconfigs:

```
BR2_LINUX_KERNEL_CUSTOM_TARBALL_LOCATION="https://github.com/openipc/linux/archive/$(OPENIPC_KERNEL).tar.gz"
```

so the download is named after the **branch**: `hisilicon-hi3516cv500.tar.gz`, `ingenic-t31.tar.gz`, `upstream-patches.tar.gz`. A moving ref, a constant filename, no `.hash` — exactly what the *Refresh moving-ref package downloads* step already exists to handle.

It just cannot see it:

```sh
-regex '.*[-.](HEAD|master|main|dist)\.tar\.(gz|bz2|xz)'
```

A branch called `hisilicon-hi3516cv500` ends in none of those four words. Since the dl cache is keyed on `date +%m` and `actions/cache` only saves on a key miss, buildroot kept unpacking whichever kernel was current when that month's snapshot was written — for up to four weeks, with nothing in the log to say so. Same failure the surrounding comment already documents for majestic and majestic-webui, with the kernel as the one package still exposed to it.

## The change

```sh
if [ -d "${BR2_DL_DIR}/linux" ]; then
  find "${BR2_DL_DIR}/linux" -maxdepth 1 -type f -name '*.tar.gz' -print -delete
else
  echo "no kernel archive cached yet -- nothing to refresh."
fi
```

Buildroot keeps a custom kernel tarball in the package's own dl subdirectory, so `dl/linux/*.tar.gz` reaches every board's kernel and nothing else. Applied to both `build.yml` and `build-one.yml`, which carry the same step.

Deliberately not silenced with `2>/dev/null || true`, for the reason the step gives two lines above: that is how it reported nothing for months while pointed at a directory that did not exist.

## Verification — the selector, against the real filenames

A tree with the names buildroot actually writes, run through the old pattern and the new one:

```
=== what the EXISTING refresh step deletes ===
dl/majestic.t31.lite.master.tar.bz2
dl/majestic-webui-dist.tar.gz
  ^ the kernel archives are untouched

=== what this PR adds ===
dl/linux/upstream-patches.tar.gz
dl/linux/ingenic-t31.tar.gz
dl/linux/hisilicon-hi3516cv500.tar.gz

=== and what it leaves alone (content-addressed, the cache's whole point) ===
dl/libevent-2.1.12-stable.tar.gz
```

That is the gap and the fix, demonstrated rather than asserted.

## Hardware evidence

- **Board:** hi3516av300 (hi3516cv500 family), `nightly-20260907-238812e`, kernel 4.9.37.
- **Symptom this delivers a fix for:** unbinding the SD host oopses the kernel, so a card that stops answering cannot be re-probed and needs a full board reboot.

This PR is CI-only and cannot itself change what runs on a camera; what it changes is *which kernel* a nightly bakes in. The behaviour it delivers is OpenIPC/linux#55, and that was built, flashed and tested on the board above.

**Before** — stock kernel, `echo -n 100f0000.himci.SD > /sys/bus/platform/drivers/himci/unbind`:

```
Unable to handle kernel paging request at virtual address c071edc4
pgd = de368000
[c071edc4] *pgd=8061941e(bad)
Internal error: Oops: 8000000d [#1] SMP ARM
CPU: 1 PID: 18128 Comm: sh Tainted: P           O    4.9.37 #1
PC is at 0xc071edc4
LR is at platform_drv_remove+0x24/0x3c
```

**After** — same board, same command, kernel rebuilt from `hisilicon-hi3516cv500` with #55, flashed to `mtd2` (readback md5 verified before reboot):

```
cycle 1: removed=yes back=yes new_oopses=0
cycle 2: removed=yes back=yes new_oopses=0
cycle 3: removed=yes back=yes new_oopses=0
cycle 4: removed=yes back=yes new_oopses=0
cycle 5: removed=yes back=yes new_oopses=0
```

and the card re-enumerates on each rebind:

```
himci: mmc host probe
mmc0: new ultra high speed SDR104 SDHC card at address 0001
mmcblk0: mmc0:0001 SD16G 29.2 GiB
```

with the freed-host lookup, read through `/proc/mci/mci_info`:

```
bound:    MCI0: pluged_connected / Type: SD card(SDHC) / Mode: UHS SDR104
unbound:  MCI0: invalid
rebound:  MCI0: pluged_connected
```

The camera was returned to the stock kernel afterwards and is running normally — majestic up, card mounted, WebUI 200, no oopses.

## Cost

One extra kernel download per build job — a few MB against a full firmware build. In exchange, a kernel fix merged today is in tonight's nightly instead of next month's.
