### PR TITLE
network: move the hwaddress bring-up fix into a hook, off every camera's flash

### DIFF
--- a/general/overlay/etc/network/if-pre-up.d/hwaddress
+++ b/general/overlay/etc/network/if-pre-up.d/hwaddress
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# A `hwaddress` in interfaces.d is applied by busybox ifupdown as part of one
+# command -- dhcp_up() runs `ip link set addr <mac> <iface> up` -- and busybox
+# `ip` sets the MAC through SIOCSIFHWADDR, which eth_mac_addr() refuses with
+# EBUSY on an interface that is already running. busybox `ip` dies on that
+# ioctl, ifupdown treats the failed command as fatal, and udhcpc is never
+# started: the camera boots with no lease and no address.
+#
+# That only bites where something brought the interface up before ifup did. On
+# rv1106 the vendor u-boot does, so eth0 is already running when S40network
+# gets there (#2382). Taking it down first lets the MAC set succeed. Where the
+# interface was still down -- gk7205v200 was measured, ADDRCONF(NETDEV_UP)
+# lands after the kernel hands off to init -- this changes nothing.
+#
+# Exits 0 whatever happens: a failure to bring the interface down is not worth
+# aborting ifup over, and dhcp_up() reports the real error a moment later.
+
+[ -n "$IF_HWADDRESS" ] || exit 0
+[ -e "/sys/class/net/$IFACE" ] || exit 0
+
+ip link set "$IFACE" down
+
+exit 0

--- a/general/overlay/etc/network/interfaces.d/eth0
+++ b/general/overlay/etc/network/interfaces.d/eth0
@@ -1,10 +1,2 @@
-# On rv1106 the vendor u-boot brings eth0 up early (it patches the derived MAC
-# into the DTB's local-mac-address, which the kernel applies), so by the time
-# ifup runs, eth0 is already up. busybox dhcp_up then issues a single
-# "ip link set addr <hwaddress> eth0 up" — which fails with SIOCSIFHWADDR
-# (a live interface's MAC cannot be changed), and ifup aborts before starting
-# udhcpc, leaving the board with no lease. Forcing the interface down in pre-up
-# lets that MAC set succeed; on SoCs where eth0 was already down it is a no-op.
 iface eth0 inet dhcp
-    pre-up ip link set eth0 down
     hwaddress ether $(fw_printenv -n ethaddr || echo 00:00:23:34:45:66)


### PR DESCRIPTION
## Problem

#2382 fixed rv1106 auto-DHCP by adding `pre-up ip link set eth0 down` to the shared
`general/overlay/etc/network/interfaces.d/eth0`, with seven lines of comment above it
explaining why. The explanation was accurate. It also shipped.

`general/scripts/rootfs_script.sh` discovers files to comment-strip **by shell shebang**
(`case "$(head -1 "${script}") in '#!'*sh*)`), plus one hardcoded exception, `/etc/profile`.
An ifupdown config file has no shebang, so it is never handed to
`strip-shell-comments.awk`, and all 541 comment bytes are rsynced verbatim into every image
on every SoC. Reported by a maintainer who built for Goke and found a paragraph about a
Rockchip bootloader in `/etc/network/interfaces.d/eth0` on a board that has never had one.

The underlying fix is worth keeping. busybox `dhcp_up()` applies a `hwaddress` as part of a
single command — `ip link set[[ addr %hwaddress%]] %iface% up` — and busybox `ip` sets the
MAC through `SIOCSIFHWADDR` (`libiproute/iplink.c: set_address()`), which `eth_mac_addr()`
refuses with `EBUSY` on a running interface. `xioctl` dies there, so the `up` never runs;
`iface_up()` treats the failed command as fatal and udhcpc is never started. That is
reachable on any SoC where something brings the interface up before `ifup` does.

So: keep the behaviour, move it — and its explanation — into
`/etc/network/if-pre-up.d/hwaddress`, which has a shebang and is therefore stripped at
build time. `run-parts /etc/network/if-pre-up.d` is the same `pre-up` phase as the inline
option it replaces, so the timing is unchanged.

The hook is also board-agnostic where the line it replaces named `eth0` outright: it acts
only on an interface that declares a `hwaddress` (ifupdown exports `IF_HWADDRESS` for it),
so `wg0`, `wlan0`, `eth1` and `usb0` return at the first line. It exits 0 unconditionally,
because a non-zero `pre-up` aborts `ifup` and `dhcp_up()` reports the real error anyway.

Shipped bytes for the pair: **667 → 210**.

## Hardware tested on

**gk7205v200** — "Goke GK7205V200 DEMO Board", lab board, femac built-in, `ethaddr` set in
the u-boot env. This is the SoC the report came from.

Tested by installing the exact shipped form of both files on the board, rebooting, and
letting a boot-time watchdog roll back to the shipped config if no default route appeared
within 60s. It did not fire.

**rv1106 was not re-verified** — the board is powered down and does not answer. The rv1106
half rests on #2382, which verified `ip link set eth0 down` before `dhcp_up()` fixes it
there, plus the `ifup -v` trace below showing the hook runs at the same point in the same
phase as the inline `pre-up` it replaces. If you would rather that be measured before this
lands, say so and I will hold it until the board is back.

## Evidence

Before — on the running gk7205v200, the file as the image ships it (667 bytes), next to the
`vlan` hook in the very next directory, which *does* have a shebang and *was* stripped:

```
# cat /etc/network/interfaces.d/eth0
# On rv1106 the vendor u-boot brings eth0 up early (it patches the derived MAC
# into the DTB's local-mac-address, which the kernel applies), so by the time
# ifup runs, eth0 is already up. busybox dhcp_up then issues a single
# "ip link set addr <hwaddress> eth0 up" — which fails with SIOCSIFHWADDR
# (a live interface's MAC cannot be changed), and ifup aborts before starting
# udhcpc, leaving the board with no lease. Forcing the interface down in pre-up
# lets that MAC set succeed; on SoCs where eth0 was already down it is a no-op.
iface eth0 inet dhcp
    pre-up ip link set eth0 down
    hwaddress ether $(fw_printenv -n ethaddr || echo 00:00:23:34:45:66)

# head -6 /etc/network/if-pre-up.d/vlan
#!/bin/sh
case "$IFACE" in
	vlan0*)
		vconfig set_name_type VLAN_PLUS_VID
		VLANID=$(echo $IFACE|sed "s/vlan0*//")
		;;
```

Why the maintainer has never hit the bug on Goke — userspace, not the kernel, brings eth0
up there, so it is down when `ifup` runs and the MAC set succeeds:

```
# dmesg | grep -n "using random MAC\|Freeing unused\|ADDRCONF(NETDEV_UP): eth0"
113:femac 10040000.ethernet: using random MAC address 0a:b8:57:ae:8f:a2
145:Freeing unused kernel memory: 196K (c04ab000 - c04dc000)
148:IPv6: ADDRCONF(NETDEV_UP): eth0: link is not ready
```

After — the two files as they reach the camera (93 + 117 bytes), and `ifup -v` showing the
hook running in the `pre-up` phase, before the MAC set and udhcpc:

```
# cat /etc/network/interfaces.d/eth0
iface eth0 inet dhcp
    hwaddress ether $(fw_printenv -n ethaddr || echo 00:00:23:34:45:66)

# cat /etc/network/if-pre-up.d/hwaddress
#!/bin/sh
[ -n "$IF_HWADDRESS" ] || exit 0
[ -e "/sys/class/net/$IFACE" ] || exit 0
ip link set "$IFACE" down
exit 0

# ifup -v eth0
run-parts /etc/network/if-pre-up.d
ip link set addr $(fw_printenv -n ethaddr || echo 00:00:23:34:45:66) eth0 up
udhcpc -x hostname:$(hostname) -A 0 -T 1 -t 5 -R -b -O search -p /var/run/udhcpc.eth0.pid -i eth0
udhcpc: started, v1.36.1
udhcpc: broadcasting discover
udhcpc: broadcasting select for 10.216.128.49, server 10.216.128.1
udhcpc: lease of 10.216.128.49 obtained from 10.216.128.1, lease time 2592000
```

After — cold boot with both files in place. Lease at 3s, and the MAC comes from `ethaddr`,
overriding the kernel's random `0a:b8:57:ae:8f:a2`, so the `hwaddress` path is doing its
job rather than being skipped:

```
uptime: 28s
lease ok after 3s                      <- rollback watchdog; it did not fire
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 ... link/ether 00:12:31:b9:9f:48
2: eth0    inet 10.216.128.49/24 brd 10.216.128.255 scope global eth0
default via 10.216.128.1 dev eth0
udhcpc pid 713
env:  00:12:31:b9:9f:48
live: 00:12:31:b9:9f:48
```

Off-camera checks:

```
$ STRICT=1 bash .github/scripts/test_shell_parse.sh | tail -2
checked 139 shell script(s)
all parsed clean under busybox ash
   (includes ok   ash  general/overlay/etc/network/if-pre-up.d/hwaddress)

$ STRICT=1 bash .github/scripts/test_strip_shell_comments.sh | tail -3
ok   139 shipped scripts parse identically after stripping (139394 bytes saved)
All strip-shell-comments checks passed.

$ python3 .github/scripts/ci-matrix.py --self-test
ci-matrix: self-test ok (99 boards, 135 packages, 56 cases)
```

Guard behaviour, with `ip` stubbed, confirming the non-ethernet interfaces return at line 1:

```
wg0 (no hwaddress)                          (no action)
wlan0 (no hwaddress)                        (no action)
eth0 hwaddress, iface absent                (no action)
eth0 hwaddress, iface present               -> ip link set <iface> down
```

## Scope

- [x] No kernel patches under `general/package/all-patches/linux/` (those go to [OpenIPC/linux](https://github.com/OpenIPC/linux))
- [x] No files specific to a single retail camera model (those go to [OpenIPC/builder](https://github.com/OpenIPC/builder))
- [x] No probing or bring-up tooling (that goes to [OpenIPC/ipctool](https://github.com/OpenIPC/ipctool))
- [x] Nothing under `general/overlay/` or in a shared `load_<vendor>` script hardcodes a value specific to my board
- [x] No `LD_PRELOAD`, and no binaries that cannot be rebuilt from source
- [x] New code is selected by a defconfig, so CI actually builds it
