### PR TITLE
Log WireGuard command errors to syslog

### DIFF
--- a/general/overlay/usr/sbin/wireguard
+++ b/general/overlay/usr/sbin/wireguard
@@ -28,11 +28,11 @@ run_cmd "Failed to load wireguard module" modprobe wireguard
 run_cmd "Failed to create wg0 interface" ip link add dev wg0 type wireguard
 
 WG_PRIVKEY=$(run_cmd "" fw_printenv -n wg_privkey)
-WG_PRESHARED_KEY=$(fw_printenv -n wg_sharkey 2>/dev/null || true)
-ENDPOINT=$(run_cmd "" fw_printenv -n wg_endpoint)
-[ -n "$ENDPOINT" ] || { echo "Error: wg_endpoint environment variable is not set or empty." >&2; exit 1; }
+WG_SHARKEY=$(fw_printenv -n wg_sharkey 2>/dev/null || true)
+WG_ENDPOINT=$(run_cmd "Failed to read wg_endpoint U-Boot environment variable" fw_printenv -n wg_endpoint)
+WG_ADDRESS=$(run_cmd "Failed to read wg_address U-Boot environment variable" fw_printenv -n wg_address)
 
-HOST="${ENDPOINT%:*}"
+HOST="${WG_ENDPOINT%:*}"
 
 if ! echo "$HOST" | grep -qE '^\[|^((^|\.)(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])){4}$'; then
 	while ! nslookup "$HOST" >/dev/null 2>&1; do
@@ -46,23 +46,16 @@ fi
 	echo "PrivateKey = $WG_PRIVKEY"
 	echo
 	echo "[Peer]"
-	echo "Endpoint = $ENDPOINT"
+	echo "Endpoint = $WG_ENDPOINT"
 	echo "PersistentKeepalive = $(run_cmd "" fw_printenv -n wg_alive)"
 	echo "PublicKey = $(run_cmd "" fw_printenv -n wg_pubkey)"
-	[ -n "$WG_PRESHARED_KEY" ] && echo "PresharedKey = $WG_PRESHARED_KEY"
+	[ -n "$WG_SHARKEY" ] && echo "PresharedKey = $WG_SHARKEY"
 	echo "AllowedIPs = $(run_cmd "" fw_printenv -n wg_allowed)"
 	echo "#"
 ) >>/tmp/wireguard.conf
 
 run_cmd "Failed to apply wireguard configuration" wg setconf wg0 /tmp/wireguard.conf
-
-wg_address=$(run_cmd "" fw_printenv -n wg_address)
-if [ -z "$wg_address" ]; then
-	echo "Error: wg_address environment variable is not set or empty." >&2
-	exit 1
-fi
-
-run_cmd "" ip address add dev wg0 "$wg_address"
+run_cmd "" ip address add dev wg0 "$WG_ADDRESS"
 run_cmd "" ip link set up dev wg0
 
 for i in $(run_cmd "" fw_printenv -n wg_allowed | tr ',' ' '); do

--- a/general/overlay/usr/sbin/wireguard
+++ b/general/overlay/usr/sbin/wireguard
@@ -24,13 +24,17 @@ run_cmd() {
 	printf '%s\n' "$output"
 }
 
+WG_PRIVKEY=$(run_cmd "Failed to read wg_privkey U-Boot environment variable" fw_printenv -n wg_privkey)
+WG_ENDPOINT=$(run_cmd "Failed to read wg_endpoint U-Boot environment variable" fw_printenv -n wg_endpoint)
+WG_ALIVE=$(run_cmd "Failed to read wg_alive U-Boot environment variable" fw_printenv -n wg_alive)
+WG_PUBKEY=$(run_cmd "Failed to read wg_pubkey U-Boot environment variable" fw_printenv -n wg_pubkey)
+WG_ALLOWED=$(run_cmd "Failed to read wg_allowed U-Boot environment variable" fw_printenv -n wg_allowed)
+WG_ADDRESS=$(run_cmd "Failed to read wg_address U-Boot environment variable" fw_printenv -n wg_address)
+
+WG_SHARKEY=$(fw_printenv -n wg_sharkey 2>/dev/null || true)
+
 run_cmd "Failed to load wireguard module" modprobe wireguard
 run_cmd "Failed to create wg0 interface" ip link add dev wg0 type wireguard
-
-WG_PRIVKEY=$(run_cmd "" fw_printenv -n wg_privkey)
-WG_SHARKEY=$(fw_printenv -n wg_sharkey 2>/dev/null || true)
-WG_ENDPOINT=$(run_cmd "Failed to read wg_endpoint U-Boot environment variable" fw_printenv -n wg_endpoint)
-WG_ADDRESS=$(run_cmd "Failed to read wg_address U-Boot environment variable" fw_printenv -n wg_address)
 
 HOST="${WG_ENDPOINT%:*}"
 
@@ -47,10 +51,10 @@ fi
 	echo
 	echo "[Peer]"
 	echo "Endpoint = $WG_ENDPOINT"
-	echo "PersistentKeepalive = $(run_cmd "" fw_printenv -n wg_alive)"
-	echo "PublicKey = $(run_cmd "" fw_printenv -n wg_pubkey)"
+	echo "PersistentKeepalive = $WG_ALIVE"
+	echo "PublicKey = $WG_PUBKEY"
 	[ -n "$WG_SHARKEY" ] && echo "PresharedKey = $WG_SHARKEY"
-	echo "AllowedIPs = $(run_cmd "" fw_printenv -n wg_allowed)"
+	echo "AllowedIPs = $WG_ALLOWED"
 	echo "#"
 ) >>/tmp/wireguard.conf
 
@@ -58,6 +62,6 @@ run_cmd "Failed to apply wireguard configuration" wg setconf wg0 /tmp/wireguard.
 run_cmd "" ip address add dev wg0 "$WG_ADDRESS"
 run_cmd "" ip link set up dev wg0
 
-for i in $(run_cmd "" fw_printenv -n wg_allowed | tr ',' ' '); do
+for i in $(echo "$WG_ALLOWED" | tr ',' ' '); do
 	run_cmd "" ip -4 route add "$i" dev wg0
 done

--- a/general/overlay/usr/sbin/wireguard
+++ b/general/overlay/usr/sbin/wireguard
@@ -1,8 +1,7 @@
 #!/bin/sh
 
-RUN_CMD_PROGRAM="${0##*/}"
-
 run_cmd() {
+	local prog="${0##*/}"
 	local msg="$1"
 	local var="$2"
 	shift 2
@@ -14,12 +13,12 @@ run_cmd() {
 	if [ "$rc" -ne 0 ]; then
 		[ -n "$msg" ] && msg="$msg. "
 
-		logger -p user.err -t "$RUN_CMD_PROGRAM[$$]" "Error: ${msg}"
-		logger -p user.err -t "$RUN_CMD_PROGRAM[$$]" "Command \`$*\` finished with code $rc:"
+		logger -p user.err -t "$prog[$$]" "Error: ${msg}"
+		logger -p user.err -t "$prog[$$]" "Command \`$*\` finished with code $rc:"
 
 		printf '%s\n' "$output" |
 		while IFS= read -r line; do
-			logger -p user.err -t "$RUN_CMD_PROGRAM[$$]" "$line"
+			logger -p user.err -t "$prog[$$]" "$line"
 		done
 
 		exit "$rc"

--- a/general/overlay/usr/sbin/wireguard
+++ b/general/overlay/usr/sbin/wireguard
@@ -6,28 +6,46 @@ run_cmd() {
 	local var="$2"
 	shift 2
 
+	local fatal
+
+	if [ "$var" = "--non-fatal" ]; then
+		fatal="false"
+		var=""
+	else
+		fatal="true"
+	fi
+
 	local output
 	output=$("$@" 2>&1)
 	local rc=$?
 
 	if [ "$rc" -ne 0 ]; then
-		[ -n "$msg" ] && msg="$msg. "
+		if [ -n "$msg" ]; then
+			logger -p user.err -t "$prog[$$]" "$msg"
+		elif [ -z "$output" ]; then
+			logger -p user.err -t "$prog[$$]" "Command \`$*\` finished with code $rc."
+		else
+			logger -p user.err -t "$prog[$$]" "Command \`$*\` finished with code $rc:"
 
-		logger -p user.err -t "$prog[$$]" "Error: ${msg}"
-		logger -p user.err -t "$prog[$$]" "Command \`$*\` finished with code $rc:"
+			printf '%s\n' "$output" |
+			while IFS= read -r line; do
+				logger -p user.err -t "$prog[$$]" "$line"
+			done
+		fi
 
-		printf '%s\n' "$output" |
-		while IFS= read -r line; do
-			logger -p user.err -t "$prog[$$]" "$line"
-		done
+		if [ -n "$output" ]; then
+			echo "$output" >&2
+		fi
 
-		exit "$rc"
+		if [ "$fatal" = "true" ]; then
+			exit "$rc"
+		fi	
 	fi
 
 	if [ -n "$var" ]; then
 		eval "$var=\"\$output\""
-	else
-		printf '%s\n' "$output"
+	elif [ -n "$output" ]; then
+		echo "$output"
 	fi
 }
 
@@ -67,9 +85,9 @@ fi
 
 run_cmd "Failed to apply wireguard configuration" "" wg setconf wg0 /tmp/wireguard.conf
 
-run_cmd "" "" ip address add dev wg0 "$WG_ADDRESS"
-run_cmd "" "" ip link set up dev wg0
+run_cmd "" --non-fatal ip address add dev wg0 "$WG_ADDRESS"
+run_cmd "" --non-fatal ip link set up dev wg0
 
 for i in $(echo "$WG_ALLOWED" | tr ',' ' '); do
-	run_cmd "" "" ip -4 route add "$i" dev wg0
+	run_cmd "" --non-fatal ip -4 route add "$i" dev wg0
 done

--- a/general/overlay/usr/sbin/wireguard
+++ b/general/overlay/usr/sbin/wireguard
@@ -20,26 +20,26 @@ run_cmd() {
 	local rc=$?
 
 	if [ "$rc" -ne 0 ]; then
-		if [ -n "$msg" ]; then
-			logger -p user.err -t "$prog[$$]" "$msg"
-		elif [ -z "$output" ]; then
-			logger -p user.err -t "$prog[$$]" "Command \`$*\` finished with code $rc."
-		else
-			logger -p user.err -t "$prog[$$]" "Command \`$*\` finished with code $rc:"
+		if [ -z "$msg" ]; then
+			local symbol
+			[ -z "$output" ] && symbol="." || symbol=":"
+			msg="Command \`$*\` finished with code $rc$symbol"
+		fi
 
+		logger -p user.err -t "$prog[$$]" "$msg"
+
+		if [ -n "$output" ]; then
 			printf '%s\n' "$output" |
 			while IFS= read -r line; do
 				logger -p user.err -t "$prog[$$]" "$line"
 			done
-		fi
 
-		if [ -n "$output" ]; then
 			echo "$output" >&2
 		fi
 
-		if [ "$fatal" = "true" ]; then
-			exit "$rc"
-		fi	
+		[ "$fatal" = "false" ] && return
+
+		exit "$rc"
 	fi
 
 	if [ -n "$var" ]; then

--- a/general/overlay/usr/sbin/wireguard
+++ b/general/overlay/usr/sbin/wireguard
@@ -8,10 +8,8 @@ run_cmd() {
 	shift 2
 
 	local output
-	local rc
-
 	output=$("$@" 2>&1)
-	rc=$?
+	local rc=$?
 
 	if [ "$rc" -ne 0 ]; then
 		[ -n "$msg" ] && msg="$msg. "

--- a/general/overlay/usr/sbin/wireguard
+++ b/general/overlay/usr/sbin/wireguard
@@ -4,37 +4,45 @@ PROGRAM="${0##*/}"
 
 run_cmd() {
 	msg="$1"
-	shift
+	var="$2"
+	shift 2
 
 	output=$("$@" 2>&1)
 	rc=$?
 
 	if [ "$rc" -ne 0 ]; then
 		[ -n "$msg" ] && msg="$msg. "
+
 		logger -p user.err -t "$PROGRAM[$$]" "Error: ${msg}"
 		logger -p user.err -t "$PROGRAM[$$]" "Command \`$*\` finished with code $rc:"
+
 		printf '%s\n' "$output" |
+
 		while IFS= read -r line; do
 			logger -p user.err -t "$PROGRAM[$$]" "$line"
 		done
-		kill -s TERM $$ 2>/dev/null
+
 		exit "$rc"
 	fi
 
-	printf '%s\n' "$output"
+	if [ -n "$var" ]; then
+		eval "$var=\"\$output\""
+	else
+		printf '%s\n' "$output"
+	fi
 }
 
-WG_PRIVKEY=$(run_cmd "Failed to read wg_privkey U-Boot environment variable" fw_printenv -n wg_privkey)
-WG_ENDPOINT=$(run_cmd "Failed to read wg_endpoint U-Boot environment variable" fw_printenv -n wg_endpoint)
-WG_ALIVE=$(run_cmd "Failed to read wg_alive U-Boot environment variable" fw_printenv -n wg_alive)
-WG_PUBKEY=$(run_cmd "Failed to read wg_pubkey U-Boot environment variable" fw_printenv -n wg_pubkey)
-WG_ALLOWED=$(run_cmd "Failed to read wg_allowed U-Boot environment variable" fw_printenv -n wg_allowed)
-WG_ADDRESS=$(run_cmd "Failed to read wg_address U-Boot environment variable" fw_printenv -n wg_address)
+run_cmd "Failed to read wg_privkey U-Boot environment variable" WG_PRIVKEY fw_printenv -n wg_privkey
+run_cmd "Failed to read wg_endpoint U-Boot environment variable" WG_ENDPOINT fw_printenv -n wg_endpoint
+run_cmd "Failed to read wg_alive U-Boot environment variable" WG_ALIVE fw_printenv -n wg_alive
+run_cmd "Failed to read wg_pubkey U-Boot environment variable" WG_PUBKEY fw_printenv -n wg_pubkey
+run_cmd "Failed to read wg_allowed U-Boot environment variable" WG_ALLOWED fw_printenv -n wg_allowed
+run_cmd "Failed to read wg_address U-Boot environment variable" WG_ADDRESS fw_printenv -n wg_address
 
 WG_SHARKEY=$(fw_printenv -n wg_sharkey 2>/dev/null || true)
 
-run_cmd "Failed to load wireguard module" modprobe wireguard
-run_cmd "Failed to create wg0 interface" ip link add dev wg0 type wireguard
+run_cmd "Failed to load wireguard module" "" modprobe wireguard
+run_cmd "Failed to create wg0 interface" "" ip link add dev wg0 type wireguard
 
 HOST="${WG_ENDPOINT%:*}"
 
@@ -58,11 +66,11 @@ fi
 	echo "#"
 ) >>/tmp/wireguard.conf
 
-run_cmd "Failed to apply wireguard configuration" wg setconf wg0 /tmp/wireguard.conf
+run_cmd "Failed to apply wireguard configuration" "" wg setconf wg0 /tmp/wireguard.conf
 
-run_cmd "" ip address add dev wg0 "$WG_ADDRESS"
-run_cmd "" ip link set up dev wg0
+run_cmd "" "" ip address add dev wg0 "$WG_ADDRESS"
+run_cmd "" "" ip link set up dev wg0
 
 for i in $(echo "$WG_ALLOWED" | tr ',' ' '); do
-	run_cmd "" ip -4 route add "$i" dev wg0
+	run_cmd "" "" ip -4 route add "$i" dev wg0
 done

--- a/general/overlay/usr/sbin/wireguard
+++ b/general/overlay/usr/sbin/wireguard
@@ -1,11 +1,14 @@
 #!/bin/sh
 
-PROGRAM="${0##*/}"
+RUN_CMD_PROGRAM="${0##*/}"
 
 run_cmd() {
-	msg="$1"
-	var="$2"
+	local msg="$1"
+	local var="$2"
 	shift 2
+
+	local output
+	local rc
 
 	output=$("$@" 2>&1)
 	rc=$?
@@ -13,13 +16,12 @@ run_cmd() {
 	if [ "$rc" -ne 0 ]; then
 		[ -n "$msg" ] && msg="$msg. "
 
-		logger -p user.err -t "$PROGRAM[$$]" "Error: ${msg}"
-		logger -p user.err -t "$PROGRAM[$$]" "Command \`$*\` finished with code $rc:"
+		logger -p user.err -t "$RUN_CMD_PROGRAM[$$]" "Error: ${msg}"
+		logger -p user.err -t "$RUN_CMD_PROGRAM[$$]" "Command \`$*\` finished with code $rc:"
 
 		printf '%s\n' "$output" |
-
 		while IFS= read -r line; do
-			logger -p user.err -t "$PROGRAM[$$]" "$line"
+			logger -p user.err -t "$RUN_CMD_PROGRAM[$$]" "$line"
 		done
 
 		exit "$rc"

--- a/general/overlay/usr/sbin/wireguard
+++ b/general/overlay/usr/sbin/wireguard
@@ -28,7 +28,7 @@ run_cmd "Failed to load wireguard module" modprobe wireguard
 run_cmd "Failed to create wg0 interface" ip link add dev wg0 type wireguard
 
 WG_PRIVKEY=$(run_cmd "" fw_printenv -n wg_privkey)
-WG_PRESHARED_KEY=$(run_cmd "" fw_printenv -n wg_sharkey 2>/dev/null || true)
+WG_PRESHARED_KEY=$(fw_printenv -n wg_sharkey 2>/dev/null || true)
 ENDPOINT=$(run_cmd "" fw_printenv -n wg_endpoint)
 [ -n "$ENDPOINT" ] || { echo "Error: wg_endpoint environment variable is not set or empty." >&2; exit 1; }
 

--- a/general/overlay/usr/sbin/wireguard
+++ b/general/overlay/usr/sbin/wireguard
@@ -20,13 +20,13 @@ run_cmd() {
 	local rc=$?
 
 	if [ "$rc" -ne 0 ]; then
-		if [ -z "$msg" ]; then
-			local symbol
-			[ -z "$output" ] && symbol="." || symbol=":"
-			msg="Command \`$*\` finished with code $rc$symbol"
+		if [ -n "$msg" ]; then
+			logger -p user.err -t "$prog[$$]" "$msg"
 		fi
 
-		logger -p user.err -t "$prog[$$]" "$msg"
+		local symbol
+		[ -z "$output" ] && symbol="." || symbol=":"
+		logger -p user.err -t "$prog[$$]" "Command \`$*\` finished with code $rc$symbol"
 
 		if [ -n "$output" ]; then
 			printf '%s\n' "$output" |
@@ -37,7 +37,9 @@ run_cmd() {
 			echo "$output" >&2
 		fi
 
-		[ "$fatal" = "false" ] && return
+		if [ "$fatal" = "false" ]; then
+			return
+		fi
 
 		exit "$rc"
 	fi

--- a/general/overlay/usr/sbin/wireguard
+++ b/general/overlay/usr/sbin/wireguard
@@ -59,6 +59,7 @@ fi
 ) >>/tmp/wireguard.conf
 
 run_cmd "Failed to apply wireguard configuration" wg setconf wg0 /tmp/wireguard.conf
+
 run_cmd "" ip address add dev wg0 "$WG_ADDRESS"
 run_cmd "" ip link set up dev wg0
 

--- a/general/overlay/usr/sbin/wireguard
+++ b/general/overlay/usr/sbin/wireguard
@@ -1,42 +1,70 @@
 #!/bin/sh
 
-modprobe wireguard || { echo "Error: Failed to load wireguard module." >&2; exit 1; }
-ip link add dev wg0 type wireguard || { echo "Error: Failed to create wg0 interface." >&2; exit 1; }
+PROGRAM="${0##*/}"
 
-WG_PRIVKEY="$(fw_printenv -n wg_privkey)"
-WG_PRESHARED_KEY="$(fw_printenv -n wg_sharkey)"
-ENDPOINT=$(fw_printenv -n wg_endpoint)
+run_cmd() {
+	msg="$1"
+	shift
+
+	output=$("$@" 2>&1)
+	rc=$?
+
+	if [ "$rc" -ne 0 ]; then
+		[ -n "$msg" ] && msg="$msg. "
+		logger -p user.err -t "$PROGRAM[$$]" "Error: ${msg}"
+		logger -p user.err -t "$PROGRAM[$$]" "Command \`$*\` finished with code $rc:"
+		printf '%s\n' "$output" |
+		while IFS= read -r line; do
+			logger -p user.err -t "$PROGRAM[$$]" "$line"
+		done
+		kill -s TERM $$ 2>/dev/null
+		exit "$rc"
+	fi
+
+	printf '%s\n' "$output"
+}
+
+run_cmd "Failed to load wireguard module" modprobe wireguard
+run_cmd "Failed to create wg0 interface" ip link add dev wg0 type wireguard
+
+WG_PRIVKEY=$(run_cmd "" fw_printenv -n wg_privkey)
+WG_PRESHARED_KEY=$(run_cmd "" fw_printenv -n wg_sharkey 2>/dev/null || true)
+ENDPOINT=$(run_cmd "" fw_printenv -n wg_endpoint)
 [ -n "$ENDPOINT" ] || { echo "Error: wg_endpoint environment variable is not set or empty." >&2; exit 1; }
+
 HOST="${ENDPOINT%:*}"
 
 if ! echo "$HOST" | grep -qE '^\[|^((^|\.)(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])){4}$'; then
-    while ! nslookup "$HOST" >/dev/null 2>&1; do
-        sleep 10
-    done
+	while ! nslookup "$HOST" >/dev/null 2>&1; do
+		sleep 10
+	done
 fi
 
-( echo "#"
-  echo "[Interface]"
-  echo "PrivateKey = $WG_PRIVKEY"
-  echo
-  echo "[Peer]"
-  echo "Endpoint = $ENDPOINT"
-  echo "PersistentKeepalive = $(fw_printenv -n wg_alive)"
-  echo "PublicKey = $(fw_printenv -n wg_pubkey)"
-  [ -n "$WG_PRESHARED_KEY" ] && echo "PresharedKey = $WG_PRESHARED_KEY"
-  echo "AllowedIPs = $(fw_printenv -n wg_allowed)"
-  echo "#"
+(
+	echo "#"
+	echo "[Interface]"
+	echo "PrivateKey = $WG_PRIVKEY"
+	echo
+	echo "[Peer]"
+	echo "Endpoint = $ENDPOINT"
+	echo "PersistentKeepalive = $(run_cmd "" fw_printenv -n wg_alive)"
+	echo "PublicKey = $(run_cmd "" fw_printenv -n wg_pubkey)"
+	[ -n "$WG_PRESHARED_KEY" ] && echo "PresharedKey = $WG_PRESHARED_KEY"
+	echo "AllowedIPs = $(run_cmd "" fw_printenv -n wg_allowed)"
+	echo "#"
 ) >>/tmp/wireguard.conf
 
-wg setconf wg0 /tmp/wireguard.conf || { echo "Error: Failed to apply wireguard configuration." >&2; exit 1; }
-wg_address="$(fw_printenv -n wg_address)"
-if [ -z "$wg_address" ]; then
-    echo "Error: wg_address environment variable is not set or empty." >&2
-    exit 1
-fi
-ip address add dev wg0 "$wg_address"
-ip link set up dev wg0
-for i in $(fw_printenv -n wg_allowed | tr ',' ' '); do
-    ip -4 route add "$i" dev wg0
-done
+run_cmd "Failed to apply wireguard configuration" wg setconf wg0 /tmp/wireguard.conf
 
+wg_address=$(run_cmd "" fw_printenv -n wg_address)
+if [ -z "$wg_address" ]; then
+	echo "Error: wg_address environment variable is not set or empty." >&2
+	exit 1
+fi
+
+run_cmd "" ip address add dev wg0 "$wg_address"
+run_cmd "" ip link set up dev wg0
+
+for i in $(run_cmd "" fw_printenv -n wg_allowed | tr ',' ' '); do
+	run_cmd "" ip -4 route add "$i" dev wg0
+done


### PR DESCRIPTION
## Problem

WireGuard initialization errors are currently printed to the console only, which makes them easy to miss when the camera is accessed remotely.

## Solution

Add a `run_cmd()` helper that captures command output and exit codes. When a command fails, the error, exit code, and command output are written to syslog before the script terminates with the original exit code.

This helper could be moved to a common shell library in the future and reused by multiple OpenIPC scripts. The global variable names would need to be adjusted first to avoid conflicts with variables in the calling scripts.

## Hardware tested on

- gk7205v300, G6S
- t31x, don't know the board name
- ssc337de, don't know the board name
- ssc378de, don't know the board name, multiple cameras

The fix has been tested on these platforms.

## Evidence

See [OpenIPC/firmware#2319](https://github.com/OpenIPC/firmware/issues/2319) for the problem reproduction, testing, and discussion.

## Scope

- [x] No kernel patches under `general/package/all-patches/linux/` (those go to https://github.com/OpenIPC/linux)
- [x] No files specific to a single retail camera model (those go to https://github.com/OpenIPC/builder)
- [x] No probing or bring-up tooling (that goes to https://github.com/OpenIPC/ipctool)
- [x] Nothing under `general/overlay/` or in a shared `load_<vendor>` script hardcodes a value specific to my board
- [x] Package sources come from an OpenIPC repository, and any version bump keeps at least the specificity of the pin it replaces (a new package should pin a full 40-character SHA)
- [x] No `LD_PRELOAD`, and no binaries that cannot be rebuilt from source
- [ ] New code is selected by a defconfig, so CI actually builds it