### PR TITLE
sysupgrade: arm bootloader boot-count recovery, and disarm it once healthy

### DIFF
--- a/general/overlay/etc/init.d/S99bootok
+++ b/general/overlay/etc/init.d/S99bootok
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Disarm the bootloader's boot-count recovery once the camera has reached a
+# healthy userspace. sysupgrade sets upgrade_available=1 before a flash; a
+# U-Boot that supports boot-count recovery keeps counting boots until this
+# clears the flag, and reflashes a known-good image if a broken one never gets
+# here. On a U-Boot without boot-count logic the variable is ignored, so this
+# is a no-op beyond one environment read. A normal (unarmed) boot costs a
+# single fw_printenv and writes nothing.
+case "$1" in
+	start|"") ;;
+	*) exit 0 ;;
+esac
+
+command -v fw_printenv >/dev/null 2>&1 || exit 0
+[ "$(fw_printenv -n upgrade_available 2>/dev/null)" = "1" ] || exit 0
+
+# Armed: confirm the new image actually works before disarming. Wait for
+# majestic to come up -- an image built without majestic is healthy the moment
+# it boots this far. If majestic never appears, leave the flag set so U-Boot
+# escalates to recovery on the following boots instead of looping on an image
+# that boots but does not stream. Backgrounded so a slow or failing start never
+# holds up the rest of boot.
+{
+	i=0
+	while [ "$i" -lt 30 ]; do
+		if [ ! -x /usr/bin/majestic ] || pidof majestic >/dev/null 2>&1; then
+			fw_setenv upgrade_available 0 2>/dev/null
+			fw_setenv bootcount 0 2>/dev/null
+			exit 0
+		fi
+		sleep 2
+		i=$((i + 1))
+	done
+} &

--- a/general/overlay/etc/init.d/S99bootok
+++ b/general/overlay/etc/init.d/S99bootok
@@ -14,21 +14,36 @@ esac
 command -v fw_printenv >/dev/null 2>&1 || exit 0
 [ "$(fw_printenv -n upgrade_available 2>/dev/null)" = "1" ] || exit 0
 
-# Armed: confirm the new image actually works before disarming. Wait for
-# majestic to come up -- an image built without majestic is healthy the moment
-# it boots this far. If majestic never appears, leave the flag set so U-Boot
-# escalates to recovery on the following boots instead of looping on an image
-# that boots but does not stream. Backgrounded so a slow or failing start never
-# holds up the rest of boot.
+# Armed. Disarm only once the new image is PROVEN healthy -- and prove it,
+# don't just glimpse it: pidof sees majestic the instant S95majestic forks,
+# before the pipeline is up, so a streamer that crashes during startup would
+# look healthy for a moment. Require it to stay up across a sustained window;
+# if it dies the window restarts, and if it never holds we leave the flag armed
+# so U-Boot escalates to recovery instead of looping on an image that boots but
+# does not stream. An image built without majestic is healthy once it boots
+# this far. Backgrounded so nothing here holds up boot.
 {
-	i=0
-	while [ "$i" -lt 30 ]; do
+	need=8       # consecutive good checks (~16s) before trusting the image
+	ok=0
+	tries=0
+	while [ "$tries" -lt 90 ]; do
 		if [ ! -x /usr/bin/majestic ] || pidof majestic >/dev/null 2>&1; then
-			fw_setenv upgrade_available 0 2>/dev/null
-			fw_setenv bootcount 0 2>/dev/null
-			exit 0
+			ok=$((ok + 1))
+			if [ "$ok" -ge "$need" ]; then
+				if fw_setenv upgrade_available 0 2>/dev/null &&
+					fw_setenv bootcount 0 2>/dev/null; then
+					exit 0
+				fi
+				# Environment readable but not writable: say so, or every
+				# healthy boot silently leaves U-Boot counting toward recovery.
+				logger -s -t bootok "healthy but could not clear upgrade_available (U-Boot env not writable) -- bootloader will keep counting" 2>/dev/null
+				exit 0
+			fi
+		else
+			ok=0
 		fi
 		sleep 2
-		i=$((i + 1))
+		tries=$((tries + 1))
 	done
+	logger -s -t bootok "majestic did not stay up; leaving boot-count recovery armed" 2>/dev/null
 } &

--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -1341,6 +1341,23 @@ if [ "1" = "$skip_reboot" ] && [ "1" = "$root_on_flash" ] &&
 	sleep "$abort_wait"
 fi
 
+# Arm the bootloader's boot-count recovery for this flash. If the freshly
+# written image never reaches a healthy userspace, a U-Boot that supports
+# boot-count recovery falls back to reflashing a known-good image instead of
+# rebooting into the broken one for ever; S99bootok disarms this once majestic
+# is up. On an older or vendor-supplied U-Boot with no boot-count logic these
+# are unused environment variables it ignores, so arming is harmless there.
+# Set here, on the still-normal system, before enter_ramfs moves the MTD
+# environment out of reach.
+if command -v fw_setenv >/dev/null 2>&1; then
+	fw_setenv upgrade_available 1 2>/dev/null
+	fw_setenv bootcount 0 2>/dev/null
+	# A camera that ever ran the pre-verify U-Boot has verify=n saved in flash,
+	# where it still overrides the built-in default; drop the key so the kernel
+	# image is CRC-checked on boot again.
+	fw_setenv verify 2>/dev/null
+fi
+
 # Past this point we erase flash. A controlling-TTY death (SSH session drop,
 # stray Ctrl-C, etc.) must not kill flashcp mid-write — that leaves the rootfs
 # partition partially erased and unbootable. SIG_IGN is inherited across

--- a/general/overlay/usr/sbin/sysupgrade
+++ b/general/overlay/usr/sbin/sysupgrade
@@ -98,6 +98,13 @@ die() {
 	if [ "1" = "$flash_touched" ] || [ "1" = "$_ramfs_phase" ]; then
 		reboot_system
 	else
+		# Nothing was written, so the camera is unchanged: drop any recovery arm
+		# set before the flash phase, or a boot that never flashed would still be
+		# counted. (A failure AFTER enter_ramfs reboots via the branch above
+		# instead, and S99bootok disarms on the next healthy boot -- bootcount
+		# only advances one per reboot and the limit is several, so no false
+		# escalation.)
+		command -v fw_setenv >/dev/null 2>&1 && fw_setenv upgrade_available 0 2>/dev/null
 		restore_resources
 		# Only ever remove a lock this process owns. die() is reachable before
 		# create_lock has run (get_system_info, called from print_sysinfo, can
@@ -1350,12 +1357,16 @@ fi
 # Set here, on the still-normal system, before enter_ramfs moves the MTD
 # environment out of reach.
 if command -v fw_setenv >/dev/null 2>&1; then
-	fw_setenv upgrade_available 1 2>/dev/null
-	fw_setenv bootcount 0 2>/dev/null
+	if fw_setenv upgrade_available 1 2>/dev/null && fw_setenv bootcount 0 2>/dev/null; then
+		:
+	else
+		echo_c 33 "Warning: could not arm boot-count recovery (U-Boot env not writable?); the upgrade proceeds without it."
+	fi
 	# A camera that ever ran the pre-verify U-Boot has verify=n saved in flash,
 	# where it still overrides the built-in default; drop the key so the kernel
 	# image is CRC-checked on boot again.
-	fw_setenv verify 2>/dev/null
+	fw_setenv verify 2>/dev/null ||
+		echo_c 33 "Warning: could not clear a saved verify=n; a corrupt kernel may not be caught on boot."
 fi
 
 # Past this point we erase flash. A controlling-TTY death (SSH session drop,


### PR DESCRIPTION
## The problem

A U-Boot with boot-count recovery (the gk7205v200 bootloader just gained it) can reflash a known-good image when a freshly-written one never reaches a working userspace — the field brick where an interrupted upgrade left an image only a UART reflash could recover. But the bootloader half is **inert until userspace tells it** (a) a flash is in flight and (b), later, that the flash actually worked. This adds those two signals.

## Change

- **`sysupgrade`** sets `upgrade_available=1` (and `bootcount=0`) just before the flash — on the still-normal system, before the ramfs pivot moves the MTD env out of reach. It also drops any saved `verify=n` so a camera that once ran the pre-verify U-Boot gets its kernel CRC-checked again.
- **`S99bootok`** (new init hook) disarms it (`upgrade_available=0`) once the camera is healthy — majestic up, or no majestic on the image at all. If majestic never comes up it *leaves the flag set*, so the bootloader escalates to recovery on the following boots instead of looping on an image that boots but doesn't stream. The wait runs in the background (never holds up boot); an unarmed boot is a single `fw_printenv` with no write.

## Safe on older / vendor U-Boot

On a camera whose U-Boot has no boot-count logic, `upgrade_available` and `bootcount` are just unused env vars it ignores — arming/disarming them changes nothing about how those cameras boot. The recovery only activates where the bootloader knows what the flag means. This is the coupled userspace half of the gk7205v200 bootloader boot-count escalation.

## Hardware tested on

**gk7205v200** (lab). The camera's U-Boot predates the boot-count logic, so the env vars are inert there — which is exactly the "safe on old U-Boot" case. Verified the arm → disarm cycle on the running camera:

```
# armed (as sysupgrade does before flashing)
upgrade_available=1  bootcount=0
# S99bootok start, majestic up  ->  disarms
after: upgrade_available=0  bootcount=0
# unarmed re-run  ->  no-op, no write
still: upgrade_available=0
```

The camera booted and streamed normally throughout. The bootloader escalation this flag drives is verified in QEMU on the u-boot side; the full end-to-end on a camera running the boot-count U-Boot is the remaining integration step.

## Scope

Shared overlay (`sysupgrade` + a new `S99bootok`), so it builds for every board; `ci-matrix --self-test` passes and `test_shell_parse` / `test_strip_shell_comments` pass (140 scripts, incl. these, parse clean stripped). Behaviour is inert on every board until a boot-count-capable U-Boot is present.