### PR TITLE
hi3519v101: drop the Wi-Fi driver with no firmware, and build mac80211's crypto in

### DIFF
--- a/br-ext-chip-hisilicon/board/hi3519v101/hi3519v101.generic.config
+++ b/br-ext-chip-hisilicon/board/hi3519v101/hi3519v101.generic.config
@@ -1186,12 +1186,17 @@ CONFIG_WLAN=y
 # CONFIG_LIBERTAS is not set
 # CONFIG_P54_COMMON is not set
 # CONFIG_RT2X00 is not set
-CONFIG_RTL_CARDS=m
-CONFIG_RTL8192CU=m
-CONFIG_RTLWIFI=m
-CONFIG_RTLWIFI_USB=m
-CONFIG_RTLWIFI_DEBUG=y
-CONFIG_RTL8192C_COMMON=m
+# rtl8192cu wants rtlwifi/rtl8192cufw*.bin, which no package in this tree
+# installs on any board -- the only firmware hi3519v101_lite ships is
+# mediatek/mt7601u.bin, so /lib/firmware/rtlwifi does not exist and the driver
+# could never finish probing. It cost 274KB of .ko (rtl8192cu, rtlwifi,
+# rtl8192c-common, rtl_usb) in a rootfs that was 4KB over its cap, and
+# RTLWIFI_DEBUG=y is why rtlwifi.ko was as large as it was. Same argument as
+# #2376 and #2399. mac80211/cfg80211 stay modular for the out-of-tree drivers
+# /etc/wireless/usb modprobes, and R8188EU stays because it is the only symbol
+# selecting WIRELESS_EXT here -- dropping it would take the wext ioctl ABI
+# those drivers and iwconfig need with it.
+# CONFIG_RTL_CARDS is not set
 # CONFIG_WL_TI is not set
 # CONFIG_ZD1211RW is not set
 # CONFIG_MWIFIEX is not set
@@ -2355,13 +2360,13 @@ CONFIG_CRYPTO=y
 #
 CONFIG_CRYPTO_ALGAPI=y
 CONFIG_CRYPTO_ALGAPI2=y
-CONFIG_CRYPTO_AEAD=m
+CONFIG_CRYPTO_AEAD=y
 CONFIG_CRYPTO_AEAD2=y
-CONFIG_CRYPTO_BLKCIPHER=m
+CONFIG_CRYPTO_BLKCIPHER=y
 CONFIG_CRYPTO_BLKCIPHER2=y
 CONFIG_CRYPTO_HASH=y
 CONFIG_CRYPTO_HASH2=y
-CONFIG_CRYPTO_RNG=m
+CONFIG_CRYPTO_RNG=y
 CONFIG_CRYPTO_RNG2=y
 CONFIG_CRYPTO_PCOMP2=y
 CONFIG_CRYPTO_MANAGER=y
@@ -2380,15 +2385,19 @@ CONFIG_CRYPTO_WORKQUEUE=y
 #
 # Authenticated Encryption with Associated Data
 #
-CONFIG_CRYPTO_CCM=m
+# ccm/ctr/seqiv/arc4 are what mac80211 selects, so they are loaded whenever a
+# Wi-Fi dongle is and idle code the rest of the time either way. Building them
+# in moves 29KB out of the size-capped rootfs into the uImage, which has 238KB
+# of headroom -- the #2397 trade, and the same reason FAT is built in below.
+CONFIG_CRYPTO_CCM=y
 # CONFIG_CRYPTO_GCM is not set
-CONFIG_CRYPTO_SEQIV=m
+CONFIG_CRYPTO_SEQIV=y
 
 #
 # Block modes
 #
 # CONFIG_CRYPTO_CBC is not set
-CONFIG_CRYPTO_CTR=m
+CONFIG_CRYPTO_CTR=y
 # CONFIG_CRYPTO_CTS is not set
 # CONFIG_CRYPTO_ECB is not set
 # CONFIG_CRYPTO_LRW is not set
@@ -2433,7 +2442,7 @@ CONFIG_CRYPTO_AES=y
 # CONFIG_CRYPTO_AES_ARM is not set
 # CONFIG_CRYPTO_AES_ARM_BS is not set
 # CONFIG_CRYPTO_ANUBIS is not set
-CONFIG_CRYPTO_ARC4=m
+CONFIG_CRYPTO_ARC4=y
 # CONFIG_CRYPTO_BLOWFISH is not set
 # CONFIG_CRYPTO_CAMELLIA is not set
 # CONFIG_CRYPTO_CAST5 is not set


### PR DESCRIPTION
## What broke

`hi3519v101_lite` fails the rootfs cap on master:

```
hi3519v101_lite
  - uImage:           [1806KB/2048KB]
  - rootfs.squashfs:  [5128KB/5120KB]
  -- size exceeded by: 8KB
```

Nothing in this repository grew to do it. The failing master nightly sits on
d87dae1e, and #2401's build on the *same base commit* passed this board at
11:36 UTC and failed at 19:16 UTC with byte-identical numbers. `majestic` and
`majestic-webui` are unpinned moving refs — `MAJESTIC_SITE` has no version in
the URL — so the growth lands with no pull request to point at. Exactly the
shape of #2397 and #2399 one nightly earlier.

This board has been living on the line for a while: the `CHECK_SIZE` headroom
comment in the `Makefile` is written about it ("sat at exactly 5120KB of a
5120KB cap for weeks"), and #2308/#2309/#2310 bought its last reprieve.

## What changes

One file, `hi3519v101.generic.config`, which backs exactly one defconfig
(`hi3519v101_lite_defconfig` — `grep -rl` over `br-ext-chip-*/configs`).

**1. The in-kernel Realtek USB Wi-Fi stack is dropped.** `rtl8192cu` asks for
`rtlwifi/rtl8192cufw{,_A,_B,_TMSC}.bin`. Nothing in this tree installs any of
those on any board — `grep -rn 8192cufw` over the repository returns nothing —
and the only firmware this board ships is `mediatek/mt7601u.bin`, because
`hi3519v101_lite_defconfig` selects `..._MEDIATEK_MT7601U` and not
`..._RTL_8188EU`. So `/lib/firmware/rtlwifi` does not exist in the image and
the driver could never finish probing. In the built baseline rootfs it cost:

| module | bytes |
| --- | --- |
| `rtl8192cu.ko` | 104,420 |
| `rtlwifi.ko` | 95,644 |
| `rtl8192c-common.ko` | 63,660 |
| `rtl_usb.ko` | 17,220 |
| **total** | **280,944 (274KB)** |

`CONFIG_RTLWIFI_DEBUG=y` was set, which is why `rtlwifi.ko` was that large.
Same argument and same shape as #2376 and #2399. There is no `wlandev` profile
for this family in `general/overlay/etc/wireless/usb` at all, so nothing in the
tree modprobes any of these names.

**2. `ccm`, `ctr`, `seqiv` and `arc4` are built in** instead of shipping as
modules. These are the algorithms `mac80211` selects, so they are resident
whenever a dongle is and idle code the rest of the time either way — this moves
29KB from the size-capped rootfs into the uImage, which has 238KB of headroom.
The #2397 trade, and the same reason FAT is built in on this board already.
After the build, `modules.builtin` carries `crypto/{ccm,ctr,arc4,seqiv}.ko` and
`modules.dep` for `mac80211.ko` lists only `cfg80211.ko`.

`CONFIG_CRYPTO_{AEAD,BLKCIPHER,RNG}` follow to `=y`; that is what
`olddefconfig` derives, not a hand edit.

## What deliberately does not change

**`CONFIG_R8188EU` stays**, even though the staging driver cannot load its
firmware either (`rtlwifi/rtl8188eufw.bin`, ships only when
`BR2_PACKAGE_LINUX_FIRMWARE_OPENIPC_RTL_8188EU` is selected, which this board
does not do) and `/etc/wireless/usb`'s `rtl8188eu-generic` profile modprobes
the out-of-tree `8188eu`, not `r8188eu`. It is 461KB — by far the biggest
single item — and dropping it would be wrong anyway:

```
$ grep -rn "select WIRELESS_EXT" drivers/staging/rtl8188eu/Kconfig
4:	select WIRELESS_EXT
```

`WIRELESS_EXT` is a prompt-less bool reachable only by `select`, and on this
board `R8188EU` is the only thing selecting it. `olddefconfig` confirms it:
drop `R8188EU` and `CONFIG_WIRELESS_EXT`, `WEXT_CORE`, `WEXT_PROC` and
`WEXT_PRIV` all go with it, taking `net/wireless/wext-core.o` and the
`net_device.wireless_handlers` field out of the kernel. That is the ioctl ABI
`iwconfig` (this board ships `wireless-tools`), wpa_supplicant's `wext` driver
(selected here via the MT7601U firmware option) and every out-of-tree Realtek
driver in `general/package/` are built against. `CONFIG_CFG80211_WEXT=y` is not
a substitute — it gives `WEXT_CORE` but not `CONFIG_WIRELESS_EXT`. Both
`hi3518ev200` and `hi3518ev300` keep `WIRELESS_EXT` the same accidental way,
which is presumably why #2399 left `R8188EU` alone there too.

`mac80211` and `cfg80211` stay modular for the same reason: they are what an
out-of-tree driver added downstream would sit on.

## Evidence

Full clean builds of `hi3519v101_lite`, before and after, same tree, same hour:

```
before   - uImage:          [1805KB/2048KB]
         - rootfs.squashfs: [5124KB/5120KB]
         -- size exceeded by: 4KB

after    - uImage:          [1809KB/2048KB]
         - rootfs.squashfs: [5028KB/5120KB]
```

(Local baseline reads 5124KB against CI's 5128KB; both overflow, and the delta
is what matters.) CI on this branch, run 34718966712, agrees:

```
hi3519v101_lite   - uImage:          [1809KB/2048KB]
                  - rootfs.squashfs: [5036KB/5120KB]
```

— 84KB under the cap, no headroom warning, and `hi3516av200_{lite,neo,ultimate}`
(the rest of the matrix this file selects) pass unchanged.

`make BOARD=hi3519v101_lite size-report` after:

```
packages=33 modules=59 removed=65
rootfs=5148672B (uncompressed 13587069B, ratio 0.3789)
headroom: kernel=238KB rootfs=92KB
```

Module count 63 → 59. In the built tree
`kernel/drivers/net/wireless/` and `kernel/crypto/` are gone from
`/lib/modules`, while `r8188eu.ko` (461,524), `mac80211.ko` (322,708),
`cfg80211.ko` (214,592), `wireguard.ko` and the 30 `hisilicon/` vendor modules
are all still there. `CONFIG_WIRELESS_EXT=y`, `WEXT_CORE=y`, `WEXT_PROC=y` and
`WEXT_PRIV=y` survive in the built `.config`.

The committed file derives exactly the `.config` that was built — copying it
over `build/linux-custom/.config` and running `olddefconfig` produces a
byte-identical file, so nothing was re-enabled behind the change.

Checks run:

```
bash .github/scripts/test_load_hisilicon.sh                  OK
bash .github/scripts/test_sysupgrade.sh                      OK
bash .github/scripts/test_excludes_report.sh                 OK
STRICT=1 bash .github/scripts/test_shell_parse.sh            OK (144 scripts)
STRICT=1 bash .github/scripts/test_strip_shell_comments.sh   OK
python3 .github/scripts/ci-matrix.py --self-test             OK (99 boards)
python3 .github/scripts/lint-workflow-shell.py --self-test   OK
python3 general/scripts/tests/test_kconfig_graph.py          OK
bash .github/scripts/check_target_modules.sh <built tree>    OK (wireguard.ko present)
```

## Not tested on hardware

There is no hi3519v101 unit on the bench, so this is measured from builds only.
Both moves are the ones #2376, #2397 and #2399 already made on Goke,
hi3518ev300 and hi3518ev200, and the reasoning for each dropped symbol is
stated above so it can be checked rather than taken on trust. Worth exercising
on a real camera before this is trusted:

- the board still boots and streams — the crypto move changes when `ccm`/`arc4`
  register, not whether;
- if anyone has a hi3519v101 camera with a USB dongle working *through the
  in-kernel* `rtl8192cu` (which would mean they are supplying
  `/lib/firmware/rtlwifi/` from outside this tree), say so and I will keep
  `CONFIG_RTL_CARDS`.

## Follow-up, not in this PR

Twenty other board configs still carry `CONFIG_RTL_CARDS=m` with the same
missing firmware, including `hi3516av200.generic.config` next door. That is a
fleet-wide sweep that would widen the CI matrix to most of the tree, so it is
better done deliberately than smuggled into a red-master fix.
