### PR TITLE
init: refuse to format an overlay that runs off the end of the flash

### DIFF
--- a/.github/scripts/test_overlay_format_guard.sh
+++ b/.github/scripts/test_overlay_format_guard.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+# Regression tests for the guard that stops general/overlay/init formatting an
+# overlay partition that runs off the end of the flash chip.
+#
+# #1998: SigmaStar sizes any NOR chip missing from its JEDEC table at 16MB. On a
+# real 8MB camera the "-(rootfs_data)" partition then spans 8896KB, jffs2 cannot
+# mount what is really an aliased mirror of the squashfs, and the format that
+# follows erases past 0x800000 -- which a 3-byte-addressed chip wraps back to
+# zero, taking the bootloader with it. The camera boots exactly once.
+#
+# The guard may only ever refuse on positive proof: a false positive costs a
+# camera its persistent settings, so every case where the proof cannot be
+# obtained must fall through and format as before. Both halves are asserted here.
+#
+# Pure shell, no root, no device. Runs in a second.
+
+set -u
+
+SRC=${SRC:-general/overlay/init}
+fail=0
+ok()  { echo "ok   $*"; }
+bad() { echo "FAIL $*"; fail=$((fail + 1)); }
+
+[ -f "$SRC" ] || { echo "FAIL cannot find $SRC -- run me from the repo root"; exit 1; }
+
+# The device is busybox ash, so test against that and nothing else -- see the
+# header of test_shell_parse.sh for why dash is not a stand-in.
+BUSYBOX=$(command -v busybox 2>/dev/null || true)
+if [ -z "$BUSYBOX" ]; then
+	if [ "${STRICT:-0}" != "0" ]; then
+		echo "FAIL busybox not found and STRICT=$STRICT -- refusing to report a"
+		echo "     pass for a check that did not run. Install busybox-static."
+		exit 1
+	fi
+	echo "note busybox not found, skipping."
+	exit 0
+fi
+
+SB=$(mktemp -d)
+trap 'rm -rf "$SB"' EXIT
+mkdir -p "$SB/proc" "$SB/dev"
+
+# Lift the two functions out of the real init and point them at the sandbox, so
+# the code under test is the code that ships rather than a copy that can drift.
+# Everything between the first function header and the closing brace of
+# mtd_geometry is taken verbatim.
+sed -n '/^overlay_wraps_past_end_of_flash()/,/^}/p;/^mtd_geometry()/,/^}/p' "$SRC" \
+	| sed -e "s|/proc/mtd|$SB/proc/mtd|g" \
+	      -e "s|/dev/mtd0|$SB/dev/mtd0|g" \
+	      -e "s|\"/dev/|\"$SB/dev/|g" > "$SB/guard.sh"
+
+for fn in overlay_wraps_past_end_of_flash mtd_geometry; do
+	grep -q "^$fn()" "$SB/guard.sh" || { echo "FAIL could not lift $fn out of $SRC"; exit 1; }
+done
+grep -q "$SB/dev/mtd0" "$SB/guard.sh" || { echo "FAIL sandbox rewrite missed the mtd0 read"; exit 1; }
+grep -q "$SB/dev/\$_chrdev" "$SB/guard.sh" || { echo "FAIL sandbox rewrite missed the partition read"; exit 1; }
+
+# --- fixtures --------------------------------------------------------------
+
+# A believable first sector: the point is only that it is not blank, so that an
+# aliased read of it is distinguishable from erased flash.
+make_bootloader() { head -c "$1" /dev/urandom > "$2"; }
+
+blank() { tr '\0' '\377' < /dev/zero | head -c "$1"; }
+
+# Build a whole chip as one file, then carve the partitions out of it exactly as
+# mtdparts would -- with the wrap, if the chip is smaller than the table claims.
+#
+#   $1 real chip size   $2 believed chip size   $3 rootfs_data offset
+build_chip() {
+	real=$1; believed=$2; off=$3
+	head -c "$real" /dev/urandom > "$SB/chip"
+	head -c 262144 "$SB/chip" > "$SB/dev/mtd0"
+	# What the driver presents as rootfs_data: the real tail of the chip, then --
+	# if it believes the chip is bigger than it is -- the chip over again, because
+	# a 3-byte SPI address at or past the real end wraps back to zero.
+	need=$((believed - off))
+	{
+		dd if="$SB/chip" bs=512 skip=$((off / 512)) 2>/dev/null
+		n=0
+		while [ $((n * real)) -lt "$need" ]; do cat "$SB/chip"; n=$((n + 1)); done
+	} 2>/dev/null | head -c "$need" > "$SB/dev/mtd4"
+}
+
+set_mtd() { cat > "$SB/proc/mtd"; }
+
+# The partition table an 8MB OpenIPC image asks for. rootfs_data's size is the
+# only thing that moves: it is whatever the driver thinks is left of the chip.
+mtd_table() {
+	printf 'dev:    size   erasesize  name\n'
+	printf 'mtd0: 00040000 00010000 "boot"\n'
+	printf 'mtd1: 00010000 00010000 "env"\n'
+	printf 'mtd2: 00200000 00010000 "kernel"\n'
+	printf 'mtd3: 00500000 00010000 "rootfs"\n'
+	printf 'mtd4: %08x 00010000 "rootfs_data"\n' "$1"
+}
+
+# Run the lifted functions the way init calls them and report the verdict as
+# the words a reader of this test cares about.
+verdict() {
+	"$BUSYBOX" ash -c ". $SB/guard.sh
+		mtd_geometry || { echo no-geometry; exit 0; }
+		if overlay_wraps_past_end_of_flash \"\$(basename $SB/dev/mtd4)\" \"\$mtdoffset\" \"\$mtdsize\"; then
+			echo refuse
+		else
+			echo format
+		fi"
+}
+
+geometry() {
+	"$BUSYBOX" ash -c ". $SB/guard.sh
+		mtd_geometry && printf '%s %s\n' \"\$mtdoffset\" \"\$mtdsize\""
+}
+
+OFF=$((0x750000))
+
+# --- 1. the reported brick -------------------------------------------------
+# 8MB chip, driver says 16MB, so rootfs_data is 8896KB and its tail is a mirror
+# of the whole chip starting with the bootloader.
+mtd_table $((0x8b0000)) | set_mtd
+build_chip $((0x800000)) $((0x1000000)) "$OFF"
+got=$(verdict)
+[ "$got" = refuse ] && ok "8MB chip sized 16MB: refuses to format (#1998)" \
+	|| bad "8MB chip sized 16MB: expected refuse, got '$got'"
+
+# --- 2. a healthy 8MB camera ----------------------------------------------
+# rootfs_data is the real 704KB tail. There is no plausible smaller chip end
+# inside the partition, so the guard must not even look.
+mtd_table $((0x0b0000)) | set_mtd
+build_chip $((0x800000)) $((0x800000)) "$OFF"
+got=$(verdict)
+[ "$got" = format ] && ok "healthy 8MB camera: formats as before" \
+	|| bad "healthy 8MB camera: expected format, got '$got'"
+
+# --- 3. a real 16MB chip carrying the 8MB layout ---------------------------
+# Same partition table as case 1 -- this is the geometry openipc.org hands out
+# when a visitor picks the 8MB layout on a 16MB chip -- but nothing aliases.
+mtd_table $((0x8b0000)) | set_mtd
+build_chip $((0x1000000)) $((0x1000000)) "$OFF"
+got=$(verdict)
+[ "$got" = format ] && ok "real 16MB chip, 8MB layout: formats as before" \
+	|| bad "real 16MB chip, 8MB layout: expected format, got '$got'"
+
+# --- 4. blank first sector -------------------------------------------------
+# An erased sector matches any other erased sector, so it proves nothing and
+# must not be allowed to. Keep case 1's aliasing otherwise.
+mtd_table $((0x8b0000)) | set_mtd
+build_chip $((0x800000)) $((0x1000000)) "$OFF"
+blank 262144 > "$SB/dev/mtd0"
+blank $((0x8b0000)) > "$SB/dev/mtd4"
+got=$(verdict)
+[ "$got" = format ] && ok "blank flash proves nothing: formats as before" \
+	|| bad "blank flash: expected format, got '$got'"
+
+# --- 5. no mtd0 to read ----------------------------------------------------
+mtd_table $((0x8b0000)) | set_mtd
+build_chip $((0x800000)) $((0x1000000)) "$OFF"
+rm -f "$SB/dev/mtd0"
+got=$(verdict)
+[ "$got" = format ] && ok "unreadable mtd0: falls through and formats" \
+	|| bad "unreadable mtd0: expected format, got '$got'"
+
+# --- 6. no rootfs_data at all ----------------------------------------------
+{ printf 'dev:    size   erasesize  name\n'; printf 'mtd0: 00040000 00010000 "boot"\n'; } | set_mtd
+got=$(verdict)
+[ "$got" = no-geometry ] && ok "no rootfs_data partition: guard stands down" \
+	|| bad "no rootfs_data partition: expected no-geometry, got '$got'"
+
+# --- 7. the octal trap -----------------------------------------------------
+# /proc/mtd pads sizes to eight hex digits. Read without an 0x prefix, 00040000
+# is octal 16384 rather than 262144, and every offset after it is wrong.
+mtd_table $((0x8b0000)) | set_mtd
+got=$(geometry)
+[ "$got" = "$((0x750000)) $((0x8b0000))" ] \
+	&& ok "hex sizes with leading zeros are not read as octal" \
+	|| bad "geometry: expected '$((0x750000)) $((0x8b0000))', got '$got'"
+
+echo
+if [ "$fail" -ne 0 ]; then
+	echo "$fail check(s) failed."
+	exit 1
+fi
+echo "All overlay format guard checks passed."

--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -81,6 +81,38 @@ jobs:
       # for a build.
       - run: bash .github/scripts/test_excludes_report.sh
 
+  overlay-format-guard:
+    name: overlay format guard refuses only on proof
+    if: >-
+      github.repository == 'OpenIPC/firmware' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !github.event.repository.private)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install busybox
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq busybox-static
+      # /init decides whether to erase the last partition on the chip, and a
+      # driver that mis-sizes the chip turns that erase into a brick (#1998).
+      # Nothing else exercises it: the overlay is copied in verbatim and a green
+      # build says nothing about what /init does on a camera.
+      - name: Drive the guard against synthetic chips
+        env:
+          STRICT: 1
+        run: bash .github/scripts/test_overlay_format_guard.sh
+
+      # /init ships comment-stripped, and the guard's reasoning lives in those
+      # comments. Re-run against the form the camera actually executes.
+      - name: Re-run against the stripped form that actually ships
+        env:
+          STRICT: 1
+        run: |
+          awk -f general/scripts/strip-shell-comments.awk \
+            general/overlay/init > /tmp/init.stripped
+          SRC=/tmp/init.stripped bash .github/scripts/test_overlay_format_guard.sh
+
   shipped-shell-parse:
     name: shipped shell scripts parse
     if: >-
@@ -123,6 +155,7 @@ jobs:
       - load-hisilicon-parsing
       - sysupgrade-verify
       - excludes-report
+      - overlay-format-guard
       - shipped-shell-parse
     # always() so the gate reports when a needed job fails, but not on a run
     # whose jobs the guard above deliberately skipped. Upstream the added
@@ -136,7 +169,7 @@ jobs:
     steps:
       - name: Require every shell test to succeed
         run: |
-          echo "load-hisilicon=${{ needs.load-hisilicon-parsing.result }} sysupgrade=${{ needs.sysupgrade-verify.result }} excludes=${{ needs.excludes-report.result }} shell-parse=${{ needs.shipped-shell-parse.result }}"
+          echo "load-hisilicon=${{ needs.load-hisilicon-parsing.result }} sysupgrade=${{ needs.sysupgrade-verify.result }} excludes=${{ needs.excludes-report.result }} overlay-guard=${{ needs.overlay-format-guard.result }} shell-parse=${{ needs.shipped-shell-parse.result }}"
           # 'skipped' is not accepted, for the reason given in lint.yml: a
           # skipped job would take this context green having checked nothing.
           if [ "${{ needs.load-hisilicon-parsing.result }}" != "success" ]; then
@@ -147,6 +180,9 @@ jobs:
           fi
           if [ "${{ needs.excludes-report.result }}" != "success" ]; then
             echo "::error::excludes lists report did not succeed"; exit 1
+          fi
+          if [ "${{ needs.overlay-format-guard.result }}" != "success" ]; then
+            echo "::error::overlay format guard did not succeed"; exit 1
           fi
           if [ "${{ needs.shipped-shell-parse.result }}" != "success" ]; then
             echo "::error::shipped shell scripts parse did not succeed"; exit 1

--- a/general/overlay/init
+++ b/general/overlay/init
@@ -7,6 +7,59 @@ on_exit() {
 
 trap on_exit EXIT
 
+# A NOR chip smaller than its driver believes aliases every address at or above
+# its real end back to zero, so the last partition -- the one sized "-(rootfs_data)"
+# against a bogus total -- runs off the end of the device, and erasing it wraps
+# round and takes the bootloader with it. That is #1998: SigmaStar sizes any chip
+# missing from its JEDEC table at 16MB, an 8MB camera gets a 8896KB overlay, and
+# the first format the camera ever runs is also its last boot.
+#
+# Prove the wrap before refusing, because the cost of a false positive is a camera
+# that silently forgets its settings: read the first sector of the flash and the
+# sector the partition would present at each plausible real end of the chip, and
+# only stop if they are the same bytes. Anything that stops us proving it -- no
+# md5sum, an unreadable mtd0, a first sector that is blank and would therefore
+# match any other blank one -- leaves the format to go ahead exactly as before.
+overlay_wraps_past_end_of_flash() {
+	_chrdev=$1
+	_offset=$2
+	_size=$3
+
+	_head=$(dd if=/dev/mtd0 bs=512 count=1 2>/dev/null | md5sum) || return 1
+	[ -n "$_head" ] || return 1
+	[ -n "$(dd if=/dev/mtd0 bs=512 count=1 2>/dev/null | tr -d '\377')" ] || return 1
+
+	_real=$(((_offset + _size) / 2))
+	while [ "$_real" -gt "$_offset" ]; do
+		if [ "$_head" = "$(dd if="/dev/$_chrdev" bs=512 count=1 \
+				skip=$(((_real - _offset) / 512)) 2>/dev/null | md5sum)" ]; then
+			return 0
+		fi
+		_real=$((_real / 2))
+	done
+	return 1
+}
+
+# /proc/mtd carries sizes but no offsets. These layouts come from a single
+# cmdlinepart string, so the partitions are in order and an offset is the sum of
+# everything before it. Sizes are hex and keep their leading zeros, so they have
+# to be read with an 0x prefix -- without it the shell reads 00040000 as octal.
+mtd_geometry() {
+	mtdoffset=0
+	mtdsize=0
+	while read -r _dev _sz _erase _name; do
+		case $_dev in
+			mtd*:) ;;
+			*) continue ;;
+		esac
+		case $_name in
+			'"rootfs_data"') mtdsize=$((0x$_sz)); return 0 ;;
+		esac
+		mtdoffset=$((mtdoffset + 0x$_sz))
+	done < /proc/mtd
+	return 1
+}
+
 mount -t proc proc /proc || exit 1
 grep -q overlay /proc/filesystems || exit 1
 
@@ -27,12 +80,19 @@ if $is_flash_root; then
 		mtdchrdev=$(grep 'rootfs_data' /proc/mtd | cut -d: -f1)
 		if ! mount -t jffs2 /dev/$mtdblkdev /overlay || dmesg | grep -q "jffs2.*: Magic bitmask.*not found"; then
 			mountpoint -q /overlay && umount /overlay
-			echo "Formatting flash..."
-			grep -q 'nand' /proc/cmdline || jffs2="-j"
-			flash_eraseall $jffs2 /dev/$mtdchrdev
-			if ! mount -t jffs2 /dev/$mtdblkdev /overlay && ! mount -t tmpfs tmpfs /overlay; then
-				echo "Cannot mount overlay."
-				exit 1
+			if mtd_geometry && overlay_wraps_past_end_of_flash "$mtdchrdev" "$mtdoffset" "$mtdsize"; then
+				echo "Overlay partition runs past the end of the flash chip."
+				echo "Refusing to format -- erasing it would wipe the bootloader."
+				echo "The flash driver has mis-sized this chip; see OpenIPC/firmware#1998."
+				mount -t tmpfs tmpfs /overlay || { echo "Cannot mount overlay."; exit 1; }
+			else
+				echo "Formatting flash..."
+				grep -q 'nand' /proc/cmdline || jffs2="-j"
+				flash_eraseall $jffs2 /dev/$mtdchrdev
+				if ! mount -t jffs2 /dev/$mtdblkdev /overlay && ! mount -t tmpfs tmpfs /overlay; then
+					echo "Cannot mount overlay."
+					exit 1
+				fi
 			fi
 		fi
 	fi


### PR DESCRIPTION
## Problem

A SigmaStar SSC325 camera with an 8 MB NOR chip boots OpenIPC once, comes up with no
network, and is dead after the next power cycle — the whole chip reads back `0xFF`.
Reported in #1998 (SSC325, 8 MB NOR) and reproduced by a second user on 2026-09-13.

The camera erases its own flash. `drivers/sstar/flash_isp` sizes any chip missing from
its JEDEC table at 16 MB — the `FLASH_IC_UNKNOWN` row declares `0x1000000` next to a
sector count that says 4 MB, so it was never a real geometry — and `mtd.size` is taken
straight from it. Our SigmaStar bootargs end in `-(rootfs_data)`, so the overlay
partition becomes whatever is left of the *believed* chip:

| detected size | rootfs_data |
| --- | --- |
| correct 8 MB | 704 KB = 11 erase blocks |
| believed 16 MB | 8896 KB = **139** erase blocks |

#1998's log says `jffs2: empty_blocks 40, bad_blocks 0, c->nr_blocks 139`. jffs2 is
then scanning an aliased mirror of the squashfs — that is what the "Old JFFS2 bitmask"
noise in that log is — so it cannot mount, `/init` falls back to `flash_eraseall`, and
the erase walks past `0x800000`. A 3-byte-addressed NOR wraps every address at or above
the real end back to zero, so the run takes the bootloader, the environment, the kernel
and the rootfs with it, while the system is still running out of page cache.

This PR is the half that stops the damage on images already in the field. The driver is
the real fix and belongs in [OpenIPC/linux](https://github.com/OpenIPC/linux); that
change is waiting on the reporter's hardware and is tracked in #1998.

The guard is not SigmaStar-specific. Any driver that over-reports a chip lands here.

## Hardware tested on

**Not run on a camera — opened as a draft for that reason.** Nobody here has an SSC325,
and the only SigmaStar board in the lab was down. The reported failure also cannot be
reproduced without a flash chip that is absent from the vendor's table, which is not
something that can be sourced on purpose.

What can be evidenced without a board is evidenced below: the guard is driven against
synthetic chips built byte-for-byte the way the driver would present them, including the
wrap, in both the tree form and the comment-stripped form that actually ships.

## Evidence

`bash .github/scripts/test_overlay_format_guard.sh` — the new suite, against
`general/overlay/init`:

```
ok   8MB chip sized 16MB: refuses to format (#1998)
ok   healthy 8MB camera: formats as before
ok   real 16MB chip, 8MB layout: formats as before
ok   blank flash proves nothing: formats as before
ok   unreadable mtd0: falls through and formats
ok   no rootfs_data partition: guard stands down
ok   hex sizes with leading zeros are not read as octal

All overlay format guard checks passed.
```

The same suite against the form the camera executes
(`awk -f general/scripts/strip-shell-comments.awk general/overlay/init`):

```
ok   8MB chip sized 16MB: refuses to format (#1998)
ok   healthy 8MB camera: formats as before
ok   real 16MB chip, 8MB layout: formats as before
ok   blank flash proves nothing: formats as before
ok   unreadable mtd0: falls through and formats
ok   no rootfs_data partition: guard stands down
ok   hex sizes with leading zeros are not read as octal

All overlay format guard checks passed.
```

Cases 2 and 3 are the ones that matter for a false positive. Case 3 is the geometry
openipc.org hands out when a visitor picks the 8 MB layout on a 16 MB chip: the same
partition table as the brick, on a chip that really is 16 MB. It must format, and does.

The rest of the shell gates, unchanged:

```
$ STRICT=1 bash .github/scripts/test_shell_parse.sh
checked 144 shell script(s)
all parsed clean under busybox ash

$ STRICT=1 bash .github/scripts/test_strip_shell_comments.sh
ok   144 shipped scripts parse identically after stripping (147978 bytes saved)
All strip-shell-comments checks passed.

$ python3 .github/scripts/lint-workflow-shell.py --self-test
checked 59 run block(s)
all run blocks parse clean
self-test passed

$ python3 .github/scripts/ci-matrix.py --self-test
ci-matrix: self-test ok (99 boards, 136 packages, 56 cases)
```

`general/overlay/init` widens the matrix to every board, as it should:

```
$ printf 'general/overlay/init\n' | python3 .github/scripts/ci-matrix.py --stdin
needs-build=true
reason=general/overlay/init affects every board
```

## Scope

- [x] No kernel patches under `general/package/all-patches/linux/` (those go to [OpenIPC/linux](https://github.com/OpenIPC/linux))
- [x] No files specific to a single retail camera model (those go to [OpenIPC/builder](https://github.com/OpenIPC/builder))
- [x] No probing or bring-up tooling (that goes to [OpenIPC/ipctool](https://github.com/OpenIPC/ipctool))
- [x] Nothing under `general/overlay/` or in a shared `load_<vendor>` script hardcodes a value specific to my board
- [x] Package sources come from an OpenIPC repository, and any version bump keeps at least the specificity of the pin it replaces (a new package should pin a full 40-character SHA)
- [x] No `LD_PRELOAD`, and no binaries that cannot be rebuilt from source
- [x] New code is selected by a defconfig, so CI actually builds it

## Note for review

`general/overlay/usr/sbin/sysupgrade`'s `do_wipe_overlay()` erases the same partition and
has the same exposure. It is deliberately left alone here so this change stays one idea;
say the word if you would rather they move together.
