### PR TITLE
vtun: wait for the network before starting, and pace the restart loop

### DIFF
--- a/general/package/vtund-openipc/files/tunnel
+++ b/general/package/vtund-openipc/files/tunnel
@@ -2,7 +2,7 @@
 #
 # OpenIPC.org | v.20230212
 # by Igor Zalatov, aka FlyRouter, aka ZigFisher
-# Busybox applets: awk cat echo insmod ip modprobe sha1sum sleep tr tunctl udhcpc uptime
+# Busybox applets: awk cat echo grep insmod ip logger modprobe nslookup sha1sum sleep tr tunctl udhcpc uptime
 #
 
 vtund_enable="true"
@@ -12,12 +12,30 @@ vtund_iface="tunnel"
 device_name="IPC-VTUND"
 working_dir="/tmp"
 
+# The session name is the MAC of the default-route interface, so until that
+# route exists there is no identity to build a config from. Report that rather
+# than returning empty strings the caller cannot distinguish from a real MAC.
 identity() {
 	identity_src=$(ip r | awk '/default/ {print $5}' | head -n 1)
-	identity_mac=$(cat /sys/class/net/"$identity_src"/address | tr 'a-z' 'A-Z')
+	[ -n "$identity_src" ] || return 1
+	identity_mac=$(cat /sys/class/net/"$identity_src"/address 2>/dev/null | tr 'a-z' 'A-Z')
+	[ -n "$identity_mac" ] || return 1
 	identity_pas=$(echo "$identity_mac" | sha1sum | awk '{print $1}')
 	identity_tid=$(echo "$identity_mac" | tr -d ':')
 	identity_cfg=$working_dir/vtund.conf
+}
+
+# vtund resolves the server name itself and exits when it cannot, so a camera
+# that boots faster than its DNS becomes reachable restarts into the same
+# failure every time. The literal-address test is the one /usr/sbin/wireguard
+# uses, so a numeric server never waits on a resolver it does not need.
+resolves() {
+	echo "$vtund_server" | grep -qE '^\[|^((^|\.)(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])){4}$' && return 0
+	nslookup "$vtund_server" >/dev/null 2>&1
+}
+
+ready() {
+	identity && resolves
 }
 
 interface() {
@@ -48,6 +66,27 @@ config() {
 		) >$identity_cfg
 }
 
+# A camera that reached here before its network was up wrote an empty session
+# name into line 5 of the config, and vtund answered "syntax error line 5" and
+# "No hosts defined" and exited at once. The loop had no delay, so that pair
+# repeated until it was the only thing left in the 64KB syslog ring and
+# whatever had really gone wrong on that boot had been evicted (#2319). Wait
+# for what the tunnel needs instead of restarting into a failure that cannot
+# succeed, and keep a floor under the restart rate for the failures that
+# remain -- vtund's own keepalive is 10:5, so it reconnects a live session by
+# itself and this delay only paces the restarts it could not.
 if [ "$vtund_enable" = "true" ]; then
-	(while true; do identity; interface; config; vtund -n -f "$identity_cfg" "$identity_tid" "$vtund_server" >/dev/null 2>&1; done) &
+	(
+		while true; do
+			if ! ready; then
+				logger -p daemon.warn -t "${0##*/}[$$]" "waiting for a default route and for $vtund_server to resolve"
+				until ready; do sleep 10; done
+				logger -p daemon.info -t "${0##*/}[$$]" "starting the tunnel to $vtund_server"
+			fi
+			interface
+			config
+			vtund -n -f "$identity_cfg" "$identity_tid" "$vtund_server" >/dev/null 2>&1
+			sleep 10
+		done
+	) &
 fi


### PR DESCRIPTION
## Problem

Reported by @usa- in #2319: after a power cut, a camera comes back with vtund filling the whole 64 KB syslog ring with the same two lines, so nothing else from that boot survives to be read.

```text
Aug 29 09:05:21 gk7205v300-imx335 daemon.err vtund[21576]: syntax error line 5
Aug 29 09:05:21 gk7205v300-imx335 daemon.err vtund[21576]: No hosts defined
```

**It is not a name-resolution failure**, despite where the report started. The session name is the MAC of the default-route interface:

```sh
identity_src=$(ip r | awk '/default/ {print $5}' | head -n 1)
identity_mac=$(cat /sys/class/net/"$identity_src"/address | tr 'a-z' 'A-Z')
```

On a boot that reaches `tunnel` before the network is up, `ip r` matches nothing, `identity_src` is empty, `cat /sys/class/net//address` fails, and `config()` writes an empty session name — which is line 5 of the file it generates. vtund names the line it is looking at and exits.

The loop had no delay at all, so it did that as fast as the SoC allowed:

```sh
(while true; do identity; interface; config; vtund ... ; done) &
```

Two syslog lines per pass, no pause between passes, 64 KB gone in well under a minute.

## What changes

One file, `general/package/vtund-openipc/files/tunnel`.

- `identity()` reports that it has no identity instead of returning empty strings the caller cannot tell from a MAC, and the loop waits for one rather than writing a config it knows is broken.
- The name half of the report is real too — vtund resolves the server itself and exits when it cannot — so the wait covers that as well, reusing the literal-address test from `/usr/sbin/wireguard` so a numeric server never waits on a resolver it does not need.
- The failures that remain get a floor under their restart rate. vtund's own `keepalive` is `10:5`, so it reconnects a live session by itself; this delay only paces the restarts it could not.
- Waiting happens inside the loop that `tunnel` already backgrounds, so boot is not blocked. `S98vtun` is unchanged.

At most two syslog lines per outage episode: one on entering the wait, one on leaving it.

## Hardware tested on

**None — I have no camera running vtund, which is why this is a draft.** The Evidence below is a stubbed busybox-ash run and the repository's own checks, not a board. Someone with the reproducer from #2319 needs to confirm it on hardware before this is ready.

@usa- — you have both the fleet and the repro; would you try this one?

## Evidence

Not from a camera. `vtund`, `ip`, `nslookup` and `logger` are shell stubs; the shell is the busybox `ash` this tree builds. The scenario is "no default route yet", the #2319 boot.

Before:

```text
old: vtund launched 17 times in 2s with no default route
     line 5 of the config it fed vtund: | {|
```

After:

```text
new: vtund launched 0 times in 2s with no default route
     config: NOT WRITTEN
     SYSLOG waiting for a default route and for vtun.localhost to resolve
     SLEEP 10
     SLEEP 10
```

The generated config, with the identity empty, showing what line 5 actually is:

```text
     4	}
     5	 {
     6		password ;
```

The other three cases:

```text
B: default route up, hostname does not resolve  -> waits, config NOT WRITTEN
C: literal IP server (10.8.0.1)                 -> zero nslookup calls, starts at once
D: everything ready                             -> line5=|AABBCCDDEEFF {|
```

Repository checks:

```text
STRICT=1 test_shell_parse.sh          -> 144 scripts, all parsed clean under busybox ash
STRICT=1 test_strip_shell_comments.sh -> all checks passed
ci-matrix.py --self-test              -> ok (99 boards, 136 packages, 56 cases)
ci-matrix.py --stdin                  -> 98/99 boards, narrowed to the boards that ship vtund
```

## Scope

- [x] No kernel patches under `general/package/all-patches/linux/` (those go to [OpenIPC/linux](https://github.com/OpenIPC/linux))
- [x] No files specific to a single retail camera model (those go to [OpenIPC/builder](https://github.com/OpenIPC/builder))
- [x] No probing or bring-up tooling (that goes to [OpenIPC/ipctool](https://github.com/OpenIPC/ipctool))
- [x] Nothing under `general/overlay/` or in a shared `load_<vendor>` script hardcodes a value specific to my board
- [ ] Package sources come from an OpenIPC repository, and any version bump keeps at least the specificity of the pin it replaces (a new package should pin a full 40-character SHA)
- [x] No `LD_PRELOAD`, and no binaries that cannot be rebuilt from source
- [x] New code is selected by a defconfig, so CI actually builds it

<sub>The unticked box is deliberate: this changes no `*_SITE` and no `*_VERSION`, and vtund's existing `SITE` is sourceforge rather than an OpenIPC repository, so ticking it would claim something untrue.</sub>
